### PR TITLE
Fixed missing transparency on upscaled textures

### DIFF
--- a/src/gl/textures/gl_texture.cpp
+++ b/src/gl/textures/gl_texture.cpp
@@ -558,7 +558,7 @@ bool FTexture::SmoothEdges(unsigned char * buffer,int w, int h)
 		l1+=4;
 		for(x=1;x<w-1;x++, l1+=4)
 		{
-			if (l1[MSB]==0 &&  !CHKPIX(-w) && !CHKPIX(-1) && !CHKPIX(1)) CHKPIX(w);
+			if (l1[MSB]==0 &&  !CHKPIX(-w) && !CHKPIX(-1) && !CHKPIX(1) && !CHKPIX(-w-1) && !CHKPIX(-w+1) && !CHKPIX(w-1) && !CHKPIX(w+1)) CHKPIX(w);
 		}
 		if (l1[MSB]==0 && !CHKPIX(-w) && !CHKPIX(-1)) CHKPIX(w);
 		l1+=4;


### PR DESCRIPTION
Textures with diagonal patterns were treated as opaque after resizing
Images upscaled by hqNx were affected mostly by this issue

http://forum.drdteam.org/viewtopic.php?f=24&t=5370
http://zandronum.com/tracker/view.php?id=269
http://zandronum.com/tracker/view.php?id=315
