### PR TITLE
LineAttack LAF_NOINTERACT expanded functionality

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4754,11 +4754,18 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 
 				// We must pass the unreplaced puff type here 
 				puff = P_SpawnPuff(t1, pufftype, bleedpos, trace.SrcAngleFromTarget, trace.SrcAngleFromTarget - 90, 2, puffFlags | PF_HITTHING, trace.Actor);
-
-				if (nointeract)
-				{
-					return puff;
-				}
+			}
+			if (victim != NULL)
+			{
+				victim->linetarget = trace.Actor;
+				victim->attackAngleFromSource = trace.SrcAngleFromTarget;
+				// With arbitrary portals this cannot be calculated so using the actual attack angle is the only option.
+				victim->angleFromSource = trace.unlinked ? victim->attackAngleFromSource : t1->AngleTo(trace.Actor);
+				victim->unlinked = trace.unlinked;
+			}
+			if (nointeract)
+			{
+				return puff;
 			}
 
 			// Allow puffs to inflict poison damage, so that hitscans can poison, too.
@@ -4833,14 +4840,7 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 					P_TraceBleed(newdam > 0 ? newdam : damage, trace.HitPos, trace.Actor, trace.SrcAngleFromTarget, pitch);
 				}
 			}
-			if (victim != NULL)
-			{
-				victim->linetarget = trace.Actor;
-				victim->attackAngleFromSource = trace.SrcAngleFromTarget;
-				// With arbitrary portals this cannot be calculated so using the actual attack angle is the only option.
-				victim->angleFromSource = trace.unlinked? victim->attackAngleFromSource : t1->AngleTo(trace.Actor);
-				victim->unlinked = trace.unlinked;
-			}
+			
 		}
 		if (trace.Crossed3DWater || trace.CrossedWater)
 		{


### PR DESCRIPTION
Allow LineAttack's LAF_NOINTERACT to fill FTranslatedLineTarget's information.

- Originally when the flag was made, LineAttack was not yet exported (I think). It makes more sense now to allow the struct to be filled since modders have direct access to it today.