### PR TITLE
Fix two issues with GL nodes handling

### DIFF
--- a/src/p_glnodes.cpp
+++ b/src/p_glnodes.cpp
@@ -724,9 +724,10 @@ static bool DoLoadGLNodes(FileReader ** lumps)
 
 static bool MatchHeader(const char * label, const char * hdata)
 {
-	if (!memcmp(hdata, "LEVEL=", 6) == 0)
+	if (memcmp(hdata, "LEVEL=", 6) == 0)
 	{
 		size_t labellen = strlen(label);
+		labellen = MIN(size_t(8), labellen);
 
 		if (strnicmp(hdata+6, label, labellen)==0 && 
 			(hdata[6+labellen]==0xa || hdata[6+labellen]==0xd))
@@ -771,7 +772,7 @@ static int FindGLNodesInWAD(int labellump)
 				if (Wads.GetLumpFile(lump)==wadfile)
 				{
 					FMemLump mem = Wads.ReadLump(lump);
-					if (MatchHeader(Wads.GetLumpFullName(labellump), (const char *)mem.GetMem())) return true;
+					if (MatchHeader(Wads.GetLumpFullName(labellump), (const char *)mem.GetMem())) return lump;
 				}
 			}
 		}
@@ -781,7 +782,7 @@ static int FindGLNodesInWAD(int labellump)
 
 //===========================================================================
 //
-// FindGLNodesInWAD
+// FindGLNodesInFile
 //
 // Looks for GL nodes in the same WAD as the level itself
 // Function returns the lump number within the file. Returns -1 if the input
@@ -929,13 +930,13 @@ bool P_LoadGLNodes(MapData * map)
 			result=true;
 			for(unsigned i=0; i<4;i++)
 			{
-				if (strnicmp(f_gwa->GetLump(i)->Name, check[i], 8))
+				if (strnicmp(f_gwa->GetLump(i+1)->Name, check[i], 8))
 				{
 					result=false;
 					break;
 				}
 				else
-					gwalumps[i] = f_gwa->GetLump(i)->NewReader();
+					gwalumps[i] = f_gwa->GetLump(i+1)->NewReader();
 			}
 			if (result) result = DoLoadGLNodes(gwalumps);
 		}


### PR DESCRIPTION
Fix inability to load GL nodes for maps with names longer than 5 characters.
Fix inability to load GL nodes from external GWA files.
