### PR TITLE
Exported GetDisplayTopOffset for font characters to ZScript

### DIFF
--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -719,6 +719,19 @@ DEFINE_ACTION_FUNCTION_NATIVE(FFont, GetDefaultKerning, GetDefaultKerning)
 	ACTION_RETURN_INT(self->GetDefaultKerning());
 }
 
+static double GetDisplayTopOffset(FFont* font, int c)
+{
+	auto texc = font->GetChar(c, CR_UNDEFINED, nullptr);
+	return texc ? texc->GetDisplayTopOffset() : 0;
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FFont, GetDisplayTopOffset, GetDisplayTopOffset)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FFont);
+	PARAM_INT(code);
+	ACTION_RETURN_FLOAT(GetDisplayTopOffset(self, code));
+}
+
 //==========================================================================
 //
 // file system

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -649,6 +649,7 @@ struct Font native
 
 	native static int FindFontColor(Name color);
 	native double GetBottomAlignOffset(int code);
+	native double GetDisplayTopOffset(int code);
 	native static Font FindFont(Name fontname);
 	native static Font GetFont(Name fontname);
 	native BrokenLines BreakLines(String text, int maxlen);


### PR DESCRIPTION
See [here](https://forum.zdoom.org/viewtopic.php?p=1229512) for details. Please correct me if I'm wrong, but I haven't been able to find a proper solution, so here's a PR to add a method to ```Font``` to get the display top offset for any character. This can be useful in scenarios where there's a need to trim the extra space above (and below) the text if ```Font.GetHeight``` does not match the actual text height.  ```GetMaxAscender``` does not work in such cases because it only returns non-negative values (apparently, to detect characters above the bounding box).