### PR TITLE
Duplicated lightmap code to GLES2

### DIFF
--- a/src/common/rendering/gles/gles_framebuffer.cpp
+++ b/src/common/rendering/gles/gles_framebuffer.cpp
@@ -302,6 +302,30 @@ void OpenGLFrameBuffer::PrecacheMaterial(FMaterial *mat, int translation)
 	gl_RenderState.ClearLastMaterial();
 }
 
+void OpenGLFrameBuffer::InitLightmap(int LMTextureSize, int LMTextureCount, TArray<uint16_t>& LMTextureData)
+{
+	if ( gles.lighmapsAvailable && LMTextureData.Size() > 0)
+	{
+		GLint activeTex = 0;
+		glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTex);
+		glActiveTexture(GL_TEXTURE0 + 17);
+
+		if (GLRenderer->mLightMapID == 0)
+			glGenTextures(1, (GLuint*)&GLRenderer->mLightMapID);
+
+		glBindTexture(GL_TEXTURE_2D_ARRAY, GLRenderer->mLightMapID);
+		glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_RGB16F, LMTextureSize, LMTextureSize, LMTextureCount, 0, GL_RGB, GL_HALF_FLOAT, &LMTextureData[0]);
+		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glGenerateMipmap(GL_TEXTURE_2D_ARRAY);
+
+		glActiveTexture(activeTex);
+
+		LMTextureData.Reset(); // We no longer need this, release the memory
+	}
+}
+
+
 IVertexBuffer *OpenGLFrameBuffer::CreateVertexBuffer()
 { 
 	return new GLVertexBuffer; 

--- a/src/common/rendering/gles/gles_framebuffer.h
+++ b/src/common/rendering/gles/gles_framebuffer.h
@@ -46,6 +46,8 @@ public:
 	IVertexBuffer *CreateVertexBuffer() override;
 	IIndexBuffer *CreateIndexBuffer() override;
 	IDataBuffer *CreateDataBuffer(int bindingpoint, bool ssbo, bool needsresize) override;
+	
+	void InitLightmap(int LMTextureSize, int LMTextureCount, TArray<uint16_t>& LMTextureData) override;
 
 	// Retrieves a buffer containing image data for a screenshot.
 	// Hint: Pitch can be negative for upside-down images, in which case buffer

--- a/src/common/rendering/gles/gles_renderer.h
+++ b/src/common/rendering/gles/gles_renderer.h
@@ -55,6 +55,8 @@ public:
 	FGLRenderBuffers *mScreenBuffers = nullptr;
 	FPresentShader *mPresentShader = nullptr;
 
+	int mLightMapID = 0;
+
 	//FRotator mAngles;
 
 	FGLRenderer(OpenGLFrameBuffer *fb);

--- a/src/common/rendering/gles/gles_shaderprogram.cpp
+++ b/src/common/rendering/gles/gles_shaderprogram.cpp
@@ -236,7 +236,7 @@ FString FShaderProgram::PatchShader(ShaderType type, const FString &code, const 
 {
 	FString patchedCode;
 
-	patchedCode.AppendFormat("#version %d\n", 100); // Set to GLES2 
+	patchedCode.AppendFormat("#version %s\n", gles.lighmapsAvailable ? "300 es" : "100"); // GLES3 if using lightmaps
 
 	patchedCode += GetGLSLPrecision();
 

--- a/src/common/rendering/gles/gles_system.cpp
+++ b/src/common/rendering/gles/gles_system.cpp
@@ -4,6 +4,7 @@
 #include "tarray.h"
 #include "v_video.h"
 #include "printf.h"
+#include "m_argv.h"
 
 CVAR(Bool, gles_use_mapped_buffer, false, 0);
 CVAR(Bool, gles_force_glsl_v100, false, 0);
@@ -16,6 +17,7 @@ void setGlVersion(double glv);
 
 PFNGLMAPBUFFERRANGEEXTPROC glMapBufferRange = NULL;
 PFNGLUNMAPBUFFEROESPROC glUnmapBuffer = NULL;
+PFNGLTEXIMAGE3DPROC glTexImage3D = NULL;
 
 #ifdef __ANDROID__
 #include <dlfcn.h>
@@ -134,6 +136,7 @@ namespace OpenGLESRenderer
 
 		glMapBufferRange = (PFNGLMAPBUFFERRANGEEXTPROC)LoadGLES2Proc("glMapBufferRange");
 		glUnmapBuffer = (PFNGLUNMAPBUFFEROESPROC)LoadGLES2Proc("glUnmapBuffer");
+		glTexImage3D = (PFNGLTEXIMAGE3DPROC)LoadGLES2Proc("glTexImage3D");
 
 #else
 		static bool first = true;
@@ -185,12 +188,14 @@ namespace OpenGLESRenderer
 		gles.npotAvailable = CheckExtension("GL_OES_texture_npot");
 		gles.depthClampAvailable = CheckExtension("GL_EXT_depth_clamp");
 		gles.anistropicFilterAvailable = CheckExtension("GL_EXT_texture_filter_anisotropic");
+		gles.lighmapsAvailable = false; // Disable for non-desktop for now
 #else
 		gles.depthStencilAvailable = true;
 		gles.npotAvailable = true;
 		gles.useMappedBuffers = true;
 		gles.depthClampAvailable = true;
 		gles.anistropicFilterAvailable = true;
+		gles.lighmapsAvailable = Args->CheckParm("-enablelightmaps");
 #endif
 
 		gles.numlightvectors = (gles.maxlights * LIGHT_VEC4_NUM);

--- a/src/common/rendering/gles/gles_system.h
+++ b/src/common/rendering/gles/gles_system.h
@@ -30,6 +30,8 @@
 	#include "glad/glad.h"
 
 // Below are used extensions for GLES
+
+// Used for mapped buffer
 typedef void* (APIENTRYP PFNGLMAPBUFFERRANGEEXTPROC)(GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
 GLAPI PFNGLMAPBUFFERRANGEEXTPROC glMapBufferRange;
 
@@ -45,6 +47,14 @@ GLAPI PFNGLUNMAPBUFFEROESPROC glUnmapBuffer;
 #define GL_BGRA                           0x80E1
 #define GL_DEPTH_CLAMP                    0x864F
 #define GL_TEXTURE_MAX_ANISOTROPY_EXT     0x84FE
+
+// Used for lightmaps
+typedef void (APIENTRYP PFNGLTEXIMAGE3DPROC) (GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void* pixels);
+GLAPI PFNGLTEXIMAGE3DPROC glTexImage3D;
+
+#define GL_TEXTURE_2D_ARRAY               0x8C1A
+#define GL_RGB16F                         0x881B
+#define GL_HALF_FLOAT                     0x140B
 
 #else
 	#include "gl_load/gl_load.h"
@@ -74,6 +84,7 @@ namespace OpenGLESRenderer
 		bool forceGLSLv100;
 		bool depthClampAvailable;
 		bool anistropicFilterAvailable;
+		bool lighmapsAvailable;
 		int max_texturesize;
 		char* vendorstring;
 		char* modelstring;

--- a/wadsrc/static/shaders_gles/glsl/main.fp
+++ b/wadsrc/static/shaders_gles/glsl/main.fp
@@ -7,6 +7,10 @@ varying vec3 gradientdist;
 varying vec4 vWorldNormal;
 varying vec4 vEyeNormal;
 
+#if __VERSION__ == 300
+varying vec3 vLightmap;
+#endif
+
 #ifdef NO_CLIPDISTANCE_SUPPORT
 varying vec4 ClipDistanceA;
 varying vec4 ClipDistanceB;
@@ -444,6 +448,16 @@ vec4 getLightColor(Material material, float fogdist, float fogfactor)
 	// apply other light manipulation by custom shaders, default is a NOP.
 	//
 	color = ProcessLight(material, color);
+	
+#if __VERSION__ == 300
+	//
+	// apply lightmaps
+	//
+	if (vLightmap.z >= 0.0)
+	{
+		color.rgb += texture(LightMap, vLightmap).rgb;
+	}
+#endif
 
 	//
 	// apply dynamic lights

--- a/wadsrc/static/shaders_gles/glsl/main.vp
+++ b/wadsrc/static/shaders_gles/glsl/main.vp
@@ -5,11 +5,14 @@ attribute vec4 aColor;
 
 varying vec4 vTexCoord;
 varying vec4 vColor;
+varying vec3 vLightmap;
+
 
 #ifndef SIMPLE	// we do not need these for simple shaders
 attribute vec4 aVertex2;
 attribute vec4 aNormal;
 attribute vec4 aNormal2;
+attribute vec3 aLightmap;
 
 varying vec4 pixelpos;
 varying vec3 glowdist;
@@ -51,6 +54,8 @@ void main()
 	#endif
 
 	#ifndef SIMPLE
+		vLightmap = aLightmap;
+
 		pixelpos.xyz = worldcoord.xyz;
 		pixelpos.w = -eyeCoordPos.z/eyeCoordPos.w;
   


### PR DESCRIPTION
When enabled it will use '#version 300 es', works on my PC but not sure if will work on all PC cards.
Without "-enablelightmaps" it should behave exactly as before.