### PR TITLE
Fixes for unsigned integers

### DIFF
--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -2685,6 +2685,19 @@ bool FxBinary::Promote(FCompileContext &ctx, bool forceint)
 	{
 		ValueType = TypeUInt32;
 	}
+	// If one side is an unsigned 32-bit int and the other side is a signed 32-bit int, the signed side is implicitly converted to unsigned.
+	else if (!ctx.FromDecorate && left->ValueType == TypeUInt32 && right->ValueType == TypeSInt32)
+	{
+		right = new FxIntCast(right, false, false, true);
+		right = right->Resolve(ctx);
+		ValueType = TypeUInt32;
+	}
+	else if (!ctx.FromDecorate && left->ValueType == TypeSInt32 && right->ValueType == TypeUInt32)
+	{
+		left = new FxIntCast(left, false, false, true);
+		left = left->Resolve(ctx);
+		ValueType = TypeUInt32;
+	}
 	else if (left->IsInteger() && right->IsInteger())
 	{
 		ValueType = TypeSInt32;		// Addition and subtraction forces all integer-derived types to signed int.

--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -2808,7 +2808,14 @@ FxExpression *ZCCCompiler::ConvertNode(ZCC_TreeNode *ast, bool substitute)
 		}
 		else if (cnst->Type->isInt())
 		{
-			return new FxConstant(cnst->IntVal, *ast);
+			if (cnst->Type == TypeUInt32)
+			{
+				return new FxConstant((unsigned)cnst->IntVal, *ast);
+			}
+			else
+			{
+				return new FxConstant(cnst->IntVal, *ast);
+			}
 		}
 		else if (cnst->Type == TypeBool)
 		{


### PR DESCRIPTION
Fixes [Modulus operator ignores sign when right-hand-side is const](https://forum.zdoom.org/viewtopic.php?f=53&t=73477&hilit=zscript).

Unsigned integers did not make it to the codegen without losing their unsignedness status.

Also, when a binary operator has an unsigned integer on one side and a signed integer on the other, the standard promotion rules (for C-style languages at least) are that they're both promoted to the next size larger signed type. If no conversion to a larger type is possible, then the signed type is promoted to an unsigned type. Here, the unsigned type was effectively being demoted to a signed type instead.