### PR TITLE
Fix incorrect mapping of texture indices for UE1 models

### DIFF
--- a/src/common/models/models_ue1.cpp
+++ b/src/common/models/models_ue1.cpp
@@ -246,8 +246,9 @@ void FUE1Model::RenderFrame( FModelRenderer *renderer, FGameTexture *skin, int f
 		FGameTexture *sskin = skin;
 		if ( !sskin )
 		{
-			if (surfaceskinids && surfaceskinids[i].isValid())
-				sskin = TexMan.GetGameTexture(surfaceskinids[i], true);
+			int ssIndex = groups[i].texNum;
+			if (surfaceskinids && surfaceskinids[ssIndex].isValid())
+				sskin = TexMan.GetGameTexture(surfaceskinids[ssIndex], true);
 			if ( !sskin )
 			{
 				vofs += vsize;


### PR DESCRIPTION
A recent commit broke the mapping of texture indices for UE1 models, as the internal surfaces don't match actual modeldef surfaceskins 1:1 (there are compatibility reasons for this).

The breakage can be readily seen with Doom Tournament in various weapon and pickup models.
![Screenshot_Doom_20220725_105010](https://user-images.githubusercontent.com/2286785/180737470-f5b07371-4f1b-4cf6-927c-a73424d84b47.jpg)

This is a simple fix that restores the correct indexing.
