### PR TITLE
Another minor correction to UE1 models

### DIFF
--- a/src/r_data/models/models_ue1.cpp
+++ b/src/r_data/models/models_ue1.cpp
@@ -129,7 +129,7 @@ void FUE1Model::LoadGeometry()
 			FVector3 dir[2];
 			dir[0] = verts[Poly.V[1]+numVerts*j].Pos-verts[Poly.V[0]+numVerts*j].Pos;
 			dir[1] = verts[Poly.V[2]+numVerts*j].Pos-verts[Poly.V[0]+numVerts*j].Pos;
-			Poly.Normals.Push(dir[0]^dir[1]);
+			Poly.Normals.Push((dir[0]^dir[1]).Unit());
 		}
 		// push
 		polys.Push(Poly);


### PR DESCRIPTION
Computed facet normals weren't normalized. This tiny mistake went by unnoticed until, well... I noticed it.

Flat shaded meshes would behave weirdly with dynamic lights for some reason, and it took me a while to realize that the cause of it all was just this one super tiny mistake.

I feel like a complete idiot for not noticing all this time.