### PR TITLE
Fixed monsters being unable to patrol in SECF_NOATTACK sectors.

### DIFF
--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -268,10 +268,11 @@ int P_CheckMeleeRange (AActor* actor, double range)
 	AActor *pl = actor->target;
 
 	double dist;
-		
-	if (!pl || (actor->Sector->Flags & SECF_NOATTACK))
+	
+	// [inkoalawetrust] Monsters inside SECF_NOATTACK sectors still follow their patrol routes.
+	if (!pl || (actor->Sector->Flags & SECF_NOATTACK && pl != actor->goal))
 		return false;
-				
+	
 	dist = actor->Distance2D (pl);
 	if (range < 0) range = actor->meleerange;
 


### PR DESCRIPTION
This PR fixes a bug in P_CheckMeleeRange() that causes monsters to be unable to reach a patrol point, if the monster is inside a sector with SECF_NOATTACK.


I have attached an example map below, where the sector with the blue particles has SECF_NOATTACK on, and one of the patrol points the Imp needs to cross is inside that sector.

[PatrolPointBugDemo.zip](https://github.com/ZDoom/gzdoom/files/9483407/PatrolPointBugDemo.zip)
