### PR TITLE
Implement antialiasing for automap lines

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1347,6 +1347,7 @@ OptionMenu AutomapOptions protected
 	Option "$AUTOMAPMNU_TEXTURED",				"am_textured", "OnOff"
 	Slider "$AUTOMAPMNU_LINEALPHA",				"am_linealpha", 0.1, 1.0, 0.1, 1
 	Slider "$AUTOMAPMNU_LINETHICKNESS",			"am_linethickness", 1, 8, 1, 0
+	Option "$AUTOMAPMNU_LINEANTIALIASING",		"am_lineantialiasing", "OnOff"
 
 	StaticText ""
 	Option "$AUTOMAPMNU_SHOWITEMS",				"am_showitems", "OnOff"


### PR DESCRIPTION
Follow-up to https://github.com/coelckers/gzdoom/pull/1429.

This implements a bruteforce approach for 2D line antialiasing. It's not perfect by any means, but it seems to do its job well enough. Since it draws 9 lines instead of 1 line per segment, it's significantly more expensive but should still be usable on modern hardware (except on very complex maps).

Automap line antialiasing is disabled by default and can be enabled with the `am_lineantialiasing 1` cvar.

## Preview

*Click to view at full size.*

### `am_linethickness 1`

*Included for reference purposes only, as this line thickness does not have an antialiased counterpart.*

![am_linethickness_1](https://user-images.githubusercontent.com/180032/144768209-bb843dd1-1be2-4ddc-96f1-2effcb40d447.png)

### `am_linethickness 2`

*Included for reference purposes only, as this line thickness does not have an antialiased counterpart.


![am_linethickness_2](https://user-images.githubusercontent.com/180032/144768212-d057388e-d0f7-4448-a0dd-378cf984c2f5.png)

### `am_linealpha 1`, `am_linethickness 3`

#### Disabled

![am_linethickness_3](https://user-images.githubusercontent.com/180032/144768215-92a3f034-c9a8-4686-9032-8dbc1d5b7914.png)

#### Enabled

![am_linethickness_3_aa](https://user-images.githubusercontent.com/180032/144768213-53ec8ea8-53a8-43d9-ba91-f656de48c26c.png)

### `am_linealpha 0.5`, `am_linethickness 4`

#### Disabled

![am_linethickness_4_am_linealpha_05](https://user-images.githubusercontent.com/180032/144768217-1818242e-9d2d-48cf-9afc-dbaefb478c61.png)

#### Enabled

![am_linethickness_4_am_linealpha_05_aa](https://user-images.githubusercontent.com/180032/144768216-bc019bc5-701e-4318-bdb0-a2c9ba4d99d7.png)

## Performance

On a very complex map such as Foursite, performance will drop noticeably when the automap is displayed. This happens without antialiasing as well, but antialiasing makes the FPS drop even more.

This is with `am_linethickness 3`; the performance drop won't be as severe with `am_linethickness 2`, which draws 5 lines instead of 9.

### Disabled

![Screenshot_Doom_20211206_002037](https://user-images.githubusercontent.com/180032/144768200-c56df0ad-6a3e-4974-bd3f-56b9a75739cc.png)

### Enabled

![Screenshot_Doom_20211206_002046](https://user-images.githubusercontent.com/180032/144768201-6441690c-e7b6-4331-8e4d-ea1ae5ff3795.png)