### PR TITLE
Added 'NoPerPixelLighting' flag to models to force it to not use per-…

### DIFF
--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -524,6 +524,10 @@ static void ParseModelDefLump(int Lump)
 				{
 					smf.flags |= MDL_USEACTORROLL;
 				}
+				else if (sc.Compare("noperpixellighting"))
+				{
+					smf.flags |= MDL_NOPERPIXELLIGHTING;
+				}
 				else if (sc.Compare("rotating"))
 				{
 					smf.flags |= MDL_ROTATING;

--- a/src/r_data/models.h
+++ b/src/r_data/models.h
@@ -55,6 +55,7 @@ enum
 	MDL_BADROTATION					= 128,
 	MDL_DONTCULLBACKFACES			= 256,
 	MDL_USEROTATIONCENTER			= 512,
+	MDL_NOPERPIXELLIGHTING			= 1024, // forces a model to not use per-pixel lighting. useful for voxel-converted-to-model objects.
 };
 
 FSpriteModelFrame * FindModelFrame(const PClass * ti, int sprite, int frame, bool dropped);

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -482,7 +482,7 @@ bool HWSprite::CalculateVertices(HWDrawInfo *di, FVector3 *v, DVector3 *vp)
 inline void HWSprite::PutSprite(HWDrawInfo *di, bool translucent)
 {
 	// That's a lot of checks...
-	if (modelframe && !modelframe->isVoxel && RenderStyle.BlendOp != STYLEOP_Shadow && gl_light_sprites && di->Level->HasDynamicLights && !di->isFullbrightScene() && !fullbright)
+	if (modelframe && !modelframe->isVoxel && !(modelframe->flags & MDL_NOPERPIXELLIGHTING) && RenderStyle.BlendOp != STYLEOP_Shadow && gl_light_sprites && di->Level->HasDynamicLights && !di->isFullbrightScene() && !fullbright)
 	{
 		hw_GetDynModelLight(actor, lightdata);
 		dynlightindex = screen->mLights->UploadLights(lightdata);


### PR DESCRIPTION
…pixel lighting. Main use case is for voxels that have been converted to models.

Due to the slow speeds of actual voxel models - but wanting to retain the blocky aesthetics of voxels - some project authors have decided to convert their voxels to actual models to take advantage of far more efficient offline mesh reduction tools and still get the chunky look for their objects.

The problem was that models are lit per-pixel, leading to some rather unpleasant visuals:

![Screenshot_Doom_20211021_154956](https://user-images.githubusercontent.com/4926156/138235906-5e3cadda-58e7-4e6d-9fbb-68db24c5b12f.png)


This new MODELDEF flag solves the problem. In the above image, the model on the far left doesn't have the new flag; while the one on the front-right does have it.

Runnable example attached.

[NoPPLModelDemo.zip](https://github.com/coelckers/gzdoom/files/7387127/NoPPLModelDemo.zip)