### PR TITLE
Added APROP_FriendlySeeBlocks for Set/GetActorProperty.

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -4045,6 +4045,7 @@ enum
 	APROP_MaxDropOffHeight= 45,
 	APROP_DamageType	= 46,
 	APROP_SoundClass	= 47,
+	APROP_FriendlySeeBlocks= 48,
 };
 
 // These are needed for ACS's APROP_RenderStyle
@@ -4317,6 +4318,9 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 			}
 		}	
 		break;
+	case APROP_FriendlySeeBlocks:
+		actor->friendlyseeblocks = value;
+		break;
 
 	default:
 		// do nothing.
@@ -4416,6 +4420,7 @@ int DLevelScript::GetActorProperty (int tid, int property)
 	case APROP_MaxDropOffHeight: return DoubleToACS(actor->MaxDropOffHeight);
 	case APROP_DamageType:	return GlobalACSStrings.AddString(actor->DamageType.GetChars());
 	case APROP_SoundClass:	return GlobalACSStrings.AddString(S_GetSoundClass(actor));
+	case APROP_FriendlySeeBlocks: return actor->friendlyseeblocks;
 
 	default:				return 0;
 	}
@@ -4465,6 +4470,7 @@ int DLevelScript::CheckActorProperty (int tid, int property, int value)
 		case APROP_MaxStepHeight:
 		case APROP_MaxDropOffHeight:
 		case APROP_StencilColor:
+		case APROP_FriendlySeeBlocks:
 			return (GetActorProperty(tid, property) == value);
 
 		// Boolean values need to compare to a binary version of value


### PR DESCRIPTION
This PR makes the FriendlySeeBlocks property changeable by Set/GetActorProperty, allowing ACS scripts to get or change the distance at which friendly monsters, or hostile monsters with SEEFRIENDLYMONSTERS, can see other non-player actors.

[I've also made a PR to ACC with the new #define.](https://github.com/ZDoom/acc/pull/90)

An example map is attached below (It uses a #define inside the map script itself for the new property.)
[APROP_FriendlySeeBlocks Example.zip](https://github.com/ZDoom/gzdoom/files/9639402/APROP_FriendlySeeBlocks.Example.zip)
