### PR TITLE
Fix definition order of ZScript structs

### DIFF
--- a/src/common/scripting/core/types.cpp
+++ b/src/common/scripting/core/types.cpp
@@ -334,6 +334,7 @@ void PType::StaticInit()
 	TypeVector2->moveOp = OP_MOVEV2;
 	TypeVector2->RegType = REGT_FLOAT;
 	TypeVector2->RegCount = 2;
+	TypeVector2->isOrdered = true;
 
 	TypeVector3 = new PStruct(NAME_Vector3, nullptr);
 	TypeVector3->AddField(NAME_X, TypeFloat64);
@@ -347,6 +348,7 @@ void PType::StaticInit()
 	TypeVector3->moveOp = OP_MOVEV3;
 	TypeVector3->RegType = REGT_FLOAT;
 	TypeVector3->RegCount = 3;
+	TypeVector3->isOrdered = true;
 
 
 	TypeFVector2 = new PStruct(NAME_FVector2, nullptr);
@@ -358,6 +360,7 @@ void PType::StaticInit()
 	TypeFVector2->moveOp = OP_MOVEV2;
 	TypeFVector2->RegType = REGT_FLOAT;
 	TypeFVector2->RegCount = 2;
+	TypeFVector2->isOrdered = true;
 
 	TypeFVector3 = new PStruct(NAME_FVector3, nullptr);
 	TypeFVector3->AddField(NAME_X, TypeFloat32);
@@ -371,6 +374,7 @@ void PType::StaticInit()
 	TypeFVector3->moveOp = OP_MOVEV3;
 	TypeFVector3->RegType = REGT_FLOAT;
 	TypeFVector3->RegCount = 3;
+	TypeFVector3->isOrdered = true;
 
 	Namespaces.GlobalNamespace->Symbols.AddSymbol(Create<PSymbolType>(NAME_sByte, TypeSInt8));
 	Namespaces.GlobalNamespace->Symbols.AddSymbol(Create<PSymbolType>(NAME_Byte, TypeUInt8));

--- a/src/common/scripting/core/types.h
+++ b/src/common/scripting/core/types.h
@@ -537,6 +537,7 @@ public:
 	PStruct(FName name, PTypeBase *outer, bool isnative = false);
 
 	bool isNative;
+	bool isOrdered = false;
 	// Some internal structs require explicit construction and destruction of fields the VM cannot handle directly so use these two functions for it.
 	VMFunction *mConstructor = nullptr;
 	VMFunction *mDestructor = nullptr;

--- a/src/common/scripting/frontend/zcc_compile.h
+++ b/src/common/scripting/frontend/zcc_compile.h
@@ -135,6 +135,9 @@ protected:
 	PType *DetermineType(PType *outertype, ZCC_TreeNode *field, FName name, ZCC_Type *ztype, bool allowarraytypes, bool formember);
 	PType *ResolveArraySize(PType *baseType, ZCC_Expression *arraysize, PContainerType *cls, bool *nosize);
 	PType *ResolveUserType(ZCC_BasicType *type, PSymbolTable *sym, bool nativetype);
+	TArray<ZCC_StructWork *> OrderStructs();
+	void AddStruct(TArray<ZCC_StructWork *> &new_order, ZCC_StructWork *struct_def);
+	ZCC_StructWork *StructTypeToWork(const PStruct *type) const;
 
 	void CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool forclass);
 


### PR DESCRIPTION
Fixes [ZScript crash (very fatal error, 100% repro)](https://forum.zdoom.org/viewtopic.php?f=2&t=73421&p=1201142&hilit=zscript#p1201142)

Do a first pass over the Structs array in CompileAllFields() to reorder them such that if a struct uses other structs, those structs will be resolved first. This allows for defining structs in any order, as long as you don't try to define a recursive struct. Example:

```c
struct a {
    b myStruct; // b is defined after a, but that's okay
}

struct b {
    int myVal;
}
```