### PR TITLE
Add detection for the GOG releases of the Unity versions of Doom and Doom II

### DIFF
--- a/src/win32/i_steam.cpp
+++ b/src/win32/i_steam.cpp
@@ -144,12 +144,26 @@ TArray<FString> I_GetGogPaths()
 		result.Push(path);	// directly in install folder
 	}
 
+	// Look for Doom I Enhanced
+	gamepath = gogregistrypath + L"\\2015545325";
+	if (QueryPathKey(HKEY_LOCAL_MACHINE, gamepath.c_str(), L"Path", path))
+	{
+		result.Push(path + "/DOOM_Data/StreamingAssets");	// in a subdirectory
+	}
+
 	// Look for Doom II
 	gamepath = gogregistrypath + L"\\1435848814";
 	if (QueryPathKey(HKEY_LOCAL_MACHINE, gamepath.c_str(), L"Path", path))
 	{
 		result.Push(path + "/doom2");	// in a subdirectory
 		// If direct support for the Master Levels is ever added, they are in path + /master/wads
+	}
+
+	// Look for Doom II Enhanced
+	gamepath = gogregistrypath + L"\\1426071866";
+	if (QueryPathKey(HKEY_LOCAL_MACHINE, gamepath.c_str(), L"Path", path))
+	{
+		result.Push(path + "/DOOM II_Data/StreamingAssets");	// in a subdirectory
 	}
 
 	// Look for Final Doom


### PR DESCRIPTION
Twitter post: https://twitter.com/GOGcom/status/1559903276094656513

Unlike the Steam versions, these are installed in separate folders from the original versions.