### PR TITLE
Add uniform texture12 to GL/VK shaders

### DIFF
--- a/src/common/rendering/gl/gl_shader.cpp
+++ b/src/common/rendering/gl/gl_shader.cpp
@@ -311,6 +311,7 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 		uniform sampler2D texture9;
 		uniform sampler2D texture10;
 		uniform sampler2D texture11;
+		uniform sampler2D texture12;
 
 		// timer data
 		uniform float timer;

--- a/src/common/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_shader.cpp
@@ -186,6 +186,7 @@ static const char *shaderBindings = R"(
 	layout(set = 1, binding = 8) uniform sampler2D texture9;
 	layout(set = 1, binding = 9) uniform sampler2D texture10;
 	layout(set = 1, binding = 10) uniform sampler2D texture11;
+	layout(set = 1, binding = 11) uniform sampler2D texture12;
 
 	// This must match the PushConstants struct
 	layout(push_constant) uniform PushConstants


### PR DESCRIPTION
I'm working on some PBR materials with custom shaders and I ran out of slots for texture.

Tested on both OpenGL and Vulkan backends.