### PR TITLE
Added the QF_GROUNDONLY, QF_AFFECTACTORS and QF_SHAKEONLY flags to earthquakes.

### DIFF
--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -113,6 +113,7 @@ enum
 	QF_FULLINTENSITY =	1 << 4,
 	QF_WAVE =			1 << 5,
 	QF_3D =				1 << 6,
+	QF_GROUNDONLY =		1 << 7,
 };
 
 struct FQuakeJiggers

--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -115,6 +115,7 @@ enum
 	QF_3D =				1 << 6,
 	QF_GROUNDONLY =		1 << 7,
 	QF_AFFECTACTORS =	1 << 8,
+	QF_SHAKEONLY =		1 << 9,
 };
 
 struct FQuakeJiggers
@@ -153,7 +154,7 @@ public:
 	double GetModIntensity(double intensity, bool fake = false) const;
 	double GetModWave(double ticFrac, double waveMultiplier) const;
 	double GetFalloff(double dist) const;
-	void DoQuakeDamage(AActor *m_Spot, AActor *victim) const;
+	void DoQuakeDamage(DEarthquake *quake, AActor *victim) const;
 
 	static int StaticGetQuakeIntensities(double ticFrac, AActor *viewer, FQuakeJiggers &jiggers);
 };

--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -114,6 +114,7 @@ enum
 	QF_WAVE =			1 << 5,
 	QF_3D =				1 << 6,
 	QF_GROUNDONLY =		1 << 7,
+	QF_AFFECTACTORS =	1 << 8,
 };
 
 struct FQuakeJiggers
@@ -152,6 +153,7 @@ public:
 	double GetModIntensity(double intensity, bool fake = false) const;
 	double GetModWave(double ticFrac, double waveMultiplier) const;
 	double GetFalloff(double dist) const;
+	void DoQuakeDamage(AActor *m_Spot, AActor *victim) const;
 
 	static int StaticGetQuakeIntensities(double ticFrac, AActor *viewer, FQuakeJiggers &jiggers);
 };

--- a/src/playsim/mapthinkers/a_quake.cpp
+++ b/src/playsim/mapthinkers/a_quake.cpp
@@ -132,7 +132,7 @@ void DEarthquake::Tick ()
 					continue;
 
 
-				DoQuakeDamage(m_Spot, mo);
+				DoQuakeDamage(this, mo);
 			}
 		}
 		else
@@ -142,7 +142,7 @@ void DEarthquake::Tick ()
 				if (Level->PlayerInGame(i) && !(Level->Players[i]->cheats & CF_NOCLIP))
 				{
 					AActor* victim = Level->Players[i]->mo;
-						DoQuakeDamage(m_Spot, victim);
+						DoQuakeDamage(this, victim);
 				}
 			}
 		}
@@ -168,15 +168,17 @@ void DEarthquake::Tick ()
 //
 //==========================================================================
 
-void DEarthquake::DoQuakeDamage(AActor *m_Spot, AActor *victim) const
+void DEarthquake::DoQuakeDamage(DEarthquake *quake, AActor *victim) const
 {
 	double dist;
 
-	dist = m_Spot->Distance2D(victim, true);
+	if (!quake || !victim) return;
+
+	dist = quake->m_Spot->Distance2D(victim, true);
 	// Check if in damage radius
 	if (dist < m_DamageRadius && victim->Z() <= victim->floorz)
 	{
-		if (pr_quake() < 50)
+		if (!(quake->m_Flags & QF_SHAKEONLY) && pr_quake() < 50)
 		{
 			P_DamageMobj(victim, NULL, NULL, pr_quake.HitDice(1), NAME_Quake);
 		}

--- a/src/playsim/mapthinkers/a_quake.cpp
+++ b/src/playsim/mapthinkers/a_quake.cpp
@@ -295,7 +295,7 @@ int DEarthquake::StaticGetQuakeIntensities(double ticFrac, AActor *victim, FQuak
 
 	while ( (quake = iterator.Next()) != nullptr)
 	{
-		if (quake->m_Spot != nullptr)
+		if (quake->m_Spot != nullptr && !(quake->m_Flags & QF_GROUNDONLY && victim->Z() > victim->floorz))
 		{
 			double dist;
 

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -642,6 +642,7 @@ enum EQuakeFlags
 	QF_FULLINTENSITY =	1 << 4,
 	QF_WAVE =			1 << 5,
 	QF_3D =				1 << 6,
+	QF_GROUNDONLY =		1 << 7,
 };
 
 // A_CheckProximity flags

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -643,6 +643,8 @@ enum EQuakeFlags
 	QF_WAVE =			1 << 5,
 	QF_3D =				1 << 6,
 	QF_GROUNDONLY =		1 << 7,
+	QF_AFFECTACTORS =	1 << 8,
+	QF_SHAKEONLY =		1 << 9,
 };
 
 // A_CheckProximity flags


### PR DESCRIPTION
This PR adds 3 new flags to the earthquake thinker:

- QF_GROUNDONLY: Makes the screen shaking effect only occur when the players' camera is touching the ground. Similar to a real earthquake.
- QF_AFFECTACTORS: Makes the earthquake able to harm and throw around non-player actors such as monsters and decorations, instead of only affecting players.
- QF_SHAKEONLY: Makes the earthquake only throw around actors, without doing any damage to them. This still requires that you specify a damage radius for the quake.

Note: The DONTTHRUST flag prevents non-player actors from being flung around by quakes, but it still doesn't do anything to players for backwards compatibility.

[It also comes with a PR for ACC (That also adds a #define for QF_3D).](https://github.com/ZDoom/acc/pull/92)

I have attached an example map below, the map has a looping crusher in the middle with all 3 flags on. It includes several objects to demonstrate the flags' behavior, such as a Cacodemon in the air, a tree with DONTTHRUST turned on, and a pad that makes the player fly.

[New QF_ flags example.zip](https://github.com/ZDoom/gzdoom/files/9640172/New.QF_.flags.example.zip)