### PR TITLE
Add vertex height and plane slope manipulation functions to LevelPostProcessor

### DIFF
--- a/src/maploader/maploader.h
+++ b/src/maploader/maploader.h
@@ -110,8 +110,6 @@ private:
 	int firstglvertex;	// helpers for loading GL nodes from GWA files.
 	bool format5;
 
-	TArray<vertexdata_t> vertexdatas;
-
 	TMap<unsigned, unsigned>  MapThingsUserDataIndex;	// from mapthing idx -> user data idx
 	TArray<FUDMFKey> MapThingsUserData;
 	int sidecount = 0;
@@ -120,6 +118,8 @@ private:
 public:	// for the scripted compatibility system these two members need to be public.
 	TArray<FMapThing> MapThingsConverted;
 	bool ForceNodeBuild = false;
+	// This needs to be public to fetch this from DLevelPostProcessor native functions
+	TArray<vertexdata_t> vertexdatas;
 private:
 
 	// Extradata loader

--- a/src/maploader/postprocessor.cpp
+++ b/src/maploader/postprocessor.cpp
@@ -437,6 +437,77 @@ DEFINE_ACTION_FUNCTION(DLevelPostProcessor, SetVertex)
 	return 0;
 }
 
+DEFINE_ACTION_FUNCTION(DLevelPostProcessor, GetVertexZ)
+{
+	PARAM_SELF_PROLOGUE(DLevelPostProcessor);
+	PARAM_UINT(vertex);
+	PARAM_INT(planeval);
+	
+	if (vertex < self->Level->vertexes.Size() && vertex < self->loader->vertexdatas.Size())
+	{
+		vertexdata_t& data = self->loader->vertexdatas[vertex];
+		double value = planeval ? data.zFloor : data.zCeiling;
+		ACTION_RETURN_FLOAT(value);
+	}
+
+	ACTION_RETURN_FLOAT(0);
+}
+
+DEFINE_ACTION_FUNCTION(DLevelPostProcessor, IsVertexZSet)
+{
+	PARAM_SELF_PROLOGUE(DLevelPostProcessor);
+	PARAM_UINT(vertex);
+	PARAM_INT(planeval);
+
+	if (vertex < self->Level->vertexes.Size() && vertex < self->loader->vertexdatas.Size())
+	{
+		vertexdata_t& data = self->loader->vertexdatas[vertex];
+		bool value = data.flags & (planeval ? VERTEXFLAG_ZFloorEnabled : VERTEXFLAG_ZCeilingEnabled);
+		ACTION_RETURN_BOOL(value);
+	}
+
+	ACTION_RETURN_BOOL(false);
+}
+
+DEFINE_ACTION_FUNCTION(DLevelPostProcessor, SetVertexZ)
+{
+	PARAM_SELF_PROLOGUE(DLevelPostProcessor);
+	PARAM_UINT(vertex);
+	PARAM_INT(planeval);
+	PARAM_FLOAT(z);
+
+	if (vertex < self->Level->vertexes.Size() && vertex < self->loader->vertexdatas.Size())
+	{
+		vertexdata_t& data = self->loader->vertexdatas[vertex];
+		if (planeval) {
+			data.flags |= VERTEXFLAG_ZFloorEnabled;
+			data.zFloor = z;
+		}
+		else
+		{
+			data.flags |= VERTEXFLAG_ZCeilingEnabled;
+			data.zCeiling = z;
+		}
+	}
+
+	return 0;
+}
+
+DEFINE_ACTION_FUNCTION(DLevelPostProcessor, UnsetVertexZ)
+{
+	PARAM_SELF_PROLOGUE(DLevelPostProcessor);
+	PARAM_UINT(vertex);
+	PARAM_INT(planeval);
+
+	if (vertex < self->Level->vertexes.Size() && vertex < self->loader->vertexdatas.Size())
+	{
+		vertexdata_t& data = self->loader->vertexdatas[vertex];
+		data.flags &= ~(planeval ? VERTEXFLAG_ZFloorEnabled : VERTEXFLAG_ZCeilingEnabled);
+	}
+
+	return 0;
+}
+
 DEFINE_ACTION_FUNCTION(DLevelPostProcessor, SetLineVertexes)
 {
 	PARAM_SELF_PROLOGUE(DLevelPostProcessor);

--- a/src/maploader/postprocessor.cpp
+++ b/src/maploader/postprocessor.cpp
@@ -443,30 +443,28 @@ DEFINE_ACTION_FUNCTION(DLevelPostProcessor, GetVertexZ)
 	PARAM_UINT(vertex);
 	PARAM_INT(planeval);
 	
-	if (vertex < self->Level->vertexes.Size() && vertex < self->loader->vertexdatas.Size())
-	{
-		vertexdata_t& data = self->loader->vertexdatas[vertex];
-		double value = planeval ? data.zFloor : data.zCeiling;
-		ACTION_RETURN_FLOAT(value);
-	}
-
-	ACTION_RETURN_FLOAT(0);
-}
-
-DEFINE_ACTION_FUNCTION(DLevelPostProcessor, IsVertexZSet)
-{
-	PARAM_SELF_PROLOGUE(DLevelPostProcessor);
-	PARAM_UINT(vertex);
-	PARAM_INT(planeval);
+	double value = 0;
+	bool isset = false;
 
 	if (vertex < self->Level->vertexes.Size() && vertex < self->loader->vertexdatas.Size())
 	{
 		vertexdata_t& data = self->loader->vertexdatas[vertex];
-		bool value = data.flags & (planeval ? VERTEXFLAG_ZFloorEnabled : VERTEXFLAG_ZCeilingEnabled);
-		ACTION_RETURN_BOOL(value);
+		value = planeval ? data.zFloor : data.zCeiling;
+		isset = data.flags & (planeval ? VERTEXFLAG_ZFloorEnabled : VERTEXFLAG_ZCeilingEnabled);
 	}
 
-	ACTION_RETURN_BOOL(false);
+	if (numret > 1)
+	{
+		numret = 2;
+		ret[1].SetInt(isset);
+	}
+
+	if (numret > 0)
+	{
+		ret[0].SetFloat(value);
+	}
+
+	return numret;
 }
 
 DEFINE_ACTION_FUNCTION(DLevelPostProcessor, SetVertexZ)
@@ -493,7 +491,7 @@ DEFINE_ACTION_FUNCTION(DLevelPostProcessor, SetVertexZ)
 	return 0;
 }
 
-DEFINE_ACTION_FUNCTION(DLevelPostProcessor, UnsetVertexZ)
+DEFINE_ACTION_FUNCTION(DLevelPostProcessor, RemoveVertexZ)
 {
 	PARAM_SELF_PROLOGUE(DLevelPostProcessor);
 	PARAM_UINT(vertex);

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -562,7 +562,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(_Sector, SetXOffset, SetXOffset)
 	 PARAM_SELF_STRUCT_PROLOGUE(sector_t);
 	 PARAM_INT(pos);
 	 PARAM_FLOAT(o);
-	 self->SetXOffset(pos, o);
+	 self->SetYOffset(pos, o);
 	 return 0;
  }
 

--- a/wadsrc/static/zscript/level_postprocessor.zs
+++ b/wadsrc/static/zscript/level_postprocessor.zs
@@ -47,6 +47,10 @@ class LevelPostProcessor native play
 	protected native void SetThingStringArgument(uint thing, Name value);
 
 	protected native void SetVertex(uint vertex, double x, double y);
+	protected native double GetVertexZ(uint vertex, int plane);
+	protected native bool IsVertexZSet(uint vertex, int plane);
+	protected native void SetVertexZ(uint vertex, int plane, double z);
+	protected native void UnsetVertexZ(uint vertex, int plane);
 	protected native void SetLineVertexes(uint Line, uint v1, uint v2);
 	protected native void FlipLineSideRefs(uint Line);
 	protected native void SetLineSectorRef(uint line, uint side, uint sector);

--- a/wadsrc/static/zscript/level_postprocessor.zs
+++ b/wadsrc/static/zscript/level_postprocessor.zs
@@ -47,10 +47,9 @@ class LevelPostProcessor native play
 	protected native void SetThingStringArgument(uint thing, Name value);
 
 	protected native void SetVertex(uint vertex, double x, double y);
-	protected native double GetVertexZ(uint vertex, int plane);
-	protected native bool IsVertexZSet(uint vertex, int plane);
+	protected native double, bool GetVertexZ(uint vertex, int plane);
 	protected native void SetVertexZ(uint vertex, int plane, double z);
-	protected native void UnsetVertexZ(uint vertex, int plane);
+	protected native void RemoveVertexZ(uint vertex, int plane);
 	protected native void SetLineVertexes(uint Line, uint v1, uint v2);
 	protected native void FlipLineSideRefs(uint Line);
 	protected native void SetLineSectorRef(uint line, uint side, uint sector);

--- a/wadsrc/static/zscript/level_postprocessor.zs
+++ b/wadsrc/static/zscript/level_postprocessor.zs
@@ -12,6 +12,7 @@ class LevelPostProcessor native play
 	protected native void ClearLineIDs(int line);
 	protected native void AddLineID(int line, int tag);
 	protected native void OffsetSectorPlane(int sector, int plane, double offset);
+	protected native void SetSectorPlane(int sector, int plane, vector3 normal, double d);
 
 	const SKILLS_ALL = 31;
 	const MODES_ALL = MTF_SINGLE | MTF_COOPERATIVE | MTF_DEATHMATCH;


### PR DESCRIPTION
This works together with OffsetSectorPlane to allow modifying vertex slopes; otherwise they are not moved and cause visual issues.

I don't think OffsetSectorPlane should be changed because of this, since 1. vertex heights are not part of plane data, and 2. it may/will break backwards compatibility. Instead I just added a new function to specifically modify vertex heights.

Example use:

```C#
if (fromZ != toZ) {
	Console.Printf("Z mismatch (%f != %f); will move %d sectors", fromZ, toZ, to.fragment.sectors.Size());
	for (uint i = 0; i < to.fragment.sectors.Size(); i++) {
		OffsetSectorPlane(to.fragment.sectors[i].Index(), 0, fromZ - toZ);
		OffsetSectorPlane(to.fragment.sectors[i].Index(), 1, fromZ - toZ);
	}
	for (uint i = 0; i < to.fragment.vertices.Size(); i++) {
		uint vertex = to.fragment.vertices[i].Index();
		for (uint k = 0; k < 2; k++) {
			double z;
			bool isset;
			[z, isset] = GetVertexZ(vertex, k);
			if (isset) {
				SetVertexZ(vertex, k, z + fromZ - toZ);
				Console.Printf("Set vertex Z from %f to %f", z, z + fromZ - toZ);
			}
		}
	}
}
```

or

```C#
for (uint i = 0; i < to.fragment.sectors.Size(); i++)
{
	let sec = to.fragment.sectors[i];
	SetSectorPlane(sec.Index(), 0, (0, 0.5, 1).Unit(), sec.floorplane.d);
	SetSectorPlane(sec.Index(), 1, (0, -0.5, -1).Unit(), sec.ceilingplane.d);
}
```