### PR TITLE
Attempt to fix the "is" operator to work with readonly pointers

### DIFF
--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -280,7 +280,8 @@ bool AreCompatiblePointerTypes(PType *dest, PType *source, bool forcompare)
 		// null pointers can be assigned to everything, everything can be assigned to void pointers.
 		if (fromtype == nullptr || totype == TypeVoidPtr) return true;
 		// when comparing const-ness does not matter.
-		if (!forcompare && totype->IsConst != fromtype->IsConst) return false;
+		// If not comparing, then we should not allow const to be cast away.
+		if (!forcompare && fromtype->IsConst && !totype->IsConst) return false;
 		// A type is always compatible to itself.
 		if (fromtype == totype) return true;
 		// Pointers to different types are only compatible if both point to an object and the source type is a child of the destination type.
@@ -4516,7 +4517,7 @@ FxExpression *FxTypeCheck::Resolve(FCompileContext& ctx)
 	}
 	else
 	{
-		left = new FxTypeCast(left, NewPointer(RUNTIME_CLASS(DObject)), false);
+		left = new FxTypeCast(left, NewPointer(RUNTIME_CLASS(DObject), true), false);
 		ClassCheck = false;
 	}
 	right = new FxClassTypeCast(NewClassPointer(RUNTIME_CLASS(DObject)), right, false);


### PR DESCRIPTION
So I think I've managed to fix the `is` operator to work on readonly pointers. The following changes have been made:

* The `is` operator will try to perform a cast to a readonly pointer instead of a normal pointer so that const-correctness is not violated.
* `AreCompatiblePointerTypes` will return false for condition `fromtype->IsConst && !totype->IsConst` instead of `totype->IsConst != fromtype->IsConst` when `forcompare` is false. In other words, when not comparing pointers, `fromtype->IsConst` must imply `totype->IsConst`. This is quite logical, isn't it? We can make a non-readonly pointer readonly (and that's what the `is` operator will now do), but not the other way around.

I've run some simple tests and it appears to work fine. The fact that gzdoom.pk3's scripts compile without errors after this change means that I probably haven't messed it up that bad, if at all. However, this still needs additional verification. It is quite difficult to make sure I haven't overlooked anything, this code is not easy to work with.