### PR TITLE
Add custom random pitch range and toggle CVARs

### DIFF
--- a/src/common/audio/sound/s_sound.cpp
+++ b/src/common/audio/sound/s_sound.cpp
@@ -45,6 +45,9 @@
 #include "printf.h"
 #include "c_cvars.h"
 
+CVARD(Bool, snd_redefine_pitch, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "enables redefinable pitch (set snd_min_pitch and snd_max_pitch)")
+CVARD(Int, snd_min_pitch, 20, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "sets max pitch limit")
+CVARD(Int, snd_max_pitch, 20, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "sets minimum pitch limit")
 CVARD(Bool, snd_enabled, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "enables/disables sound effects")
 
 int SoundEnabled()
@@ -542,7 +545,12 @@ FSoundChan *SoundEngine::StartSound(int type, const void *source,
 	// Vary the sfx pitches. Overridden by $PitchSet and A_StartSound.
 	if (pitchmask != 0)
 	{
-		pitch = DEFAULT_PITCH - (rand() & pitchmask) + (rand() & pitchmask);
+		if(snd_redefine_pitch == 0){
+			pitch = DEFAULT_PITCH - (rand() & pitchmask) + (rand() & pitchmask);
+		}
+		else{
+			pitch = DEFAULT_PITCH - (rand() & snd_min_pitch) + (rand() & snd_max_pitch);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
This PR adds three new console commands that allow the user to set a minimum and maximum range for the random sound pitch playback using the new min_pitch and max_pitch CVARs, and to enable/disable these custom ranges at any time with the snd_redefine_pitch CVAR.