### PR TITLE
Update to use the new ZMusic_GetStreamInfoEx

### DIFF
--- a/src/common/audio/sound/i_sound.cpp
+++ b/src/common/audio/sound/i_sound.cpp
@@ -172,7 +172,7 @@ public:
 	}
 
 	// Streaming sounds.
-	SoundStream *CreateStream (SoundStreamCallback callback, int buffbytes, int flags, int samplerate, void *userdata)
+	SoundStream *CreateStream (SoundStreamCallback callback, int buffbytes, SampleType stype, ChannelConfig chans, int samplerate, void *userdata)
 	{
 		return NULL;
 	}
@@ -302,6 +302,7 @@ const char *GetSampleTypeName(SampleType type)
     {
         case SampleType_UInt8: return "Unsigned 8-bit";
         case SampleType_Int16: return "Signed 16-bit";
+        case SampleType_Float32: return "32-bit float";
     }
     return "(invalid sample type)";
 }

--- a/src/common/audio/sound/i_sound.h
+++ b/src/common/audio/sound/i_sound.h
@@ -64,17 +64,6 @@ class SoundStream
 public:
 	virtual ~SoundStream () {}
 
-	enum
-	{	// For CreateStream
-		Mono = 1,
-		Bits8 = 2,
-		Bits32 = 4,
-		Float = 8,
-
-		// For OpenStream
-		Loop = 16
-	};
-
 	virtual bool Play(bool looping, float volume) = 0;
 	virtual void Stop() = 0;
 	virtual void SetVolume(float volume) = 0;
@@ -106,7 +95,7 @@ public:
 	virtual float GetOutputRate() = 0;
 
 	// Streaming sounds.
-	virtual SoundStream *CreateStream (SoundStreamCallback callback, int buffbytes, int flags, int samplerate, void *userdata) = 0;
+	virtual SoundStream *CreateStream (SoundStreamCallback callback, int buffbytes, SampleType stype, ChannelConfig chans, int samplerate, void *userdata) = 0;
   
 	// Starts a sound.
 	virtual FISoundChannel *StartSound (SoundHandle sfx, float vol, int pitch, int chanflags, FISoundChannel *reuse_chan, float startTime = 0.f) = 0;

--- a/src/common/audio/sound/oalsound.h
+++ b/src/common/audio/sound/oalsound.h
@@ -135,7 +135,7 @@ public:
 	virtual float GetOutputRate();
 
 	// Streaming sounds.
-	virtual SoundStream *CreateStream(SoundStreamCallback callback, int buffbytes, int flags, int samplerate, void *userdata);
+	virtual SoundStream *CreateStream(SoundStreamCallback callback, int buffbytes, SampleType stype, ChannelConfig chans, int samplerate, void *userdata);
 
 	// Starts a sound.
 	virtual FISoundChannel *StartSound(SoundHandle sfx, float vol, int pitch, int chanflags, FISoundChannel *reuse_chan, float startTime);


### PR DESCRIPTION
This doesn't seem to want to build on CI currently, as its using the internal ZMusic files in `bin/windows/zmusic`. I can't update the Windows binaries (the import `.lib` files I could make have had issues with MSVC before, and for some reason there's a DLL in there for arm64?), so someone else will need to update that stuff before this can be merged.

Once that's updated, this is merged, and I can start adding support for surround sound formats to ZMusic without GZDoom breaking, which will then allow surround sound support to be added to GZDoom.