### PR TITLE
Fix another incorrect mapping of texture indices for UE1 models

### DIFF
--- a/src/common/models/models_ue1.cpp
+++ b/src/common/models/models_ue1.cpp
@@ -309,8 +309,9 @@ void FUE1Model::AddSkins( uint8_t *hitlist, const FTextureID* surfaceskinids)
 {
 	for (int i = 0; i < numGroups; i++)
 	{
-		if (surfaceskinids && surfaceskinids[i].isValid())
-			hitlist[surfaceskinids[i].GetIndex()] |= FTextureManager::HIT_Flat;
+		int ssIndex = groups[i].texNum;
+		if (surfaceskinids && surfaceskinids[ssIndex].isValid())
+			hitlist[surfaceskinids[ssIndex].GetIndex()] |= FTextureManager::HIT_Flat;
 	}
 }
 


### PR DESCRIPTION
Looks like I overlooked this one in AddSkins, my bad.