### PR TITLE
Fix some issues with A_ChangeModel and using not enough model indices

### DIFF
--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -280,7 +280,8 @@ void RenderFrameModels(FModelRenderer *renderer, FLevelLocals *Level, const FSpr
 	//[SM] - if we added any models for the frame to also render, then we also need to update modelsAmount for this smf
 	if (actor->modelData != nullptr)
 	{
-		modelsamount = actor->modelData->modelIDs.Size();
+		if (actor->modelData->modelIDs.Size() > modelsamount)
+			modelsamount = actor->modelData->modelIDs.Size();
 	}
 
 	TArray<FTextureID> surfaceskinids;
@@ -293,10 +294,10 @@ void RenderFrameModels(FModelRenderer *renderer, FLevelLocals *Level, const FSpr
 		FTextureID skinid; skinid.SetInvalid();
 
 		surfaceskinids.Clear();
-		bool surfaceskinsswapped = false;
 		if (actor->modelData != nullptr)
 		{
-			modelid = actor->modelData->modelIDs[i];
+			if (i < (int)actor->modelData->modelIDs.Size())
+				modelid = actor->modelData->modelIDs[i];
 
 			if (i < (int)actor->modelData->modelFrameGenerators.Size())
 			{


### PR DESCRIPTION
- Removed a useless bool
- Fixed an issue with model containers having less models than their smf total models amount using the smaller amount. So if the container carried only a model at index 0, but there are 4 model indices total, it would stop drawing the rest after index 0