### PR TITLE
Add sv_noextraammo. When set to true, disables that weird hardcoded b…

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -565,6 +565,7 @@ CVAR (Flag, sv_respawnsuper,		dmflags2, DF2_RESPAWN_SUPER);
 CVAR (Flag, sv_nothingspawn,		dmflags2, DF2_NO_COOP_THING_SPAWN);
 CVAR (Flag, sv_alwaysspawnmulti,	dmflags2, DF2_ALWAYS_SPAWN_MULTI);
 CVAR (Flag, sv_novertspread,		dmflags2, DF2_NOVERTSPREAD);
+CVAR (Flag, sv_noextraammo,			dmflags2, DF2_NO_EXTRA_AMMO);
 
 //==========================================================================
 //

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -173,6 +173,7 @@ enum
 	DF2_NO_COOP_THING_SPAWN	= 1 << 28,	// Don't spawn multiplayer things in coop games
 	DF2_ALWAYS_SPAWN_MULTI	= 1 << 29,	// Always spawn multiplayer items
 	DF2_NOVERTSPREAD		= 1 << 30,	// Don't allow vertical spread for hitscan weapons (excluding ssg)
+	DF2_NO_EXTRA_AMMO		= 1 << 31,	// Don't add extra ammo when picking up weapons (like in original Doom)
 };
 
 // [RH] Compatibility flags.

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1683,6 +1683,7 @@ OptionMenu DeathmatchOptions protected
 	Option "$GMPLYMNU_LOSEFRAG",				"sv_losefrag", "YesNo"
 	Option "$GMPLYMNU_KEEPFRAGS",				"sv_keepfrags", "YesNo"
 	Option "$GMPLYMNU_NOTEAMSWITCH",			"sv_noteamswitch", "YesNo"
+	Option "$GMPLYMNU_NOEXTRAAMMO",				"sv_noextraammo", "NoYes"
 	Class "GameplayMenu"
 }
 

--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -742,7 +742,7 @@ class Weapon : StateProvider
 
 		// [BC] This behavior is from the original Doom. Give 5/2 times as much ammoitem when
 		// we pick up a weapon in deathmatch.
-		if (( deathmatch ) && ( gameinfo.gametype & GAME_DoomChex ))
+		if (( deathmatch && !sv_noextraammo ) && ( gameinfo.gametype & GAME_DoomChex ))
 			amount = amount * 5 / 2;
 
 		// extra ammoitem in baby mode and nightmare mode


### PR DESCRIPTION
…ehavior from original Doom that gives extra ammo when picking up weapons in deathmatch