### PR TITLE
Add support for nested user types

### DIFF
--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -1994,8 +1994,34 @@ PType *ZCCCompiler::ResolveUserType(ZCC_BasicType *type, ZCC_Identifier *id, PSy
 		}
 		if (!nativetype) return ptype;
 	}
-	Error(type, "Unable to resolve %s%s as type.", nativetype? "@" : "", FName(type->UserType->Id).GetChars());
+	Error(type, "Unable to resolve %s%s as a type.", nativetype? "@" : "", UserTypeName(type).GetChars());
 	return TypeError;
+}
+
+
+//==========================================================================
+//
+// ZCCCompiler :: UserTypeName										STATIC
+//
+// Returns the full name for a UserType node.
+// 
+//==========================================================================
+
+FString ZCCCompiler::UserTypeName(ZCC_BasicType *type)
+{
+	FString out;
+	ZCC_Identifier *id = type->UserType;
+
+	do
+	{
+		assert(id->NodeType == AST_Identifier);
+		if (out.Len() > 0)
+		{
+			out += '.';
+		}
+		out += FName(id->Id).GetChars();
+	} while ((id = static_cast<ZCC_Identifier *>(id->SiblingNext)) != type->UserType);
+	return out;
 }
 
 //==========================================================================
@@ -2339,7 +2365,11 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 					}
 					if (type->GetRegType() == REGT_NIL && type != TypeVector2 && type != TypeVector3 && type != TypeFVector2 && type != TypeFVector3)
 					{
-						Error(p, "Invalid type %s for function parameter", type->DescriptiveName());
+						// If it's TypeError, then an error was already given
+						if (type != TypeError)
+						{
+							Error(p, "Invalid type %s for function parameter", type->DescriptiveName());
+						}
 					}
 					else if (p->Default != nullptr)
 					{

--- a/src/common/scripting/frontend/zcc_compile.h
+++ b/src/common/scripting/frontend/zcc_compile.h
@@ -135,6 +135,7 @@ protected:
 	PType *DetermineType(PType *outertype, ZCC_TreeNode *field, FName name, ZCC_Type *ztype, bool allowarraytypes, bool formember);
 	PType *ResolveArraySize(PType *baseType, ZCC_Expression *arraysize, PContainerType *cls, bool *nosize);
 	PType *ResolveUserType(ZCC_BasicType *type, ZCC_Identifier *id, PSymbolTable *sym, bool nativetype);
+	static FString UserTypeName(ZCC_BasicType *type);
 	TArray<ZCC_StructWork *> OrderStructs();
 	void AddStruct(TArray<ZCC_StructWork *> &new_order, ZCC_StructWork *struct_def);
 	ZCC_StructWork *StructTypeToWork(const PStruct *type) const;

--- a/src/common/scripting/frontend/zcc_compile.h
+++ b/src/common/scripting/frontend/zcc_compile.h
@@ -134,7 +134,7 @@ protected:
 	FString FlagsToString(uint32_t flags);
 	PType *DetermineType(PType *outertype, ZCC_TreeNode *field, FName name, ZCC_Type *ztype, bool allowarraytypes, bool formember);
 	PType *ResolveArraySize(PType *baseType, ZCC_Expression *arraysize, PContainerType *cls, bool *nosize);
-	PType *ResolveUserType(ZCC_BasicType *type, PSymbolTable *sym, bool nativetype);
+	PType *ResolveUserType(ZCC_BasicType *type, ZCC_Identifier *id, PSymbolTable *sym, bool nativetype);
 	TArray<ZCC_StructWork *> OrderStructs();
 	void AddStruct(TArray<ZCC_StructWork *> &new_order, ZCC_StructWork *struct_def);
 	ZCC_StructWork *StructTypeToWork(const PStruct *type) const;


### PR DESCRIPTION
The grammar already understood these constructs. Now the compiler does too.

Fixes [ZScript Syntax for referring to an inner type is broken](https://forum.zdoom.org/viewtopic.php?p=1212088#p1212088)