### PR TITLE
Add detection for Steam Doom II's Final Doom WADs

### DIFF
--- a/src/posix/i_steam.cpp
+++ b/src/posix/i_steam.cpp
@@ -160,7 +160,10 @@ static struct SteamAppInfo
 	{"Hexen Deathkings of the Dark Citadel/base", 2370},
 	{"Ultimate Doom/base", 2280},
 	{"DOOM 3 BFG Edition/base/wads", 208200},
-	{"Strife", 317040}
+	{"Strife", 317040},
+	{"Ultimate Doom/rerelease/DOOM_Data/StreamingAssets", 2280},
+	{"Doom 2/rerelease/DOOM II_Data/StreamingAssets", 2300},
+	{"Doom 2/finaldoombase", 2300}
 };
 
 TArray<FString> I_GetSteamPath()

--- a/src/win32/i_steam.cpp
+++ b/src/win32/i_steam.cpp
@@ -222,7 +222,8 @@ TArray<FString> I_GetSteamPath()
 		"DOOM 3 BFG Edition/base/wads",
 		"Strife",
 		"Ultimate Doom/rerelease/DOOM_Data/StreamingAssets",
-		"Doom 2/rerelease/DOOM II_Data/StreamingAssets"
+		"Doom 2/rerelease/DOOM II_Data/StreamingAssets",
+		"Doom 2/finaldoombase"
 	};
 
 	FString path;


### PR DESCRIPTION
As detailed in [https://bethesda.net/en/article/58GKjmwGkwgl2DRImhHFFC/id-software-steam-store-consolidation](url), the Steam version of Doom II now includes Final Doom and the Master Levels in the same installation. This pull request adds detection for the Final Doom WADs.

I also added detection for the Steam Unity versions of Doom and Doom II in posix/i_steam.cpp, since that wasn't done by whoever added it to win32/i_steam.cpp.