### PR TITLE
fix Screen.DrawShapeFill not properly setting renderstyle

### DIFF
--- a/src/common/2d/v_draw.cpp
+++ b/src/common/2d/v_draw.cpp
@@ -306,7 +306,7 @@ void DrawShape(F2DDrawer *drawer, FGameTexture *img, DShape2D *shape, VMVa_List 
 	drawer->AddShape(img, shape, parms);
 }
 
-void DrawShapeFill(F2DDrawer *drawer, int color, double amount, DShape2D *shape, VMVa_List &args)
+void DrawShapeFill(F2DDrawer *drawer, PalEntry color, double amount, DShape2D *shape, VMVa_List &args)
 {
 	DrawParms parms;
 	uint32_t tag = ListGetInt(args);
@@ -827,7 +827,7 @@ static inline FSpecialColormap * ListGetSpecialColormap(VMVa_List &tags)
 //==========================================================================
 
 template<class T>
-bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double y, uint32_t tag, T& tags, DrawParms *parms, int type, int fill, double fillalpha)
+bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double y, uint32_t tag, T& tags, DrawParms *parms, int type, PalEntry fill, double fillalpha)
 {
 	INTBOOL boolval;
 	int intval;
@@ -861,7 +861,7 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 	parms->destwidth = INT_MAX;
 	parms->destheight = INT_MAX;
 	parms->Alpha = type == DrawTexture_Fill ? fillalpha : 1.f;
-	parms->fillcolor = type == DrawTexture_Fill ? fill : -1;
+	parms->fillcolor = type == DrawTexture_Fill ? fill : PalEntry(~0u);
 	parms->TranslationId = -1;
 	parms->colorOverlay = 0;
 	parms->alphaChannel = false;
@@ -1430,8 +1430,8 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 }
 // explicitly instantiate both versions for v_text.cpp.
 
-template bool ParseDrawTextureTags<Va_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, Va_List& tags, DrawParms *parms, int type, int fill, double fillalpha);
-template bool ParseDrawTextureTags<VMVa_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, VMVa_List& tags, DrawParms *parms, int type, int fill, double fillalpha);
+template bool ParseDrawTextureTags<Va_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, Va_List& tags, DrawParms *parms, int type, PalEntry fill, double fillalpha);
+template bool ParseDrawTextureTags<VMVa_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, VMVa_List& tags, DrawParms *parms, int type, PalEntry fill, double fillalpha);
 
 //==========================================================================
 //

--- a/src/common/2d/v_draw.cpp
+++ b/src/common/2d/v_draw.cpp
@@ -199,7 +199,7 @@ void DoDrawTexture(F2DDrawer *drawer, FGameTexture* img, double x, double y, int
 	DrawParms parms;
 
 	if (!img || !img->isValid()) return;
-	bool res = ParseDrawTextureTags(drawer, img, x, y, tags_first, tags, &parms, false);
+	bool res = ParseDrawTextureTags(drawer, img, x, y, tags_first, tags, &parms, DrawTexture_Normal);
 	va_end(tags.list);
 	if (!res)
 	{
@@ -238,7 +238,7 @@ void DoDrawTexture(F2DDrawer *drawer, FGameTexture *img, double x, double y, VMV
 	DrawParms parms;
 	uint32_t tag = ListGetInt(args);
 	if (!img || !img->isValid()) return;
-	bool res = ParseDrawTextureTags(drawer, img, x, y, tag, args, &parms, false);
+	bool res = ParseDrawTextureTags(drawer, img, x, y, tag, args, &parms, DrawTexture_Normal);
 	if (!res) return;
 	drawer->AddTexture(img, parms);
 }
@@ -290,7 +290,7 @@ void DrawShape(F2DDrawer *drawer, FGameTexture *img, DShape2D *shape, int tags_f
 	va_start(tags.list, tags_first);
 	DrawParms parms;
 
-	bool res = ParseDrawTextureTags(drawer, img, 0, 0, tags_first, tags, &parms, false);
+	bool res = ParseDrawTextureTags(drawer, img, 0, 0, tags_first, tags, &parms, DrawTexture_Normal);
 	va_end(tags.list);
 	if (!res) return;
 	drawer->AddShape(img, shape, parms);
@@ -301,20 +301,18 @@ void DrawShape(F2DDrawer *drawer, FGameTexture *img, DShape2D *shape, VMVa_List 
 	DrawParms parms;
 	uint32_t tag = ListGetInt(args);
 
-	bool res = ParseDrawTextureTags(drawer, img, 0, 0, tag, args, &parms, false);
+	bool res = ParseDrawTextureTags(drawer, img, 0, 0, tag, args, &parms, DrawTexture_Normal);
 	if (!res) return;
 	drawer->AddShape(img, shape, parms);
 }
 
-void DrawShapeFill(F2DDrawer *drawer, int color, DShape2D *shape, VMVa_List &args)
+void DrawShapeFill(F2DDrawer *drawer, int color, double amount, DShape2D *shape, VMVa_List &args)
 {
 	DrawParms parms;
 	uint32_t tag = ListGetInt(args);
 
-	bool res = ParseDrawTextureTags(drawer, nullptr, 0, 0, tag, args, &parms, false, false);
+	bool res = ParseDrawTextureTags(drawer, nullptr, 0, 0, tag, args, &parms, DrawTexture_Fill, color, amount);
 	if (!res) return;
-
-	parms.fillcolor = color;
 
 	drawer->AddShape(nullptr, shape, parms);
 }
@@ -367,9 +365,7 @@ DEFINE_ACTION_FUNCTION(_Screen, DrawShapeFill)
 
 	VMVa_List args = { param + 3, 0, numparam - 4, va_reginfo + 3 };
 
-	color.a = int(amount * 255.0f);
-
-	DrawShapeFill(twod, color, shape, args);
+	DrawShapeFill(twod, color, amount, shape, args);
 	return 0;
 }
 
@@ -384,9 +380,7 @@ DEFINE_ACTION_FUNCTION(FCanvas, DrawShapeFill)
 
 	VMVa_List args = { param + 4, 0, numparam - 5, va_reginfo + 4 };
 
-	color.a = int(amount * 255.0f);
-
-	DrawShapeFill(&self->Drawer, color, shape, args);
+	DrawShapeFill(&self->Drawer, color, amount, shape, args);
 	self->Tex->NeedUpdate();
 	return 0;
 }
@@ -532,7 +526,7 @@ void CalcFullscreenScale(DrawParms *parms, double srcwidth, double srcheight, in
 	if (autoaspect == FSMode_ScaleToFit43 || autoaspect == FSMode_ScaleToFit43Top || autoaspect == FSMode_ScaleToFit43Bottom)
 	{
 		// screen is wider than the image -> pillarbox it. 4:3 images must also be pillarboxed if the screen is taller than the image
-		if (screenratio >= aspect || aspect < 1.4) autoaspect = FSMode_ScaleToFit; 
+		if (screenratio >= aspect || aspect < 1.4) autoaspect = FSMode_ScaleToFit;
 		else if (screenratio > 1.32) autoaspect = FSMode_ScaleToFill;				// on anything 4:3 and wider crop the sides of the image.
 		else
 		{
@@ -833,13 +827,13 @@ static inline FSpecialColormap * ListGetSpecialColormap(VMVa_List &tags)
 //==========================================================================
 
 template<class T>
-bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double y, uint32_t tag, T& tags, DrawParms *parms, bool fortext, bool checkimage)
+bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double y, uint32_t tag, T& tags, DrawParms *parms, int type, int fill, double fillalpha)
 {
 	INTBOOL boolval;
 	int intval;
-	bool fillcolorset = false;
+	bool fillcolorset = type == DrawTexture_Fill;
 
-	if (!fortext && checkimage)
+	if (type == DrawTexture_Normal)
 	{
 		if (img == NULL || !img->isValid())
 		{
@@ -855,7 +849,7 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 		return false;
 	}
 
-	parms->fortext = fortext;
+	parms->fortext = type == DrawTexture_Text;
 	parms->windowleft = 0;
 	parms->windowright = INT_MAX;
 	parms->dclip = drawer->GetHeight();
@@ -866,8 +860,8 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 	parms->top = INT_MAX;
 	parms->destwidth = INT_MAX;
 	parms->destheight = INT_MAX;
-	parms->Alpha = 1.f;
-	parms->fillcolor = -1;
+	parms->Alpha = type == DrawTexture_Fill ? fillalpha : 1.f;
+	parms->fillcolor = type == DrawTexture_Fill ? fill : -1;
 	parms->TranslationId = -1;
 	parms->colorOverlay = 0;
 	parms->alphaChannel = false;
@@ -916,29 +910,29 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			break;
 
 		case DTA_DestWidth:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->cleanmode = DTA_Base;
 			parms->destwidth = ListGetInt(tags);
 			break;
 
 		case DTA_DestWidthF:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->cleanmode = DTA_Base;
 			parms->destwidth = ListGetDouble(tags);
 			break;
 
 		case DTA_DestHeight:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->cleanmode = DTA_Base;
 			parms->destheight = ListGetInt(tags);
 			break;
 
 		case DTA_DestHeightF:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->cleanmode = DTA_Base;
 			parms->destheight = ListGetDouble(tags);
 			break;
@@ -1046,7 +1040,7 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			boolval = ListGetInt(tags);
 			if (boolval)
 			{
-				assert(fortext == false);
+				assert(type != DrawTexture_Text);
 				if (img == NULL) return false;
 				parms->cleanmode = DTA_Fullscreen;
 				parms->fsscalemode = (uint8_t)twod->fullscreenautoaspect;
@@ -1060,7 +1054,7 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			intval = ListGetInt(tags);
 			if (intval >= 0 && intval <= 3)
 			{
-				assert(fortext == false);
+				assert(type != DrawTexture_Text);
 				if (img == NULL) return false;
 				parms->cleanmode = DTA_Fullscreen;
 				parms->fsscalemode = (uint8_t)intval;
@@ -1135,32 +1129,32 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			break;
 
 		case DTA_TopOffset:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->top = ListGetInt(tags);
 			break;
 
 		case DTA_TopOffsetF:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->top = ListGetDouble(tags);
 			break;
 
 		case DTA_LeftOffset:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->left = ListGetInt(tags);
 			break;
 
 		case DTA_LeftOffsetF:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->left = ListGetDouble(tags);
 			break;
 
 		case DTA_TopLeft:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			if (ListGetInt(tags))
 			{
 				parms->left = 0;
@@ -1169,8 +1163,8 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			break;
 
 		case DTA_CenterOffset:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			if (ListGetInt(tags))
 			{
 				parms->left = img->GetDisplayWidth() * 0.5;
@@ -1179,8 +1173,8 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			break;
 
 		case DTA_CenterOffsetRel:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			intval = ListGetInt(tags);
 			if (intval == 1)
 			{
@@ -1195,8 +1189,8 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			break;
 
 		case DTA_CenterBottomOffset:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			if (ListGetInt(tags))
 			{
 				parms->left = img->GetDisplayWidth() * 0.5;
@@ -1205,26 +1199,26 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			break;
 
 		case DTA_WindowLeft:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->windowleft = ListGetInt(tags);
 			break;
 
 		case DTA_WindowLeftF:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->windowleft = ListGetDouble(tags);
 			break;
 
 		case DTA_WindowRight:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->windowright = ListGetInt(tags);
 			break;
 
 		case DTA_WindowRightF:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->windowright = ListGetDouble(tags);
 			break;
 
@@ -1362,8 +1356,8 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			break;
 
 		case DTA_Rotate:
-			assert(fortext == false);
-			if (fortext) return false;
+			assert(type != DrawTexture_Text);
+			if (type == DrawTexture_Text) return false;
 			parms->rotateangle = ListGetDouble(tags);
 			break;
 
@@ -1436,8 +1430,8 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 }
 // explicitly instantiate both versions for v_text.cpp.
 
-template bool ParseDrawTextureTags<Va_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, Va_List& tags, DrawParms *parms, bool fortext, bool checkimage);
-template bool ParseDrawTextureTags<VMVa_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, VMVa_List& tags, DrawParms *parms, bool fortext, bool checkimage);
+template bool ParseDrawTextureTags<Va_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, Va_List& tags, DrawParms *parms, int type, int fill, double fillalpha);
+template bool ParseDrawTextureTags<VMVa_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, VMVa_List& tags, DrawParms *parms, int type, int fill, double fillalpha);
 
 //==========================================================================
 //
@@ -1446,7 +1440,7 @@ template bool ParseDrawTextureTags<VMVa_List>(F2DDrawer* drawer, FGameTexture *i
 //==========================================================================
 
 static void VirtualToRealCoords(F2DDrawer *drawer, double Width, double Height, double &x, double &y, double &w, double &h,
-	double vwidth, double vheight, bool vbottom, bool handleaspect) 
+	double vwidth, double vheight, bool vbottom, bool handleaspect)
 {
 	float myratio = float(handleaspect ? ActiveRatio (Width, Height) : (4.0 / 3.0));
 
@@ -1594,7 +1588,7 @@ DEFINE_ACTION_FUNCTION(FCanvas, DrawLine)
 	return 0;
 }
 
-static void DrawThickLine(int x0, int y0, int x1, int y1, double thickness, uint32_t realcolor, int alpha) 
+static void DrawThickLine(int x0, int y0, int x1, int y1, double thickness, uint32_t realcolor, int alpha)
 {
 	if (!twod->HasBegun2D()) ThrowAbortException(X_OTHER, "Attempt to draw to screen outside a draw function");
 	twod->AddThickLine(x0, y0, x1, y1, thickness, realcolor, alpha);
@@ -1980,4 +1974,3 @@ DEFINE_ACTION_FUNCTION(FCanvas, ClearTransform)
 	self->Tex->NeedUpdate();
 	return 0;
 }
-

--- a/src/common/2d/v_draw.h
+++ b/src/common/2d/v_draw.h
@@ -103,7 +103,7 @@ enum
 	DTA_CellX,			// horizontal size of character cell
 	DTA_CellY,			// vertical size of character cell
 
-	// New additions. 
+	// New additions.
 	DTA_Color,
 	DTA_FlipY,			// bool: flip image vertically
 	DTA_SrcX,			// specify a source rectangle (this supersedes the poorly implemented DTA_WindowLeft/Right
@@ -258,8 +258,15 @@ inline int active_con_scale(F2DDrawer *drawer)
 #undef DrawText	// See WinUser.h for the definition of DrawText as a macro
 #endif
 
+enum
+{
+	DrawTexture_Normal,
+	DrawTexture_Text,
+	DrawTexture_Fill,
+};
+
 template<class T>
-bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture* img, double x, double y, uint32_t tag, T& tags, DrawParms* parms, bool fortext, bool checkimage = true);
+bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture* img, double x, double y, uint32_t tag, T& tags, DrawParms* parms, int type, int fill = -1, double fillalpha = 0.0);
 
 template<class T>
 void DrawTextCommon(F2DDrawer *drawer, FFont* font, int normalcolor, double x, double y, const T* string, DrawParms& parms);

--- a/src/common/2d/v_draw.h
+++ b/src/common/2d/v_draw.h
@@ -266,7 +266,7 @@ enum
 };
 
 template<class T>
-bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture* img, double x, double y, uint32_t tag, T& tags, DrawParms* parms, int type, int fill = -1, double fillalpha = 0.0);
+bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture* img, double x, double y, uint32_t tag, T& tags, DrawParms* parms, int type, PalEntry fill = ~0u, double fillalpha = 0.0);
 
 template<class T>
 void DrawTextCommon(F2DDrawer *drawer, FFont* font, int normalcolor, double x, double y, const T* string, DrawParms& parms);

--- a/src/common/2d/v_drawtext.cpp
+++ b/src/common/2d/v_drawtext.cpp
@@ -179,7 +179,7 @@ void DrawChar(F2DDrawer *drawer, FFont* font, int normalcolor, double x, double 
 		DrawParms parms;
 		Va_List tags;
 		va_start(tags.list, tag_first);
-		bool res = ParseDrawTextureTags(drawer, pic, x, y, tag_first, tags, &parms, false);
+		bool res = ParseDrawTextureTags(drawer, pic, x, y, tag_first, tags, &parms, DrawTexture_Normal);
 		va_end(tags.list);
 		if (!res)
 		{
@@ -208,7 +208,7 @@ void DrawChar(F2DDrawer *drawer,  FFont *font, int normalcolor, double x, double
 	{
 		DrawParms parms;
 		uint32_t tag = ListGetInt(args);
-		bool res = ParseDrawTextureTags(drawer, pic, x, y, tag, args, &parms, false);
+		bool res = ParseDrawTextureTags(drawer, pic, x, y, tag, args, &parms, DrawTexture_Normal);
 		if (!res) return;
 		bool palettetrans = (normalcolor == CR_NATIVEPAL && parms.TranslationId != 0);
 		PalEntry color = 0xffffffff;
@@ -261,7 +261,7 @@ DEFINE_ACTION_FUNCTION(FCanvas, DrawChar)
 //==========================================================================
 
 // This is only needed as a dummy. The code using wide strings does not need color control.
-EColorRange V_ParseFontColor(const char32_t *&color_value, int normalcolor, int boldcolor) { return CR_UNTRANSLATED; } 
+EColorRange V_ParseFontColor(const char32_t *&color_value, int normalcolor, int boldcolor) { return CR_UNTRANSLATED; }
 
 template<class chartype>
 void DrawTextCommon(F2DDrawer *drawer, FFont *font, int normalcolor, double x, double y, const chartype *string, DrawParms &parms)
@@ -374,7 +374,7 @@ void DrawText(F2DDrawer *drawer, FFont* font, int normalcolor, double x, double 
 		return;
 
 	va_start(tags.list, tag_first);
-	bool res = ParseDrawTextureTags(drawer, nullptr, 0, 0, tag_first, tags, &parms, true);
+	bool res = ParseDrawTextureTags(drawer, nullptr, 0, 0, tag_first, tags, &parms, DrawTexture_Text);
 	va_end(tags.list);
 	if (!res)
 	{
@@ -393,7 +393,7 @@ void DrawText(F2DDrawer *drawer, FFont* font, int normalcolor, double x, double 
 		return;
 
 	va_start(tags.list, tag_first);
-	bool res = ParseDrawTextureTags(drawer, nullptr, 0, 0, tag_first, tags, &parms, true);
+	bool res = ParseDrawTextureTags(drawer, nullptr, 0, 0, tag_first, tags, &parms, DrawTexture_Text);
 	va_end(tags.list);
 	if (!res)
 	{
@@ -411,7 +411,7 @@ void DrawText(F2DDrawer *drawer, FFont *font, int normalcolor, double x, double 
 		return;
 
 	uint32_t tag = ListGetInt(args);
-	bool res = ParseDrawTextureTags(drawer, nullptr, 0, 0, tag, args, &parms, true);
+	bool res = ParseDrawTextureTags(drawer, nullptr, 0, 0, tag, args, &parms, DrawTexture_Text);
 	if (!res)
 	{
 		return;
@@ -455,4 +455,3 @@ DEFINE_ACTION_FUNCTION(FCanvas, DrawText)
 	self->Tex->NeedUpdate();
 	return 0;
 }
-

--- a/src/common/scripting/vm/vm.h
+++ b/src/common/scripting/vm/vm.h
@@ -131,7 +131,7 @@ struct VMReturn
 		*(double *)Location = val;
 	}
 	void SetVector(const double val[3])
-	{	
+	{
 		assert(RegType == (REGT_FLOAT|REGT_MULTIREG3));
 		((double *)Location)[0] = val[0];
 		((double *)Location)[1] = val[1];
@@ -513,7 +513,7 @@ bool AssertObject(void * ob);
 #define PARAM_BOOL_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); bool x = !!param[p].i;
 #define PARAM_NAME_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); FName x = ENamedName(param[p].i);
 #define PARAM_SOUND_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); FSoundID x = param[p].i;
-#define PARAM_COLOR_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); PalEntry x; x.d = param[p].i;
+#define PARAM_COLOR_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); PalEntry x = param[p].i;
 #define PARAM_FLOAT_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_FLOAT); double x = param[p].f;
 #define PARAM_ANGLE_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_FLOAT); DAngle x = DAngle::fromDeg(param[p].f);
 #define PARAM_FANGLE_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_FLOAT); FAngle x = FAngle::fromDeg(param[p].f);


### PR DESCRIPTION
directly setting `parms.fillcolor` means that without any other arguments `DrawShapeFill` will simply not do what is expected, so pass that information to `ParseDrawTextureTags`