### PR TITLE
UE1 models now handle frame index -1 properly

### DIFF
--- a/src/common/models/models_ue1.cpp
+++ b/src/common/models/models_ue1.cpp
@@ -232,7 +232,7 @@ int FUE1Model::FindFrame( const char *name, bool nodefault )
 void FUE1Model::RenderFrame( FModelRenderer *renderer, FGameTexture *skin, int frame, int frame2, double inter, int translation, const FTextureID* surfaceskinids)
 {
 	// the moment of magic
-	if ( (frame >= numFrames) || (frame2 >= numFrames) ) return;
+	if ( (frame < 0) || (frame2 < 0) || (frame >= numFrames) || (frame2 >= numFrames) ) return;
 	renderer->SetInterpolation(inter);
 	int vsize, fsize = 0, vofs = 0;
 	for ( int i=0; i<numGroups; i++ ) fsize += groups[i].numPolys*3;


### PR DESCRIPTION
This was a major oversight from my part here. Without this fix, the renderer will be reading garbage data instead of just hiding the model (very dangerous and unsafe).