### PR TITLE
PreTravelled virtual for player and inventory

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -855,6 +855,17 @@ class Inventory : Actor
 
 	//===========================================================================
 	//
+	// Inventory :: PreTravelled
+	//
+	// Called when an item in somebody's inventory is about to be carried
+	// over to another map, in case it needs to do special clean-up.
+	//
+	//===========================================================================
+
+	virtual void PreTravelled() {}
+
+	//===========================================================================
+	//
 	// Inventory :: Travelled
 	//
 	// Called when an item in somebody's inventory is carried over to another

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2083,6 +2083,15 @@ class PlayerPawn : Actor
 			me.ClearInventory();
 			me.GiveDefaultInventory();
 		}
+
+		// [MK] notify self and inventory that we're about to travel
+		// this must be called here so these functions can still have a
+		// chance to alter the world before a snapshot is done in hubs
+		me.PreTravelled();
+		for (item = me.Inv; item != NULL; item = item.Inv)
+		{
+			item.PreTravelled();
+		}
 	}
 	 
 	//===========================================================================
@@ -2460,6 +2469,18 @@ class PlayerPawn : Actor
 		else player.air_finished = int.max;
 		return wasdrowning;
 	}
+
+	//===========================================================================
+	//
+	// PlayerPawn :: PreTravelled
+	//
+	// Called before the player moves to another map, in case it needs to do
+	// special clean-up. This is called right before all carried items
+	// execute their respective PreTravelled() virtuals.
+	//
+	//===========================================================================
+
+	virtual void PreTravelled() {}
 
 	//===========================================================================
 	//


### PR DESCRIPTION
Allows players and items to do "clean up" before a level transition (e.g.: destroying certain effects from powerups, or objects that track the player's position).

As an example here I show how a powerup that spawns a physical light around the player would make use of the function.
[pretravelled_test.zip](https://github.com/coelckers/gzdoom/files/7354288/pretravelled_test.zip)
Normally, without this cleanup, there would be lingering actors when traversing back and forth between maps in a hub, duplicating over and over, but with it, the old light can be destroyed and a new one spawned in between level transitions.