### PR TITLE
Add cvars to fade sprite shadows progressively according to thing <-> floor distance

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -67,7 +67,8 @@ const float LARGE_VALUE = 1e19f;
 
 EXTERN_CVAR(Bool, r_debug_disable_vis_filter)
 EXTERN_CVAR(Float, transsouls)
-
+EXTERN_CVAR(Float, r_actorspriteshadowalpha)
+EXTERN_CVAR(Float, r_actorspriteshadowfadeheight)
 
 //==========================================================================
 //
@@ -1174,7 +1175,12 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	{
 		RenderStyle = STYLE_Stencil;
 		ThingColor = MAKEARGB(255, 0, 0, 0);
-		trans *= 0.5f;
+		// fade shadow progressively as the thing moves higher away from the floor
+		if (r_actorspriteshadowfadeheight > 0.0) {
+			trans *= clamp(0.0f, float(r_actorspriteshadowalpha - (thingpos.Z - thing->floorz) * (1.0 / r_actorspriteshadowfadeheight)), float(r_actorspriteshadowalpha));
+		} else {
+			trans *= r_actorspriteshadowalpha;
+		}
 		hw_styleflags = STYLEHW_NoAlphaTest;
 	}
 

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -121,6 +121,20 @@ CUSTOM_CVARD(Float, r_actorspriteshadowdist, 1500.0, CVAR_ARCHIVE | CVAR_GLOBALC
 	else if (self > 8192.f)
 		self = 8192.f;
 }
+CUSTOM_CVARD(Float, r_actorspriteshadowalpha, 0.5, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "maximum sprite shadow opacity, only effective with hardware renderers (0.0 = fully transparent, 1.0 = opaque)")
+{
+	if (self < 0.f)
+		self = 0.f;
+	else if (self > 1.f)
+		self = 1.f;
+}
+CUSTOM_CVARD(Float, r_actorspriteshadowfadeheight, 0.0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "distance over which sprite shadows should fade, only effective with hardware renderers (0 = infinite)")
+{
+	if (self < 0.f)
+		self = 0.f;
+	else if (self > 8192.f)
+		self = 8192.f;
+}
 
 int 			viewwindowx;
 int 			viewwindowy;


### PR DESCRIPTION
Related to https://github.com/coelckers/gzdoom/pull/1393 (but can be merged independently).

This also adds the `r_actorspriteshadowalpha` and `r_actorspriteshadowfadeheight` cvars for greater control (only effective in hardware renderers). Fading over distance is disabled if `r_actorspriteshadowfadeheight` is equal to 0. These are set to 0.5 and 0 by default, which means this fading behavior is disabled by default.

When enabled, this has two benefits:

- It becomes easier for the player to judge an entity's height since the shadow opacity now gives this information.
- Entities that are far high above the ground no longer cast a shadow, which looked strange.

The default behavior is unchanged: sprite shadows won't fade as their caster moves higher above the floor.

The actor sprite shadow alpha can be increased to 1.0 if you want those Build-like shadows :slightly_smiling_face: 

## Preview

`r_actorspriteshadowalpha 0.5` (the default) and `r_actorspriteshadowfadeheight 333`:

https://user-images.githubusercontent.com/180032/119274420-0c7dc600-bc10-11eb-9d4b-b64f27bc28a6.mp4