### PR TITLE
Movie sync, take 2

### DIFF
--- a/src/common/audio/music/music.cpp
+++ b/src/common/audio/music/music.cpp
@@ -117,10 +117,11 @@ int MusicEnabled() // int return is for scripting
 static std::unique_ptr<SoundStream> musicStream;
 static TArray<SoundStream*> customStreams;
 
-SoundStream *S_CreateCustomStream(size_t size, int samplerate, int numchannels, StreamCallback cb, void *userdata)
+SoundStream *S_CreateCustomStream(size_t size, int samplerate, int numchannels, MusicCustomStreamType sampletype, StreamCallback cb, void *userdata)
 {
 	int flags = 0;
 	if (numchannels < 2) flags |= SoundStream::Mono;
+	if (sampletype == MusicSamplesFloat) flags |= SoundStream::Float;
 	auto stream = GSnd->CreateStream(cb, int(size), flags, samplerate, userdata);
 	if (stream)
 	{

--- a/src/common/audio/music/s_music.h
+++ b/src/common/audio/music/s_music.h
@@ -11,9 +11,13 @@ class FileReader;
 class SoundStream;
 
 
+enum MusicCustomStreamType : bool {
+	MusicSamples16bit,
+	MusicSamplesFloat
+};
 int MusicEnabled();
 typedef bool(*StreamCallback)(SoundStream* stream, void* buff, int len, void* userdata);
-SoundStream *S_CreateCustomStream(size_t size, int samplerate, int numchannels, StreamCallback cb, void *userdata);
+SoundStream *S_CreateCustomStream(size_t size, int samplerate, int numchannels, MusicCustomStreamType sampletype, StreamCallback cb, void *userdata);
 void S_StopCustomStream(SoundStream* stream);
 void S_PauseAllCustomStreams(bool on);
 

--- a/src/common/audio/sound/alext.h
+++ b/src/common/audio/sound/alext.h
@@ -1,0 +1,643 @@
+/**
+ * OpenAL cross platform audio library
+ * Copyright (C) 2008 by authors.
+ * This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ *  License along with this library; if not, write to the
+ *  Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * Or go to http://www.gnu.org/copyleft/lgpl.html
+ */
+
+#ifndef AL_ALEXT_H
+#define AL_ALEXT_H
+
+#include <stddef.h>
+/* Define int64 and uint64 types */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) ||             \
+    (defined(__cplusplus) && __cplusplus >= 201103L)
+#include <stdint.h>
+typedef int64_t _alsoft_int64_t;
+typedef uint64_t _alsoft_uint64_t;
+#elif defined(_WIN32)
+typedef __int64 _alsoft_int64_t;
+typedef unsigned __int64 _alsoft_uint64_t;
+#else
+/* Fallback if nothing above works */
+#include <stdint.h>
+typedef int64_t _alsoft_int64_t;
+typedef uint64_t _alsoft_uint64_t;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef AL_LOKI_IMA_ADPCM_format
+#define AL_LOKI_IMA_ADPCM_format 1
+#define AL_FORMAT_IMA_ADPCM_MONO16_EXT           0x10000
+#define AL_FORMAT_IMA_ADPCM_STEREO16_EXT         0x10001
+#endif
+
+#ifndef AL_LOKI_WAVE_format
+#define AL_LOKI_WAVE_format 1
+#define AL_FORMAT_WAVE_EXT                       0x10002
+#endif
+
+#ifndef AL_EXT_vorbis
+#define AL_EXT_vorbis 1
+#define AL_FORMAT_VORBIS_EXT                     0x10003
+#endif
+
+#ifndef AL_LOKI_quadriphonic
+#define AL_LOKI_quadriphonic 1
+#define AL_FORMAT_QUAD8_LOKI                     0x10004
+#define AL_FORMAT_QUAD16_LOKI                    0x10005
+#endif
+
+#ifndef AL_EXT_float32
+#define AL_EXT_float32 1
+#define AL_FORMAT_MONO_FLOAT32                   0x10010
+#define AL_FORMAT_STEREO_FLOAT32                 0x10011
+#endif
+
+#ifndef AL_EXT_double
+#define AL_EXT_double 1
+#define AL_FORMAT_MONO_DOUBLE_EXT                0x10012
+#define AL_FORMAT_STEREO_DOUBLE_EXT              0x10013
+#endif
+
+#ifndef AL_EXT_MULAW
+#define AL_EXT_MULAW 1
+#define AL_FORMAT_MONO_MULAW_EXT                 0x10014
+#define AL_FORMAT_STEREO_MULAW_EXT               0x10015
+#endif
+
+#ifndef AL_EXT_ALAW
+#define AL_EXT_ALAW 1
+#define AL_FORMAT_MONO_ALAW_EXT                  0x10016
+#define AL_FORMAT_STEREO_ALAW_EXT                0x10017
+#endif
+
+#ifndef ALC_LOKI_audio_channel
+#define ALC_LOKI_audio_channel 1
+#define ALC_CHAN_MAIN_LOKI                       0x500001
+#define ALC_CHAN_PCM_LOKI                        0x500002
+#define ALC_CHAN_CD_LOKI                         0x500003
+#endif
+
+#ifndef AL_EXT_MCFORMATS
+#define AL_EXT_MCFORMATS 1
+/* Provides support for surround sound buffer formats with 8, 16, and 32-bit
+ * samples.
+ *
+ * QUAD8: Unsigned 8-bit, Quadraphonic (Front Left, Front Right, Rear Left,
+ *        Rear Right).
+ * QUAD16: Signed 16-bit, Quadraphonic.
+ * QUAD32: 32-bit float, Quadraphonic.
+ * REAR8: Unsigned 8-bit, Rear Stereo (Rear Left, Rear Right).
+ * REAR16: Signed 16-bit, Rear Stereo.
+ * REAR32: 32-bit float, Rear Stereo.
+ * 51CHN8: Unsigned 8-bit, 5.1 Surround (Front Left, Front Right, Front Center,
+ *         LFE, Side Left, Side Right). Note that some audio systems may label
+ *         5.1's Side channels as Rear or Surround; they are equivalent for the
+ *         purposes of this extension.
+ * 51CHN16: Signed 16-bit, 5.1 Surround.
+ * 51CHN32: 32-bit float, 5.1 Surround.
+ * 61CHN8: Unsigned 8-bit, 6.1 Surround (Front Left, Front Right, Front Center,
+ *         LFE, Rear Center, Side Left, Side Right).
+ * 61CHN16: Signed 16-bit, 6.1 Surround.
+ * 61CHN32: 32-bit float, 6.1 Surround.
+ * 71CHN8: Unsigned 8-bit, 7.1 Surround (Front Left, Front Right, Front Center,
+ *         LFE, Rear Left, Rear Right, Side Left, Side Right).
+ * 71CHN16: Signed 16-bit, 7.1 Surround.
+ * 71CHN32: 32-bit float, 7.1 Surround.
+ */
+#define AL_FORMAT_QUAD8                          0x1204
+#define AL_FORMAT_QUAD16                         0x1205
+#define AL_FORMAT_QUAD32                         0x1206
+#define AL_FORMAT_REAR8                          0x1207
+#define AL_FORMAT_REAR16                         0x1208
+#define AL_FORMAT_REAR32                         0x1209
+#define AL_FORMAT_51CHN8                         0x120A
+#define AL_FORMAT_51CHN16                        0x120B
+#define AL_FORMAT_51CHN32                        0x120C
+#define AL_FORMAT_61CHN8                         0x120D
+#define AL_FORMAT_61CHN16                        0x120E
+#define AL_FORMAT_61CHN32                        0x120F
+#define AL_FORMAT_71CHN8                         0x1210
+#define AL_FORMAT_71CHN16                        0x1211
+#define AL_FORMAT_71CHN32                        0x1212
+#endif
+
+#ifndef AL_EXT_MULAW_MCFORMATS
+#define AL_EXT_MULAW_MCFORMATS 1
+#define AL_FORMAT_MONO_MULAW                     0x10014
+#define AL_FORMAT_STEREO_MULAW                   0x10015
+#define AL_FORMAT_QUAD_MULAW                     0x10021
+#define AL_FORMAT_REAR_MULAW                     0x10022
+#define AL_FORMAT_51CHN_MULAW                    0x10023
+#define AL_FORMAT_61CHN_MULAW                    0x10024
+#define AL_FORMAT_71CHN_MULAW                    0x10025
+#endif
+
+#ifndef AL_EXT_IMA4
+#define AL_EXT_IMA4 1
+#define AL_FORMAT_MONO_IMA4                      0x1300
+#define AL_FORMAT_STEREO_IMA4                    0x1301
+#endif
+
+#ifndef AL_EXT_STATIC_BUFFER
+#define AL_EXT_STATIC_BUFFER 1
+typedef void (AL_APIENTRY*PFNALBUFFERDATASTATICPROC)(const ALint,ALenum,ALvoid*,ALsizei,ALsizei);
+#ifdef AL_ALEXT_PROTOTYPES
+AL_API void AL_APIENTRY alBufferDataStatic(const ALint buffer, ALenum format, ALvoid *data, ALsizei len, ALsizei freq);
+#endif
+#endif
+
+#ifndef ALC_EXT_EFX
+#define ALC_EXT_EFX 1
+#include "efx.h"
+#endif
+
+#ifndef ALC_EXT_disconnect
+#define ALC_EXT_disconnect 1
+#define ALC_CONNECTED                            0x313
+#endif
+
+#ifndef ALC_EXT_thread_local_context
+#define ALC_EXT_thread_local_context 1
+typedef ALCboolean  (ALC_APIENTRY*PFNALCSETTHREADCONTEXTPROC)(ALCcontext *context);
+typedef ALCcontext* (ALC_APIENTRY*PFNALCGETTHREADCONTEXTPROC)(void);
+#ifdef AL_ALEXT_PROTOTYPES
+ALC_API ALCboolean  ALC_APIENTRY alcSetThreadContext(ALCcontext *context);
+ALC_API ALCcontext* ALC_APIENTRY alcGetThreadContext(void);
+#endif
+#endif
+
+#ifndef AL_EXT_source_distance_model
+#define AL_EXT_source_distance_model 1
+#define AL_SOURCE_DISTANCE_MODEL                 0x200
+#endif
+
+#ifndef AL_SOFT_buffer_sub_data
+#define AL_SOFT_buffer_sub_data 1
+#define AL_BYTE_RW_OFFSETS_SOFT                  0x1031
+#define AL_SAMPLE_RW_OFFSETS_SOFT                0x1032
+typedef void (AL_APIENTRY*PFNALBUFFERSUBDATASOFTPROC)(ALuint,ALenum,const ALvoid*,ALsizei,ALsizei);
+#ifdef AL_ALEXT_PROTOTYPES
+AL_API void AL_APIENTRY alBufferSubDataSOFT(ALuint buffer,ALenum format,const ALvoid *data,ALsizei offset,ALsizei length);
+#endif
+#endif
+
+#ifndef AL_SOFT_loop_points
+#define AL_SOFT_loop_points 1
+#define AL_LOOP_POINTS_SOFT                      0x2015
+#endif
+
+#ifndef AL_EXT_FOLDBACK
+#define AL_EXT_FOLDBACK 1
+#define AL_EXT_FOLDBACK_NAME                     "AL_EXT_FOLDBACK"
+#define AL_FOLDBACK_EVENT_BLOCK                  0x4112
+#define AL_FOLDBACK_EVENT_START                  0x4111
+#define AL_FOLDBACK_EVENT_STOP                   0x4113
+#define AL_FOLDBACK_MODE_MONO                    0x4101
+#define AL_FOLDBACK_MODE_STEREO                  0x4102
+typedef void (AL_APIENTRY*LPALFOLDBACKCALLBACK)(ALenum,ALsizei);
+typedef void (AL_APIENTRY*LPALREQUESTFOLDBACKSTART)(ALenum,ALsizei,ALsizei,ALfloat*,LPALFOLDBACKCALLBACK);
+typedef void (AL_APIENTRY*LPALREQUESTFOLDBACKSTOP)(void);
+#ifdef AL_ALEXT_PROTOTYPES
+AL_API void AL_APIENTRY alRequestFoldbackStart(ALenum mode,ALsizei count,ALsizei length,ALfloat *mem,LPALFOLDBACKCALLBACK callback);
+AL_API void AL_APIENTRY alRequestFoldbackStop(void);
+#endif
+#endif
+
+#ifndef ALC_EXT_DEDICATED
+#define ALC_EXT_DEDICATED 1
+#define AL_DEDICATED_GAIN                        0x0001
+#define AL_EFFECT_DEDICATED_DIALOGUE             0x9001
+#define AL_EFFECT_DEDICATED_LOW_FREQUENCY_EFFECT 0x9000
+#endif
+
+#ifndef AL_SOFT_buffer_samples
+#define AL_SOFT_buffer_samples 1
+/* Channel configurations */
+#define AL_MONO_SOFT                             0x1500
+#define AL_STEREO_SOFT                           0x1501
+#define AL_REAR_SOFT                             0x1502
+#define AL_QUAD_SOFT                             0x1503
+#define AL_5POINT1_SOFT                          0x1504
+#define AL_6POINT1_SOFT                          0x1505
+#define AL_7POINT1_SOFT                          0x1506
+
+/* Sample types */
+#define AL_BYTE_SOFT                             0x1400
+#define AL_UNSIGNED_BYTE_SOFT                    0x1401
+#define AL_SHORT_SOFT                            0x1402
+#define AL_UNSIGNED_SHORT_SOFT                   0x1403
+#define AL_INT_SOFT                              0x1404
+#define AL_UNSIGNED_INT_SOFT                     0x1405
+#define AL_FLOAT_SOFT                            0x1406
+#define AL_DOUBLE_SOFT                           0x1407
+#define AL_BYTE3_SOFT                            0x1408
+#define AL_UNSIGNED_BYTE3_SOFT                   0x1409
+
+/* Storage formats */
+#define AL_MONO8_SOFT                            0x1100
+#define AL_MONO16_SOFT                           0x1101
+#define AL_MONO32F_SOFT                          0x10010
+#define AL_STEREO8_SOFT                          0x1102
+#define AL_STEREO16_SOFT                         0x1103
+#define AL_STEREO32F_SOFT                        0x10011
+#define AL_QUAD8_SOFT                            0x1204
+#define AL_QUAD16_SOFT                           0x1205
+#define AL_QUAD32F_SOFT                          0x1206
+#define AL_REAR8_SOFT                            0x1207
+#define AL_REAR16_SOFT                           0x1208
+#define AL_REAR32F_SOFT                          0x1209
+#define AL_5POINT1_8_SOFT                        0x120A
+#define AL_5POINT1_16_SOFT                       0x120B
+#define AL_5POINT1_32F_SOFT                      0x120C
+#define AL_6POINT1_8_SOFT                        0x120D
+#define AL_6POINT1_16_SOFT                       0x120E
+#define AL_6POINT1_32F_SOFT                      0x120F
+#define AL_7POINT1_8_SOFT                        0x1210
+#define AL_7POINT1_16_SOFT                       0x1211
+#define AL_7POINT1_32F_SOFT                      0x1212
+
+/* Buffer attributes */
+#define AL_INTERNAL_FORMAT_SOFT                  0x2008
+#define AL_BYTE_LENGTH_SOFT                      0x2009
+#define AL_SAMPLE_LENGTH_SOFT                    0x200A
+#define AL_SEC_LENGTH_SOFT                       0x200B
+
+typedef void (AL_APIENTRY*LPALBUFFERSAMPLESSOFT)(ALuint,ALuint,ALenum,ALsizei,ALenum,ALenum,const ALvoid*);
+typedef void (AL_APIENTRY*LPALBUFFERSUBSAMPLESSOFT)(ALuint,ALsizei,ALsizei,ALenum,ALenum,const ALvoid*);
+typedef void (AL_APIENTRY*LPALGETBUFFERSAMPLESSOFT)(ALuint,ALsizei,ALsizei,ALenum,ALenum,ALvoid*);
+typedef ALboolean (AL_APIENTRY*LPALISBUFFERFORMATSUPPORTEDSOFT)(ALenum);
+#ifdef AL_ALEXT_PROTOTYPES
+AL_API void AL_APIENTRY alBufferSamplesSOFT(ALuint buffer, ALuint samplerate, ALenum internalformat, ALsizei samples, ALenum channels, ALenum type, const ALvoid *data);
+AL_API void AL_APIENTRY alBufferSubSamplesSOFT(ALuint buffer, ALsizei offset, ALsizei samples, ALenum channels, ALenum type, const ALvoid *data);
+AL_API void AL_APIENTRY alGetBufferSamplesSOFT(ALuint buffer, ALsizei offset, ALsizei samples, ALenum channels, ALenum type, ALvoid *data);
+AL_API ALboolean AL_APIENTRY alIsBufferFormatSupportedSOFT(ALenum format);
+#endif
+#endif
+
+#ifndef AL_SOFT_direct_channels
+#define AL_SOFT_direct_channels 1
+#define AL_DIRECT_CHANNELS_SOFT                  0x1033
+#endif
+
+#ifndef ALC_SOFT_loopback
+#define ALC_SOFT_loopback 1
+#define ALC_FORMAT_CHANNELS_SOFT                 0x1990
+#define ALC_FORMAT_TYPE_SOFT                     0x1991
+
+/* Sample types */
+#define ALC_BYTE_SOFT                            0x1400
+#define ALC_UNSIGNED_BYTE_SOFT                   0x1401
+#define ALC_SHORT_SOFT                           0x1402
+#define ALC_UNSIGNED_SHORT_SOFT                  0x1403
+#define ALC_INT_SOFT                             0x1404
+#define ALC_UNSIGNED_INT_SOFT                    0x1405
+#define ALC_FLOAT_SOFT                           0x1406
+
+/* Channel configurations */
+#define ALC_MONO_SOFT                            0x1500
+#define ALC_STEREO_SOFT                          0x1501
+#define ALC_QUAD_SOFT                            0x1503
+#define ALC_5POINT1_SOFT                         0x1504
+#define ALC_6POINT1_SOFT                         0x1505
+#define ALC_7POINT1_SOFT                         0x1506
+
+typedef ALCdevice* (ALC_APIENTRY*LPALCLOOPBACKOPENDEVICESOFT)(const ALCchar*);
+typedef ALCboolean (ALC_APIENTRY*LPALCISRENDERFORMATSUPPORTEDSOFT)(ALCdevice*,ALCsizei,ALCenum,ALCenum);
+typedef void (ALC_APIENTRY*LPALCRENDERSAMPLESSOFT)(ALCdevice*,ALCvoid*,ALCsizei);
+#ifdef AL_ALEXT_PROTOTYPES
+ALC_API ALCdevice* ALC_APIENTRY alcLoopbackOpenDeviceSOFT(const ALCchar *deviceName);
+ALC_API ALCboolean ALC_APIENTRY alcIsRenderFormatSupportedSOFT(ALCdevice *device, ALCsizei freq, ALCenum channels, ALCenum type);
+ALC_API void ALC_APIENTRY alcRenderSamplesSOFT(ALCdevice *device, ALCvoid *buffer, ALCsizei samples);
+#endif
+#endif
+
+#ifndef AL_EXT_STEREO_ANGLES
+#define AL_EXT_STEREO_ANGLES 1
+#define AL_STEREO_ANGLES                         0x1030
+#endif
+
+#ifndef AL_EXT_SOURCE_RADIUS
+#define AL_EXT_SOURCE_RADIUS 1
+#define AL_SOURCE_RADIUS                         0x1031
+#endif
+
+#ifndef AL_SOFT_source_latency
+#define AL_SOFT_source_latency 1
+#define AL_SAMPLE_OFFSET_LATENCY_SOFT            0x1200
+#define AL_SEC_OFFSET_LATENCY_SOFT               0x1201
+typedef _alsoft_int64_t ALint64SOFT;
+typedef _alsoft_uint64_t ALuint64SOFT;
+typedef void (AL_APIENTRY*LPALSOURCEDSOFT)(ALuint,ALenum,ALdouble);
+typedef void (AL_APIENTRY*LPALSOURCE3DSOFT)(ALuint,ALenum,ALdouble,ALdouble,ALdouble);
+typedef void (AL_APIENTRY*LPALSOURCEDVSOFT)(ALuint,ALenum,const ALdouble*);
+typedef void (AL_APIENTRY*LPALGETSOURCEDSOFT)(ALuint,ALenum,ALdouble*);
+typedef void (AL_APIENTRY*LPALGETSOURCE3DSOFT)(ALuint,ALenum,ALdouble*,ALdouble*,ALdouble*);
+typedef void (AL_APIENTRY*LPALGETSOURCEDVSOFT)(ALuint,ALenum,ALdouble*);
+typedef void (AL_APIENTRY*LPALSOURCEI64SOFT)(ALuint,ALenum,ALint64SOFT);
+typedef void (AL_APIENTRY*LPALSOURCE3I64SOFT)(ALuint,ALenum,ALint64SOFT,ALint64SOFT,ALint64SOFT);
+typedef void (AL_APIENTRY*LPALSOURCEI64VSOFT)(ALuint,ALenum,const ALint64SOFT*);
+typedef void (AL_APIENTRY*LPALGETSOURCEI64SOFT)(ALuint,ALenum,ALint64SOFT*);
+typedef void (AL_APIENTRY*LPALGETSOURCE3I64SOFT)(ALuint,ALenum,ALint64SOFT*,ALint64SOFT*,ALint64SOFT*);
+typedef void (AL_APIENTRY*LPALGETSOURCEI64VSOFT)(ALuint,ALenum,ALint64SOFT*);
+#ifdef AL_ALEXT_PROTOTYPES
+AL_API void AL_APIENTRY alSourcedSOFT(ALuint source, ALenum param, ALdouble value);
+AL_API void AL_APIENTRY alSource3dSOFT(ALuint source, ALenum param, ALdouble value1, ALdouble value2, ALdouble value3);
+AL_API void AL_APIENTRY alSourcedvSOFT(ALuint source, ALenum param, const ALdouble *values);
+AL_API void AL_APIENTRY alGetSourcedSOFT(ALuint source, ALenum param, ALdouble *value);
+AL_API void AL_APIENTRY alGetSource3dSOFT(ALuint source, ALenum param, ALdouble *value1, ALdouble *value2, ALdouble *value3);
+AL_API void AL_APIENTRY alGetSourcedvSOFT(ALuint source, ALenum param, ALdouble *values);
+AL_API void AL_APIENTRY alSourcei64SOFT(ALuint source, ALenum param, ALint64SOFT value);
+AL_API void AL_APIENTRY alSource3i64SOFT(ALuint source, ALenum param, ALint64SOFT value1, ALint64SOFT value2, ALint64SOFT value3);
+AL_API void AL_APIENTRY alSourcei64vSOFT(ALuint source, ALenum param, const ALint64SOFT *values);
+AL_API void AL_APIENTRY alGetSourcei64SOFT(ALuint source, ALenum param, ALint64SOFT *value);
+AL_API void AL_APIENTRY alGetSource3i64SOFT(ALuint source, ALenum param, ALint64SOFT *value1, ALint64SOFT *value2, ALint64SOFT *value3);
+AL_API void AL_APIENTRY alGetSourcei64vSOFT(ALuint source, ALenum param, ALint64SOFT *values);
+#endif
+#endif
+
+#ifndef ALC_EXT_DEFAULT_FILTER_ORDER
+#define ALC_EXT_DEFAULT_FILTER_ORDER 1
+#define ALC_DEFAULT_FILTER_ORDER                 0x1100
+#endif
+
+#ifndef AL_SOFT_deferred_updates
+#define AL_SOFT_deferred_updates 1
+#define AL_DEFERRED_UPDATES_SOFT                 0xC002
+typedef void (AL_APIENTRY*LPALDEFERUPDATESSOFT)(void);
+typedef void (AL_APIENTRY*LPALPROCESSUPDATESSOFT)(void);
+#ifdef AL_ALEXT_PROTOTYPES
+AL_API void AL_APIENTRY alDeferUpdatesSOFT(void);
+AL_API void AL_APIENTRY alProcessUpdatesSOFT(void);
+#endif
+#endif
+
+#ifndef AL_SOFT_block_alignment
+#define AL_SOFT_block_alignment 1
+#define AL_UNPACK_BLOCK_ALIGNMENT_SOFT           0x200C
+#define AL_PACK_BLOCK_ALIGNMENT_SOFT             0x200D
+#endif
+
+#ifndef AL_SOFT_MSADPCM
+#define AL_SOFT_MSADPCM 1
+#define AL_FORMAT_MONO_MSADPCM_SOFT              0x1302
+#define AL_FORMAT_STEREO_MSADPCM_SOFT            0x1303
+#endif
+
+#ifndef AL_SOFT_source_length
+#define AL_SOFT_source_length 1
+/*#define AL_BYTE_LENGTH_SOFT                      0x2009*/
+/*#define AL_SAMPLE_LENGTH_SOFT                    0x200A*/
+/*#define AL_SEC_LENGTH_SOFT                       0x200B*/
+#endif
+
+#ifndef ALC_SOFT_pause_device
+#define ALC_SOFT_pause_device 1
+typedef void (ALC_APIENTRY*LPALCDEVICEPAUSESOFT)(ALCdevice *device);
+typedef void (ALC_APIENTRY*LPALCDEVICERESUMESOFT)(ALCdevice *device);
+#ifdef AL_ALEXT_PROTOTYPES
+ALC_API void ALC_APIENTRY alcDevicePauseSOFT(ALCdevice *device);
+ALC_API void ALC_APIENTRY alcDeviceResumeSOFT(ALCdevice *device);
+#endif
+#endif
+
+#ifndef AL_EXT_BFORMAT
+#define AL_EXT_BFORMAT 1
+/* Provides support for B-Format ambisonic buffers (first-order, FuMa scaling
+ * and layout).
+ *
+ * BFORMAT2D_8: Unsigned 8-bit, 3-channel non-periphonic (WXY).
+ * BFORMAT2D_16: Signed 16-bit, 3-channel non-periphonic (WXY).
+ * BFORMAT2D_FLOAT32: 32-bit float, 3-channel non-periphonic (WXY).
+ * BFORMAT3D_8: Unsigned 8-bit, 4-channel periphonic (WXYZ).
+ * BFORMAT3D_16: Signed 16-bit, 4-channel periphonic (WXYZ).
+ * BFORMAT3D_FLOAT32: 32-bit float, 4-channel periphonic (WXYZ).
+ */
+#define AL_FORMAT_BFORMAT2D_8                    0x20021
+#define AL_FORMAT_BFORMAT2D_16                   0x20022
+#define AL_FORMAT_BFORMAT2D_FLOAT32              0x20023
+#define AL_FORMAT_BFORMAT3D_8                    0x20031
+#define AL_FORMAT_BFORMAT3D_16                   0x20032
+#define AL_FORMAT_BFORMAT3D_FLOAT32              0x20033
+#endif
+
+#ifndef AL_EXT_MULAW_BFORMAT
+#define AL_EXT_MULAW_BFORMAT 1
+#define AL_FORMAT_BFORMAT2D_MULAW                0x10031
+#define AL_FORMAT_BFORMAT3D_MULAW                0x10032
+#endif
+
+#ifndef ALC_SOFT_HRTF
+#define ALC_SOFT_HRTF 1
+#define ALC_HRTF_SOFT                            0x1992
+#define ALC_DONT_CARE_SOFT                       0x0002
+#define ALC_HRTF_STATUS_SOFT                     0x1993
+#define ALC_HRTF_DISABLED_SOFT                   0x0000
+#define ALC_HRTF_ENABLED_SOFT                    0x0001
+#define ALC_HRTF_DENIED_SOFT                     0x0002
+#define ALC_HRTF_REQUIRED_SOFT                   0x0003
+#define ALC_HRTF_HEADPHONES_DETECTED_SOFT        0x0004
+#define ALC_HRTF_UNSUPPORTED_FORMAT_SOFT         0x0005
+#define ALC_NUM_HRTF_SPECIFIERS_SOFT             0x1994
+#define ALC_HRTF_SPECIFIER_SOFT                  0x1995
+#define ALC_HRTF_ID_SOFT                         0x1996
+typedef const ALCchar* (ALC_APIENTRY*LPALCGETSTRINGISOFT)(ALCdevice *device, ALCenum paramName, ALCsizei index);
+typedef ALCboolean (ALC_APIENTRY*LPALCRESETDEVICESOFT)(ALCdevice *device, const ALCint *attribs);
+#ifdef AL_ALEXT_PROTOTYPES
+ALC_API const ALCchar* ALC_APIENTRY alcGetStringiSOFT(ALCdevice *device, ALCenum paramName, ALCsizei index);
+ALC_API ALCboolean ALC_APIENTRY alcResetDeviceSOFT(ALCdevice *device, const ALCint *attribs);
+#endif
+#endif
+
+#ifndef AL_SOFT_gain_clamp_ex
+#define AL_SOFT_gain_clamp_ex 1
+#define AL_GAIN_LIMIT_SOFT                       0x200E
+#endif
+
+#ifndef AL_SOFT_source_resampler
+#define AL_SOFT_source_resampler
+#define AL_NUM_RESAMPLERS_SOFT                   0x1210
+#define AL_DEFAULT_RESAMPLER_SOFT                0x1211
+#define AL_SOURCE_RESAMPLER_SOFT                 0x1212
+#define AL_RESAMPLER_NAME_SOFT                   0x1213
+typedef const ALchar* (AL_APIENTRY*LPALGETSTRINGISOFT)(ALenum pname, ALsizei index);
+#ifdef AL_ALEXT_PROTOTYPES
+AL_API const ALchar* AL_APIENTRY alGetStringiSOFT(ALenum pname, ALsizei index);
+#endif
+#endif
+
+#ifndef AL_SOFT_source_spatialize
+#define AL_SOFT_source_spatialize
+#define AL_SOURCE_SPATIALIZE_SOFT                0x1214
+#define AL_AUTO_SOFT                             0x0002
+#endif
+
+#ifndef ALC_SOFT_output_limiter
+#define ALC_SOFT_output_limiter
+#define ALC_OUTPUT_LIMITER_SOFT                  0x199A
+#endif
+
+#ifndef ALC_SOFT_device_clock
+#define ALC_SOFT_device_clock 1
+typedef _alsoft_int64_t ALCint64SOFT;
+typedef _alsoft_uint64_t ALCuint64SOFT;
+#define ALC_DEVICE_CLOCK_SOFT                    0x1600
+#define ALC_DEVICE_LATENCY_SOFT                  0x1601
+#define ALC_DEVICE_CLOCK_LATENCY_SOFT            0x1602
+#define AL_SAMPLE_OFFSET_CLOCK_SOFT              0x1202
+#define AL_SEC_OFFSET_CLOCK_SOFT                 0x1203
+typedef void (ALC_APIENTRY*LPALCGETINTEGER64VSOFT)(ALCdevice *device, ALCenum pname, ALsizei size, ALCint64SOFT *values);
+#ifdef AL_ALEXT_PROTOTYPES
+ALC_API void ALC_APIENTRY alcGetInteger64vSOFT(ALCdevice *device, ALCenum pname, ALsizei size, ALCint64SOFT *values);
+#endif
+#endif
+
+#ifndef AL_SOFT_direct_channels_remix
+#define AL_SOFT_direct_channels_remix 1
+#define AL_DROP_UNMATCHED_SOFT                   0x0001
+#define AL_REMIX_UNMATCHED_SOFT                  0x0002
+#endif
+
+#ifndef AL_SOFT_bformat_ex
+#define AL_SOFT_bformat_ex 1
+#define AL_AMBISONIC_LAYOUT_SOFT                 0x1997
+#define AL_AMBISONIC_SCALING_SOFT                0x1998
+
+/* Ambisonic layouts */
+#define AL_FUMA_SOFT                             0x0000
+#define AL_ACN_SOFT                              0x0001
+
+/* Ambisonic scalings (normalization) */
+/*#define AL_FUMA_SOFT*/
+#define AL_SN3D_SOFT                             0x0001
+#define AL_N3D_SOFT                              0x0002
+#endif
+
+#ifndef ALC_SOFT_loopback_bformat
+#define ALC_SOFT_loopback_bformat 1
+#define ALC_AMBISONIC_LAYOUT_SOFT                0x1997
+#define ALC_AMBISONIC_SCALING_SOFT               0x1998
+#define ALC_AMBISONIC_ORDER_SOFT                 0x1999
+#define ALC_MAX_AMBISONIC_ORDER_SOFT             0x199B
+
+#define ALC_BFORMAT3D_SOFT                       0x1507
+
+/* Ambisonic layouts */
+#define ALC_FUMA_SOFT                            0x0000
+#define ALC_ACN_SOFT                             0x0001
+
+/* Ambisonic scalings (normalization) */
+/*#define ALC_FUMA_SOFT*/
+#define ALC_SN3D_SOFT                            0x0001
+#define ALC_N3D_SOFT                             0x0002
+#endif
+
+#ifndef AL_SOFT_effect_target
+#define AL_SOFT_effect_target
+#define AL_EFFECTSLOT_TARGET_SOFT                0x199C
+#endif
+
+#ifndef AL_SOFT_events
+#define AL_SOFT_events 1
+#define AL_EVENT_CALLBACK_FUNCTION_SOFT          0x19A2
+#define AL_EVENT_CALLBACK_USER_PARAM_SOFT        0x19A3
+#define AL_EVENT_TYPE_BUFFER_COMPLETED_SOFT      0x19A4
+#define AL_EVENT_TYPE_SOURCE_STATE_CHANGED_SOFT  0x19A5
+#define AL_EVENT_TYPE_DISCONNECTED_SOFT          0x19A6
+typedef void (AL_APIENTRY*ALEVENTPROCSOFT)(ALenum eventType, ALuint object, ALuint param,
+                                           ALsizei length, const ALchar *message,
+                                           void *userParam);
+typedef void (AL_APIENTRY*LPALEVENTCONTROLSOFT)(ALsizei count, const ALenum *types, ALboolean enable);
+typedef void (AL_APIENTRY*LPALEVENTCALLBACKSOFT)(ALEVENTPROCSOFT callback, void *userParam);
+typedef void* (AL_APIENTRY*LPALGETPOINTERSOFT)(ALenum pname);
+typedef void (AL_APIENTRY*LPALGETPOINTERVSOFT)(ALenum pname, void **values);
+#ifdef AL_ALEXT_PROTOTYPES
+AL_API void AL_APIENTRY alEventControlSOFT(ALsizei count, const ALenum *types, ALboolean enable);
+AL_API void AL_APIENTRY alEventCallbackSOFT(ALEVENTPROCSOFT callback, void *userParam);
+AL_API void* AL_APIENTRY alGetPointerSOFT(ALenum pname);
+AL_API void AL_APIENTRY alGetPointervSOFT(ALenum pname, void **values);
+#endif
+#endif
+
+#ifndef ALC_SOFT_reopen_device
+#define ALC_SOFT_reopen_device
+typedef ALCboolean (ALC_APIENTRY*LPALCREOPENDEVICESOFT)(ALCdevice *device,
+    const ALCchar *deviceName, const ALCint *attribs);
+#ifdef AL_ALEXT_PROTOTYPES
+ALCboolean ALC_APIENTRY alcReopenDeviceSOFT(ALCdevice *device, const ALCchar *deviceName,
+    const ALCint *attribs);
+#endif
+#endif
+
+#ifndef AL_SOFT_callback_buffer
+#define AL_SOFT_callback_buffer
+#define AL_BUFFER_CALLBACK_FUNCTION_SOFT         0x19A0
+#define AL_BUFFER_CALLBACK_USER_PARAM_SOFT       0x19A1
+typedef ALsizei (AL_APIENTRY*ALBUFFERCALLBACKTYPESOFT)(ALvoid *userptr, ALvoid *sampledata, ALsizei numbytes);
+typedef void (AL_APIENTRY*LPALBUFFERCALLBACKSOFT)(ALuint buffer, ALenum format, ALsizei freq, ALBUFFERCALLBACKTYPESOFT callback, ALvoid *userptr);
+typedef void (AL_APIENTRY*LPALGETBUFFERPTRSOFT)(ALuint buffer, ALenum param, ALvoid **value);
+typedef void (AL_APIENTRY*LPALGETBUFFER3PTRSOFT)(ALuint buffer, ALenum param, ALvoid **value1, ALvoid **value2, ALvoid **value3);
+typedef void (AL_APIENTRY*LPALGETBUFFERPTRVSOFT)(ALuint buffer, ALenum param, ALvoid **values);
+#ifdef AL_ALEXT_PROTOTYPES
+AL_API void AL_APIENTRY alBufferCallbackSOFT(ALuint buffer, ALenum format, ALsizei freq, ALBUFFERCALLBACKTYPESOFT callback, ALvoid *userptr);
+AL_API void AL_APIENTRY alGetBufferPtrSOFT(ALuint buffer, ALenum param, ALvoid **ptr);
+AL_API void AL_APIENTRY alGetBuffer3PtrSOFT(ALuint buffer, ALenum param, ALvoid **ptr0, ALvoid **ptr1, ALvoid **ptr2);
+AL_API void AL_APIENTRY alGetBufferPtrvSOFT(ALuint buffer, ALenum param, ALvoid **ptr);
+#endif
+#endif
+
+#ifndef AL_SOFT_UHJ
+#define AL_SOFT_UHJ
+#define AL_FORMAT_UHJ2CHN8_SOFT                  0x19A2
+#define AL_FORMAT_UHJ2CHN16_SOFT                 0x19A3
+#define AL_FORMAT_UHJ2CHN_FLOAT32_SOFT           0x19A4
+#define AL_FORMAT_UHJ3CHN8_SOFT                  0x19A5
+#define AL_FORMAT_UHJ3CHN16_SOFT                 0x19A6
+#define AL_FORMAT_UHJ3CHN_FLOAT32_SOFT           0x19A7
+#define AL_FORMAT_UHJ4CHN8_SOFT                  0x19A8
+#define AL_FORMAT_UHJ4CHN16_SOFT                 0x19A9
+#define AL_FORMAT_UHJ4CHN_FLOAT32_SOFT           0x19AA
+
+#define AL_STEREO_MODE_SOFT                      0x19B0
+#define AL_NORMAL_SOFT                           0x0000
+#define AL_SUPER_STEREO_SOFT                     0x0001
+#define AL_SUPER_STEREO_WIDTH_SOFT               0x19B1
+#endif
+
+#ifndef ALC_SOFT_output_mode
+#define ALC_SOFT_output_mode
+#define ALC_OUTPUT_MODE_SOFT                     0x19AC
+#define ALC_ANY_SOFT                             0x19AD
+/*#define ALC_MONO_SOFT                            0x1500*/
+/*#define ALC_STEREO_SOFT                          0x1501*/
+#define ALC_STEREO_BASIC_SOFT                    0x19AE
+#define ALC_STEREO_UHJ_SOFT                      0x19AF
+#define ALC_STEREO_HRTF_SOFT                     0x19B2
+/*#define ALC_QUAD_SOFT                            0x1503*/
+#define ALC_SURROUND_5_1_SOFT                    0x1504
+#define ALC_SURROUND_6_1_SOFT                    0x1505
+#define ALC_SURROUND_7_1_SOFT                    0x1506
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/common/audio/sound/efx.h
+++ b/src/common/audio/sound/efx.h
@@ -1,6 +1,7 @@
 #ifndef AL_EFX_H
 #define AL_EFX_H
 
+#include <float.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -201,12 +202,12 @@ extern "C" {
 
 /* Effect object function types. */
 typedef void (AL_APIENTRY *LPALGENEFFECTS)(ALsizei, ALuint*);
-typedef void (AL_APIENTRY *LPALDELETEEFFECTS)(ALsizei, ALuint*);
+typedef void (AL_APIENTRY *LPALDELETEEFFECTS)(ALsizei, const ALuint*);
 typedef ALboolean (AL_APIENTRY *LPALISEFFECT)(ALuint);
 typedef void (AL_APIENTRY *LPALEFFECTI)(ALuint, ALenum, ALint);
-typedef void (AL_APIENTRY *LPALEFFECTIV)(ALuint, ALenum, ALint*);
+typedef void (AL_APIENTRY *LPALEFFECTIV)(ALuint, ALenum, const ALint*);
 typedef void (AL_APIENTRY *LPALEFFECTF)(ALuint, ALenum, ALfloat);
-typedef void (AL_APIENTRY *LPALEFFECTFV)(ALuint, ALenum, ALfloat*);
+typedef void (AL_APIENTRY *LPALEFFECTFV)(ALuint, ALenum, const ALfloat*);
 typedef void (AL_APIENTRY *LPALGETEFFECTI)(ALuint, ALenum, ALint*);
 typedef void (AL_APIENTRY *LPALGETEFFECTIV)(ALuint, ALenum, ALint*);
 typedef void (AL_APIENTRY *LPALGETEFFECTF)(ALuint, ALenum, ALfloat*);
@@ -214,12 +215,12 @@ typedef void (AL_APIENTRY *LPALGETEFFECTFV)(ALuint, ALenum, ALfloat*);
 
 /* Filter object function types. */
 typedef void (AL_APIENTRY *LPALGENFILTERS)(ALsizei, ALuint*);
-typedef void (AL_APIENTRY *LPALDELETEFILTERS)(ALsizei, ALuint*);
+typedef void (AL_APIENTRY *LPALDELETEFILTERS)(ALsizei, const ALuint*);
 typedef ALboolean (AL_APIENTRY *LPALISFILTER)(ALuint);
 typedef void (AL_APIENTRY *LPALFILTERI)(ALuint, ALenum, ALint);
-typedef void (AL_APIENTRY *LPALFILTERIV)(ALuint, ALenum, ALint*);
+typedef void (AL_APIENTRY *LPALFILTERIV)(ALuint, ALenum, const ALint*);
 typedef void (AL_APIENTRY *LPALFILTERF)(ALuint, ALenum, ALfloat);
-typedef void (AL_APIENTRY *LPALFILTERFV)(ALuint, ALenum, ALfloat*);
+typedef void (AL_APIENTRY *LPALFILTERFV)(ALuint, ALenum, const ALfloat*);
 typedef void (AL_APIENTRY *LPALGETFILTERI)(ALuint, ALenum, ALint*);
 typedef void (AL_APIENTRY *LPALGETFILTERIV)(ALuint, ALenum, ALint*);
 typedef void (AL_APIENTRY *LPALGETFILTERF)(ALuint, ALenum, ALfloat*);
@@ -227,87 +228,87 @@ typedef void (AL_APIENTRY *LPALGETFILTERFV)(ALuint, ALenum, ALfloat*);
 
 /* Auxiliary Effect Slot object function types. */
 typedef void (AL_APIENTRY *LPALGENAUXILIARYEFFECTSLOTS)(ALsizei, ALuint*);
-typedef void (AL_APIENTRY *LPALDELETEAUXILIARYEFFECTSLOTS)(ALsizei, ALuint*);
+typedef void (AL_APIENTRY *LPALDELETEAUXILIARYEFFECTSLOTS)(ALsizei, const ALuint*);
 typedef ALboolean (AL_APIENTRY *LPALISAUXILIARYEFFECTSLOT)(ALuint);
 typedef void (AL_APIENTRY *LPALAUXILIARYEFFECTSLOTI)(ALuint, ALenum, ALint);
-typedef void (AL_APIENTRY *LPALAUXILIARYEFFECTSLOTIV)(ALuint, ALenum, ALint*);
+typedef void (AL_APIENTRY *LPALAUXILIARYEFFECTSLOTIV)(ALuint, ALenum, const ALint*);
 typedef void (AL_APIENTRY *LPALAUXILIARYEFFECTSLOTF)(ALuint, ALenum, ALfloat);
-typedef void (AL_APIENTRY *LPALAUXILIARYEFFECTSLOTFV)(ALuint, ALenum, ALfloat*);
+typedef void (AL_APIENTRY *LPALAUXILIARYEFFECTSLOTFV)(ALuint, ALenum, const ALfloat*);
 typedef void (AL_APIENTRY *LPALGETAUXILIARYEFFECTSLOTI)(ALuint, ALenum, ALint*);
 typedef void (AL_APIENTRY *LPALGETAUXILIARYEFFECTSLOTIV)(ALuint, ALenum, ALint*);
 typedef void (AL_APIENTRY *LPALGETAUXILIARYEFFECTSLOTF)(ALuint, ALenum, ALfloat*);
 typedef void (AL_APIENTRY *LPALGETAUXILIARYEFFECTSLOTFV)(ALuint, ALenum, ALfloat*);
 
 #ifdef AL_ALEXT_PROTOTYPES
-AL_API ALvoid AL_APIENTRY alGenEffects(ALsizei n, ALuint *effects);
-AL_API ALvoid AL_APIENTRY alDeleteEffects(ALsizei n, ALuint *effects);
+AL_API void AL_APIENTRY alGenEffects(ALsizei n, ALuint *effects);
+AL_API void AL_APIENTRY alDeleteEffects(ALsizei n, const ALuint *effects);
 AL_API ALboolean AL_APIENTRY alIsEffect(ALuint effect);
-AL_API ALvoid AL_APIENTRY alEffecti(ALuint effect, ALenum param, ALint iValue);
-AL_API ALvoid AL_APIENTRY alEffectiv(ALuint effect, ALenum param, ALint *piValues);
-AL_API ALvoid AL_APIENTRY alEffectf(ALuint effect, ALenum param, ALfloat flValue);
-AL_API ALvoid AL_APIENTRY alEffectfv(ALuint effect, ALenum param, ALfloat *pflValues);
-AL_API ALvoid AL_APIENTRY alGetEffecti(ALuint effect, ALenum param, ALint *piValue);
-AL_API ALvoid AL_APIENTRY alGetEffectiv(ALuint effect, ALenum param, ALint *piValues);
-AL_API ALvoid AL_APIENTRY alGetEffectf(ALuint effect, ALenum param, ALfloat *pflValue);
-AL_API ALvoid AL_APIENTRY alGetEffectfv(ALuint effect, ALenum param, ALfloat *pflValues);
+AL_API void AL_APIENTRY alEffecti(ALuint effect, ALenum param, ALint iValue);
+AL_API void AL_APIENTRY alEffectiv(ALuint effect, ALenum param, const ALint *piValues);
+AL_API void AL_APIENTRY alEffectf(ALuint effect, ALenum param, ALfloat flValue);
+AL_API void AL_APIENTRY alEffectfv(ALuint effect, ALenum param, const ALfloat *pflValues);
+AL_API void AL_APIENTRY alGetEffecti(ALuint effect, ALenum param, ALint *piValue);
+AL_API void AL_APIENTRY alGetEffectiv(ALuint effect, ALenum param, ALint *piValues);
+AL_API void AL_APIENTRY alGetEffectf(ALuint effect, ALenum param, ALfloat *pflValue);
+AL_API void AL_APIENTRY alGetEffectfv(ALuint effect, ALenum param, ALfloat *pflValues);
 
-AL_API ALvoid AL_APIENTRY alGenFilters(ALsizei n, ALuint *filters);
-AL_API ALvoid AL_APIENTRY alDeleteFilters(ALsizei n, ALuint *filters);
+AL_API void AL_APIENTRY alGenFilters(ALsizei n, ALuint *filters);
+AL_API void AL_APIENTRY alDeleteFilters(ALsizei n, const ALuint *filters);
 AL_API ALboolean AL_APIENTRY alIsFilter(ALuint filter);
-AL_API ALvoid AL_APIENTRY alFilteri(ALuint filter, ALenum param, ALint iValue);
-AL_API ALvoid AL_APIENTRY alFilteriv(ALuint filter, ALenum param, ALint *piValues);
-AL_API ALvoid AL_APIENTRY alFilterf(ALuint filter, ALenum param, ALfloat flValue);
-AL_API ALvoid AL_APIENTRY alFilterfv(ALuint filter, ALenum param, ALfloat *pflValues);
-AL_API ALvoid AL_APIENTRY alGetFilteri(ALuint filter, ALenum param, ALint *piValue);
-AL_API ALvoid AL_APIENTRY alGetFilteriv(ALuint filter, ALenum param, ALint *piValues);
-AL_API ALvoid AL_APIENTRY alGetFilterf(ALuint filter, ALenum param, ALfloat *pflValue);
-AL_API ALvoid AL_APIENTRY alGetFilterfv(ALuint filter, ALenum param, ALfloat *pflValues);
+AL_API void AL_APIENTRY alFilteri(ALuint filter, ALenum param, ALint iValue);
+AL_API void AL_APIENTRY alFilteriv(ALuint filter, ALenum param, const ALint *piValues);
+AL_API void AL_APIENTRY alFilterf(ALuint filter, ALenum param, ALfloat flValue);
+AL_API void AL_APIENTRY alFilterfv(ALuint filter, ALenum param, const ALfloat *pflValues);
+AL_API void AL_APIENTRY alGetFilteri(ALuint filter, ALenum param, ALint *piValue);
+AL_API void AL_APIENTRY alGetFilteriv(ALuint filter, ALenum param, ALint *piValues);
+AL_API void AL_APIENTRY alGetFilterf(ALuint filter, ALenum param, ALfloat *pflValue);
+AL_API void AL_APIENTRY alGetFilterfv(ALuint filter, ALenum param, ALfloat *pflValues);
 
-AL_API ALvoid AL_APIENTRY alGenAuxiliaryEffectSlots(ALsizei n, ALuint *effectslots);
-AL_API ALvoid AL_APIENTRY alDeleteAuxiliaryEffectSlots(ALsizei n, ALuint *effectslots);
+AL_API void AL_APIENTRY alGenAuxiliaryEffectSlots(ALsizei n, ALuint *effectslots);
+AL_API void AL_APIENTRY alDeleteAuxiliaryEffectSlots(ALsizei n, const ALuint *effectslots);
 AL_API ALboolean AL_APIENTRY alIsAuxiliaryEffectSlot(ALuint effectslot);
-AL_API ALvoid AL_APIENTRY alAuxiliaryEffectSloti(ALuint effectslot, ALenum param, ALint iValue);
-AL_API ALvoid AL_APIENTRY alAuxiliaryEffectSlotiv(ALuint effectslot, ALenum param, ALint *piValues);
-AL_API ALvoid AL_APIENTRY alAuxiliaryEffectSlotf(ALuint effectslot, ALenum param, ALfloat flValue);
-AL_API ALvoid AL_APIENTRY alAuxiliaryEffectSlotfv(ALuint effectslot, ALenum param, ALfloat *pflValues);
-AL_API ALvoid AL_APIENTRY alGetAuxiliaryEffectSloti(ALuint effectslot, ALenum param, ALint *piValue);
-AL_API ALvoid AL_APIENTRY alGetAuxiliaryEffectSlotiv(ALuint effectslot, ALenum param, ALint *piValues);
-AL_API ALvoid AL_APIENTRY alGetAuxiliaryEffectSlotf(ALuint effectslot, ALenum param, ALfloat *pflValue);
-AL_API ALvoid AL_APIENTRY alGetAuxiliaryEffectSlotfv(ALuint effectslot, ALenum param, ALfloat *pflValues);
+AL_API void AL_APIENTRY alAuxiliaryEffectSloti(ALuint effectslot, ALenum param, ALint iValue);
+AL_API void AL_APIENTRY alAuxiliaryEffectSlotiv(ALuint effectslot, ALenum param, const ALint *piValues);
+AL_API void AL_APIENTRY alAuxiliaryEffectSlotf(ALuint effectslot, ALenum param, ALfloat flValue);
+AL_API void AL_APIENTRY alAuxiliaryEffectSlotfv(ALuint effectslot, ALenum param, const ALfloat *pflValues);
+AL_API void AL_APIENTRY alGetAuxiliaryEffectSloti(ALuint effectslot, ALenum param, ALint *piValue);
+AL_API void AL_APIENTRY alGetAuxiliaryEffectSlotiv(ALuint effectslot, ALenum param, ALint *piValues);
+AL_API void AL_APIENTRY alGetAuxiliaryEffectSlotf(ALuint effectslot, ALenum param, ALfloat *pflValue);
+AL_API void AL_APIENTRY alGetAuxiliaryEffectSlotfv(ALuint effectslot, ALenum param, ALfloat *pflValues);
 #endif
 
 /* Filter ranges and defaults. */
 
 /* Lowpass filter */
-#define LOWPASS_MIN_GAIN                         (0.0f)
-#define LOWPASS_MAX_GAIN                         (1.0f)
-#define LOWPASS_DEFAULT_GAIN                     (1.0f)
+#define AL_LOWPASS_MIN_GAIN                      (0.0f)
+#define AL_LOWPASS_MAX_GAIN                      (1.0f)
+#define AL_LOWPASS_DEFAULT_GAIN                  (1.0f)
 
-#define LOWPASS_MIN_GAINHF                       (0.0f)
-#define LOWPASS_MAX_GAINHF                       (1.0f)
-#define LOWPASS_DEFAULT_GAINHF                   (1.0f)
+#define AL_LOWPASS_MIN_GAINHF                    (0.0f)
+#define AL_LOWPASS_MAX_GAINHF                    (1.0f)
+#define AL_LOWPASS_DEFAULT_GAINHF                (1.0f)
 
 /* Highpass filter */
-#define HIGHPASS_MIN_GAIN                        (0.0f)
-#define HIGHPASS_MAX_GAIN                        (1.0f)
-#define HIGHPASS_DEFAULT_GAIN                    (1.0f)
+#define AL_HIGHPASS_MIN_GAIN                     (0.0f)
+#define AL_HIGHPASS_MAX_GAIN                     (1.0f)
+#define AL_HIGHPASS_DEFAULT_GAIN                 (1.0f)
 
-#define HIGHPASS_MIN_GAINLF                      (0.0f)
-#define HIGHPASS_MAX_GAINLF                      (1.0f)
-#define HIGHPASS_DEFAULT_GAINLF                  (1.0f)
+#define AL_HIGHPASS_MIN_GAINLF                   (0.0f)
+#define AL_HIGHPASS_MAX_GAINLF                   (1.0f)
+#define AL_HIGHPASS_DEFAULT_GAINLF               (1.0f)
 
 /* Bandpass filter */
-#define BANDPASS_MIN_GAIN                        (0.0f)
-#define BANDPASS_MAX_GAIN                        (1.0f)
-#define BANDPASS_DEFAULT_GAIN                    (1.0f)
+#define AL_BANDPASS_MIN_GAIN                     (0.0f)
+#define AL_BANDPASS_MAX_GAIN                     (1.0f)
+#define AL_BANDPASS_DEFAULT_GAIN                 (1.0f)
 
-#define BANDPASS_MIN_GAINHF                      (0.0f)
-#define BANDPASS_MAX_GAINHF                      (1.0f)
-#define BANDPASS_DEFAULT_GAINHF                  (1.0f)
+#define AL_BANDPASS_MIN_GAINHF                   (0.0f)
+#define AL_BANDPASS_MAX_GAINHF                   (1.0f)
+#define AL_BANDPASS_DEFAULT_GAINHF               (1.0f)
 
-#define BANDPASS_MIN_GAINLF                      (0.0f)
-#define BANDPASS_MAX_GAINLF                      (1.0f)
-#define BANDPASS_DEFAULT_GAINLF                  (1.0f)
+#define AL_BANDPASS_MIN_GAINLF                   (0.0f)
+#define AL_BANDPASS_MAX_GAINLF                   (1.0f)
+#define AL_BANDPASS_DEFAULT_GAINLF               (1.0f)
 
 
 /* Effect parameter ranges and defaults. */

--- a/src/common/audio/sound/i_sound.h
+++ b/src/common/audio/sound/i_sound.h
@@ -35,6 +35,7 @@
 #ifndef __I_SOUND__
 #define __I_SOUND__
 
+#include <chrono>
 #include <vector>
 #include "i_soundinternal.h"
 #include "zstring.h"
@@ -62,7 +63,7 @@ enum ECodecType
 class SoundStream
 {
 public:
-	virtual ~SoundStream () {}
+	virtual ~SoundStream() = default;
 
 	enum
 	{	// For CreateStream
@@ -75,11 +76,18 @@ public:
 		Loop = 16
 	};
 
+	struct Position {
+		uint64_t samplesplayed;
+		std::chrono::nanoseconds latency;
+	};
+
 	virtual bool Play(bool looping, float volume) = 0;
 	virtual void Stop() = 0;
 	virtual void SetVolume(float volume) = 0;
 	virtual bool SetPaused(bool paused) = 0;
 	virtual bool IsEnded() = 0;
+	// Be aware this can be called during the callback invocation after Play is called.
+	virtual Position GetPlayPosition() = 0;
 	virtual FString GetStats();
 };
 

--- a/src/common/audio/sound/oalsound.cpp
+++ b/src/common/audio/sound/oalsound.cpp
@@ -183,6 +183,8 @@ class OpenALSoundStream : public SoundStream
 	std::atomic<bool> Playing;
 	//bool Looping;
 	ALfloat Volume;
+	uint64_t Offset = 0;
+	std::mutex Mutex;
 
 	bool SetupSource()
 	{
@@ -263,6 +265,7 @@ public:
 			return true;
 
 		/* Clear the buffer queue, then fill and queue each buffer */
+		Offset = 0;
 		alSourcei(Source, AL_BUFFER, 0);
 		for(int i = 0;i < BufferCount;i++)
 		{
@@ -297,6 +300,7 @@ public:
 		alSourcei(Source, AL_BUFFER, 0);
 		getALError();
 
+		Offset = 0;
 		Playing.store(false);
 	}
 
@@ -325,6 +329,44 @@ public:
 	{
 		return !Playing.load();
 			}
+
+	Position GetPlayPosition() override
+	{
+		using namespace std::chrono;
+
+		std::lock_guard _{Mutex};
+		ALint64SOFT offset[2]{};
+		ALint state{}, queued{};
+		alGetSourcei(Source, AL_BUFFERS_QUEUED, &queued);
+		if(Renderer->AL.SOFT_source_latency)
+		{
+			// AL_SAMPLE_OFFSET_LATENCY_SOFT fills offset[0] with the source sample
+			// offset in 32.32 fixed-point (which we chop off the sub-sample position
+			// since it's not crucial), and offset[1] with the playback latency in
+			// nanoseconds (how many nanoseconds until the sample point in offset[0]
+			// reaches the DAC).
+			Renderer->alGetSourcei64vSOFT(Source, AL_SAMPLE_OFFSET_LATENCY_SOFT, offset);
+			offset[0] >>= 32;
+		}
+		else
+		{
+			// Without AL_SOFT_source_latency, we can only get the sample offset, no
+			// latency info.
+			ALint ioffset{};
+			alGetSourcei(Source, AL_SAMPLE_OFFSET, &ioffset);
+			offset[0] = ioffset;
+			offset[1] = 0;
+		}
+		alGetSourcei(Source, AL_SOURCE_STATE, &state);
+		// If the source is stopped, there was an underrun, so the play position is
+		// the end of the queue.
+		if(state == AL_STOPPED)
+			return Position{Offset + queued*(Data.Size()/FrameSize), nanoseconds{offset[1]}};
+		// The offset is otherwise valid as long as the source has been started.
+		if(state != AL_INITIAL)
+			return Position{Offset + offset[0], nanoseconds{offset[1]}};
+		return Position{0, nanoseconds{0}};
+	}
 
 	virtual FString GetStats()
 		{
@@ -386,8 +428,12 @@ public:
 
 			// Unqueue the oldest buffer, fill it with more data, and queue it
 			// on the end
-			alSourceUnqueueBuffers(Source, 1, &bufid);
-			processed--;
+			{
+				std::lock_guard _{Mutex};
+				alSourceUnqueueBuffers(Source, 1, &bufid);
+				Offset += Data.Size() / FrameSize;
+				processed--;
+			}
 
 			if(Callback(this, &Data[0], Data.Size(), UserData))
 			{
@@ -624,6 +670,7 @@ OpenALSoundRenderer::OpenALSoundRenderer()
 	AL.EXT_SOURCE_RADIUS = !!alIsExtensionPresent("AL_EXT_SOURCE_RADIUS");
 	AL.SOFT_deferred_updates = !!alIsExtensionPresent("AL_SOFT_deferred_updates");
 	AL.SOFT_loop_points = !!alIsExtensionPresent("AL_SOFT_loop_points");
+	AL.SOFT_source_latency = !!alIsExtensionPresent("AL_SOFT_source_latency");
 	AL.SOFT_source_resampler = !!alIsExtensionPresent("AL_SOFT_source_resampler");
 	AL.SOFT_source_spatialize = !!alIsExtensionPresent("AL_SOFT_source_spatialize");
 
@@ -651,6 +698,8 @@ OpenALSoundRenderer::OpenALSoundRenderer()
 		alProcessUpdatesSOFT = _wrap_ProcessUpdatesSOFT;
 	}
 
+	if(AL.SOFT_source_latency)
+		LOAD_FUNC(alGetSourcei64vSOFT);
 	if(AL.SOFT_source_resampler)
 		LOAD_FUNC(alGetStringiSOFT);
 

--- a/src/common/audio/sound/oalsound.h
+++ b/src/common/audio/sound/oalsound.h
@@ -21,100 +21,7 @@
 #include "alc.h"
 #endif
 
-#include "efx.h"
-
-#ifndef ALC_ENUMERATE_ALL_EXT
-#define ALC_ENUMERATE_ALL_EXT 1
-#define ALC_DEFAULT_ALL_DEVICES_SPECIFIER        0x1012
-#define ALC_ALL_DEVICES_SPECIFIER                0x1013
-#endif
-
-#ifndef ALC_EXT_disconnect
-#define ALC_EXT_disconnect 1
-#define ALC_CONNECTED                            0x313
-#endif
-
-#ifndef ALC_SOFT_HRTF
-#define ALC_SOFT_HRTF 1
-#define ALC_HRTF_SOFT                            0x1992
-#define ALC_DONT_CARE_SOFT                       0x0002
-#define ALC_HRTF_STATUS_SOFT                     0x1993
-#define ALC_HRTF_DISABLED_SOFT                   0x0000
-#define ALC_HRTF_ENABLED_SOFT                    0x0001
-#define ALC_HRTF_DENIED_SOFT                     0x0002
-#define ALC_HRTF_REQUIRED_SOFT                   0x0003
-#define ALC_HRTF_HEADPHONES_DETECTED_SOFT        0x0004
-#define ALC_HRTF_UNSUPPORTED_FORMAT_SOFT         0x0005
-#define ALC_NUM_HRTF_SPECIFIERS_SOFT             0x1994
-#define ALC_HRTF_SPECIFIER_SOFT                  0x1995
-#define ALC_HRTF_ID_SOFT                         0x1996
-#define ALC_OUTPUT_LIMITER_SOFT                  0x199A 
-
-typedef const ALCchar* (ALC_APIENTRY*LPALCGETSTRINGISOFT)(ALCdevice *device, ALCenum paramName, ALCsizei index);
-typedef ALCboolean (ALC_APIENTRY*LPALCRESETDEVICESOFT)(ALCdevice *device, const ALCint *attribs);
-#ifdef AL_ALEXT_PROTOTYPES
-ALC_API const ALCchar* ALC_APIENTRY alcGetStringiSOFT(ALCdevice *device, ALCenum paramName, ALCsizei index);
-ALC_API ALCboolean ALC_APIENTRY alcResetDeviceSOFT(ALCdevice *device, const ALCint *attribs);
-#endif
-#endif
-
-#ifndef AL_EXT_source_distance_model
-#define AL_EXT_source_distance_model 1
-#define AL_SOURCE_DISTANCE_MODEL                 0x200
-#endif
-
-#ifndef AL_SOFT_loop_points
-#define AL_SOFT_loop_points 1
-#define AL_LOOP_POINTS_SOFT                      0x2015
-#endif
-
-#ifndef AL_EXT_float32
-#define AL_EXT_float32 1
-#define AL_FORMAT_MONO_FLOAT32                   0x10010
-#define AL_FORMAT_STEREO_FLOAT32                 0x10011
-#endif
-
-#ifndef AL_EXT_MCFORMATS
-#define AL_EXT_MCFORMATS 1
-#define AL_FORMAT_QUAD8                          0x1204
-#define AL_FORMAT_QUAD16                         0x1205
-#define AL_FORMAT_QUAD32                         0x1206
-#define AL_FORMAT_REAR8                          0x1207
-#define AL_FORMAT_REAR16                         0x1208
-#define AL_FORMAT_REAR32                         0x1209
-#define AL_FORMAT_51CHN8                         0x120A
-#define AL_FORMAT_51CHN16                        0x120B
-#define AL_FORMAT_51CHN32                        0x120C
-#define AL_FORMAT_61CHN8                         0x120D
-#define AL_FORMAT_61CHN16                        0x120E
-#define AL_FORMAT_61CHN32                        0x120F
-#define AL_FORMAT_71CHN8                         0x1210
-#define AL_FORMAT_71CHN16                        0x1211
-#define AL_FORMAT_71CHN32                        0x1212
-#endif
-
-#ifndef AL_EXT_SOURCE_RADIUS
-#define AL_EXT_SOURCE_RADIUS 1
-#define AL_SOURCE_RADIUS                         0x1031
-#endif
-
-#ifndef AL_SOFT_source_resampler
-#define AL_SOFT_source_resampler 1
-#define AL_NUM_RESAMPLERS_SOFT                   0x1210
-#define AL_DEFAULT_RESAMPLER_SOFT                0x1211
-#define AL_SOURCE_RESAMPLER_SOFT                 0x1212
-#define AL_RESAMPLER_NAME_SOFT                   0x1213
-typedef const ALchar* (AL_APIENTRY*LPALGETSTRINGISOFT)(ALenum pname, ALsizei index);
-#ifdef AL_ALEXT_PROTOTYPES
-AL_API const ALchar* AL_APIENTRY alGetStringiSOFT(ALenum pname, ALsizei index);
-#endif
-#endif
-
-#ifndef AL_SOFT_source_spatialize
-#define AL_SOFT_source_spatialize
-#define AL_SOURCE_SPATIALIZE_SOFT                0x1214
-#define AL_AUTO_SOFT                             0x0002
-#endif
+#include "alext.h"
 
 
 class OpenALSoundStream;
@@ -190,6 +97,7 @@ private:
         bool EXT_SOURCE_RADIUS;
         bool SOFT_deferred_updates;
         bool SOFT_loop_points;
+        bool SOFT_source_latency;
         bool SOFT_source_resampler;
         bool SOFT_source_spatialize;
     } AL;
@@ -238,6 +146,8 @@ private:
     ALvoid (AL_APIENTRY*alProcessUpdatesSOFT)(void);
 
     LPALGETSTRINGISOFT alGetStringiSOFT;
+
+    LPALGETSOURCEI64VSOFT alGetSourcei64vSOFT;
 
     void (ALC_APIENTRY*alcDevicePauseSOFT)(ALCdevice *device);
     void (ALC_APIENTRY*alcDeviceResumeSOFT)(ALCdevice *device);

--- a/src/common/cutscenes/movieplayer.cpp
+++ b/src/common/cutscenes/movieplayer.cpp
@@ -47,6 +47,10 @@
 #include "filesystem.h"
 #include "vm.h"
 #include "printf.h"
+#include <atomic>
+#include <cmath>
+#include <zmusic.h>
+#include "filereadermusicinterface.h"
 
 class MoviePlayer
 {
@@ -65,6 +69,88 @@ public:
 	virtual void Stop() {}
 	virtual ~MoviePlayer() = default;
 	virtual FTextureID GetTexture() = 0;
+};
+
+//---------------------------------------------------------------------------
+//
+//
+//
+//---------------------------------------------------------------------------
+
+// A simple filter is used to smooth out jittery timers
+static const double AudioAvgFilterCoeff{std::pow(0.01, 1.0/10.0)};
+// A threshold is in place to avoid constantly skipping due to imprecise timers.
+static constexpr double AudioSyncThreshold{0.03};
+
+class MovieAudioTrack
+{
+	SoundStream *AudioStream = nullptr;
+	std::atomic<uint64_t> ClockTime = 0;
+	int64_t AudioOffset = 0;
+	double ClockDiffAvg = 0;
+	int SampleRate = 0;
+	int FrameSize = 0;
+
+	double FilterDelay(double diff)
+	{
+		ClockDiffAvg = ClockDiffAvg*AudioAvgFilterCoeff + diff;
+		diff = ClockDiffAvg*(1.0 - AudioAvgFilterCoeff);
+		if(diff < AudioSyncThreshold/2.0 && diff > -AudioSyncThreshold)
+			return 0.0;
+
+		return diff;
+	}
+
+public:
+	MovieAudioTrack() = default;
+	~MovieAudioTrack()
+	{
+		if(AudioStream)
+			S_StopCustomStream(AudioStream);
+	}
+
+	bool Start(int srate, int channels, MusicCustomStreamType sampletype, StreamCallback callback, void *ptr)
+	{
+		SampleRate = srate;
+		FrameSize = channels * ((sampletype == MusicSamples16bit) ? sizeof(int16_t) : sizeof(float));
+		int bufsize = 40 * SampleRate / 1000 * FrameSize;
+		AudioStream = S_CreateCustomStream(bufsize, SampleRate, channels, sampletype, callback, ptr);
+		return !!AudioStream;
+	}
+
+	void Finish()
+	{
+		if(AudioStream)
+			S_StopCustomStream(AudioStream);
+		AudioStream = nullptr;
+	}
+
+	void SetClock(uint64_t clock) noexcept
+	{
+		ClockTime.store(clock, std::memory_order_release);
+	}
+
+	// NOTE: The callback (and thus GetClockDiff) can be called before
+	// S_CreateCustomStream returns, and thus before AudioStream gets set. So the
+	// caller needs to pass in the SoundStream given to the callback.
+	double GetClockDiff(SoundStream *stream)
+	{
+		// Calculate the difference in time between the movie clock and the audio position.
+		auto pos = stream->GetPlayPosition();
+		uint64_t clock = ClockTime.load(std::memory_order_acquire);
+		return FilterDelay(clock / 1'000'000'000.0 -
+			double(int64_t(pos.samplesplayed)+AudioOffset) / SampleRate +
+			pos.latency.count() / 1'000'000'000.0);
+	}
+
+	void AdjustOffset(int adjust) noexcept
+	{
+		AudioOffset += adjust;
+	}
+
+	SoundStream *GetAudioStream() const noexcept { return AudioStream; }
+	int GetSampleRate() const noexcept { return SampleRate; }
+	int GetFrameSize() const noexcept { return FrameSize; }
 };
 
 //---------------------------------------------------------------------------
@@ -174,7 +260,59 @@ public:
 class MvePlayer : public MoviePlayer
 {
 	InterplayDecoder decoder;
+	MovieAudioTrack audioTrack;
 	bool failed = false;
+
+	bool StreamCallback(SoundStream *stream, void *buff, int len)
+	{
+		const double delay = audioTrack.GetClockDiff(stream);
+		const int samplerate = audioTrack.GetSampleRate();
+		const int framesize = audioTrack.GetFrameSize();
+
+		if(delay > 0.0)
+		{
+			// If diff > 0, skip samples. Don't skip more than a full update at once.
+			int skip = std::min(int(delay*samplerate)*framesize, len);
+			if(!decoder.FillSamples(buff, len))
+				return false;
+
+			// Offset the measured audio position to account for the skipped samples.
+			audioTrack.AdjustOffset(skip/framesize);
+
+			if(skip == len)
+				return decoder.FillSamples(buff, len);
+			memmove(buff, (char*)buff+skip, len-skip);
+			if(!decoder.FillSamples((char*)buff+len-skip, skip))
+				memset((char*)buff+len-skip, 0, skip);
+
+			return true;
+		}
+
+		if(delay < 0.0)
+		{
+			// If diff < 0, duplicate samples. Don't duplicate a full update (we need at
+			// least one new sample frame to duplicate).
+			int dup = std::min(int(-delay*samplerate)*framesize, len-framesize);
+			if(!decoder.FillSamples((char*)buff+dup, len-dup))
+				return false;
+
+			if(framesize == 1)
+				memset(buff, ((char*)buff)[dup], dup);
+			else
+			{
+				for(int i=0;i < dup;++i)
+					((char*)buff)[i] = ((char*)buff+dup)[i%framesize];
+			}
+
+			// Offset the measured audio position to account for the duplicated samples.
+			audioTrack.AdjustOffset(-dup/framesize);
+			return true;
+		}
+
+		return decoder.FillSamples(buff, len);
+	}
+	static bool StreamCallbackC(SoundStream *stream, void *buff, int len, void *userdata)
+	{ return static_cast<MvePlayer*>(userdata)->StreamCallback(stream, buff, len); }
 
 public:
 	bool isvalid() { return !failed; }
@@ -193,12 +331,27 @@ public:
 	bool Frame(uint64_t clock) override
 	{
 		if (failed) return false;
+
+		audioTrack.SetClock(clock);
 		bool playon = decoder.RunFrame(clock);
+		if (playon)
+		{
+			if (!audioTrack.GetAudioStream() && decoder.HasAudio())
+			{
+				S_StopMusic(true);
+				// start audio playback
+				if (!audioTrack.Start(decoder.GetSampleRate(), decoder.NumChannels(), MusicSamples16bit, StreamCallbackC, this))
+					decoder.DisableAudio();
+			}
+		}
+
 		return playon;
 	}
 
 	~MvePlayer()
 	{
+		audioTrack.Finish();
+
 		decoder.Close();
 	}
 
@@ -221,6 +374,9 @@ class VpxPlayer : public MoviePlayer
 	AnimTextures animtex;
 	const TArray<int> animSnd;
 
+	ZMusic_MusicStream MusicStream = nullptr;
+	MovieAudioTrack AudioTrack;
+
 	unsigned width, height;
 	TArray<uint8_t> Pic;
 	TArray<uint8_t> readBuf;
@@ -240,6 +396,56 @@ class VpxPlayer : public MoviePlayer
 public:
 	int soundtrack = -1;
 
+	bool StreamCallback(SoundStream *stream, void *buff, int len)
+	{
+		const double delay = AudioTrack.GetClockDiff(stream);
+		const int samplerate = AudioTrack.GetSampleRate();
+		const int framesize = AudioTrack.GetFrameSize();
+
+		if(delay > 0.0)
+		{
+			// If diff > 0, skip samples. Don't skip more than a full update at once.
+			int skip = std::min(int(delay*samplerate)*framesize, len);
+			if(!ZMusic_FillStream(MusicStream, buff, len))
+				return false;
+
+			// Offset the measured audio position to account for the skipped samples.
+			AudioTrack.AdjustOffset(skip/framesize);
+
+			if(skip == len)
+				return ZMusic_FillStream(MusicStream, buff, len);
+			memmove(buff, (char*)buff+skip, len-skip);
+			if(!ZMusic_FillStream(MusicStream, (char*)buff+len-skip, skip))
+				memset((char*)buff+len-skip, 0, skip);
+
+			return true;
+		}
+
+		if(delay < 0.0)
+		{
+			// If diff < 0, duplicate samples. Don't duplicate a full update (we need at
+			// least one new sample frame to duplicate).
+			int dup = std::min(int(-delay*samplerate)*framesize, len-framesize);
+			if(!ZMusic_FillStream(MusicStream, (char*)buff+dup, len-dup))
+				return false;
+
+			if(framesize == 1)
+				memset(buff, ((char*)buff)[dup], dup);
+			else
+			{
+				for(int i=0;i < dup;++i)
+					((char*)buff)[i] = ((char*)buff+dup)[i%framesize];
+			}
+
+			// Offset the measured audio position to account for the duplicated samples.
+			AudioTrack.AdjustOffset(-dup/framesize);
+			return true;
+		}
+
+		return ZMusic_FillStream(MusicStream, buff, len);
+	}
+	static bool StreamCallbackC(SoundStream *stream, void *buff, int len, void *userdata)
+	{ return static_cast<VpxPlayer*>(userdata)->StreamCallback(stream, buff, len); }
 
 public:
 	bool isvalid() { return !failed; }
@@ -405,9 +611,22 @@ public:
 
 	void Start() override
 	{
-		if (soundtrack > 0)
+		if (SoundStream *stream = AudioTrack.GetAudioStream())
 		{
-			S_ChangeMusic(fileSystem.GetFileFullName(soundtrack, false), 0, false);
+			stream->SetPaused(false);
+		}
+		else if (soundtrack >= 0)
+		{
+			S_StopMusic(true);
+			FileReader reader = fileSystem.OpenFileReader(soundtrack);
+			if (reader.isOpen())
+			{
+				MusicStream = ZMusic_OpenSong(GetMusicReader(reader), MDEV_DEFAULT, nullptr);
+			}
+			if (!MusicStream)
+			{
+				Printf(PRINT_BOLD, "Failed to decode %s\n", fileSystem.GetFileFullName(soundtrack, false));
+			}
 		}
 		animtex.SetSize(AnimTexture::YUV, width, height);
 	}
@@ -420,8 +639,10 @@ public:
 
 	bool Frame(uint64_t clock) override
 	{
+		AudioTrack.SetClock(clock);
+
 		bool stop = false;
-		if (clock > nextframetime)
+		if (clock >= nextframetime)
 		{
 			nextframetime += nsecsperframe;
 
@@ -436,6 +657,25 @@ public:
 			}
 			framenum++;
 			if (framenum >= numframes) stop = true;
+
+			if (!AudioTrack.GetAudioStream() && MusicStream)
+			{
+				bool ok = false;
+				SoundStreamInfo info{};
+				ZMusic_GetStreamInfo(MusicStream, &info);
+				// if mBufferSize == 0, the music stream is played externally (e.g.
+				// Windows' MIDI synth), which we can't keep synced. Play anyway?
+				if (info.mBufferSize > 0 && ZMusic_Start(MusicStream, 0, false))
+				{
+					ok = AudioTrack.Start(info.mSampleRate, abs(info.mNumChannels),
+						(info.mNumChannels < 0) ? MusicSamples16bit : MusicSamplesFloat, &StreamCallbackC, this);
+				}
+				if (!ok)
+				{
+					ZMusic_Close(MusicStream);
+					MusicStream = nullptr;
+				}
+			}
 
 			bool nostopsound = (flags & NOSOUNDCUTOFF);
 			int soundframe = convdenom ? Scale(framenum, convnumer, convdenom) : framenum;
@@ -461,15 +701,21 @@ public:
 		return !stop;
 	}
 
-	void Stop()
+	void Stop() override
 	{
-		S_StopMusic(true);
+		if (SoundStream *stream = AudioTrack.GetAudioStream())
+			stream->SetPaused(true);
 		bool nostopsound = (flags & NOSOUNDCUTOFF);
 		if (!nostopsound) soundEngine->StopAllChannels();
 	}
 
 	~VpxPlayer()
 	{
+		if(MusicStream)
+		{
+			AudioTrack.Finish();
+			ZMusic_Close(MusicStream);
+		}
 		vpx_codec_destroy(&codec);
 		animtex.Clean();
 	}
@@ -488,13 +734,10 @@ public:
 
 struct AudioData
 {
-	int hFx;
 	SmackerAudioInfo inf;
 
-	int16_t samples[6000 * 20]; // must be a multiple of the stream buffer size and larger than the initial chunk of audio
-
-	int nWrite;
-	int nRead;
+	int nWrite = 0;
+	int nRead = 0;
 };
 
 class SmkPlayer : public MoviePlayer
@@ -506,46 +749,119 @@ class SmkPlayer : public MoviePlayer
 	uint8_t palette[768];
 	AnimTextures animtex;
 	TArray<uint8_t> pFrame;
-	TArray<uint8_t> audioBuffer;
+	TArray<int16_t> audioBuffer;
 	int nFrames;
 	bool fullscreenScale;
 	uint64_t nFrameNs;
 	int nFrame = 0;
 	const TArray<int> animSnd;
 	FString filename;
-	SoundStream* stream = nullptr;
+	MovieAudioTrack AudioTrack;
 	bool hassound = false;
 
 public:
 	bool isvalid() { return hSMK.isValid; }
 
-	static bool StreamCallbackFunc(SoundStream* stream, void* buff, int len, void* userdata)
+	bool StreamCallback(SoundStream* stream, void* buff, int len)
 	{
-		SmkPlayer* pId = (SmkPlayer*)userdata;
-		memcpy(buff, &pId->adata.samples[pId->adata.nRead], len);
-		pId->adata.nRead += len / 2;
-		if (pId->adata.nRead >= (int)countof(pId->adata.samples)) pId->adata.nRead = 0;
+		const double delay = AudioTrack.GetClockDiff(stream);
+		const int samplerate = AudioTrack.GetSampleRate();
+		const int framesize = AudioTrack.GetFrameSize();
+
+		int avail = (adata.nWrite - adata.nRead) * 2;
+
+		if(delay > 0.0)
+		{
+			// If diff > 0, skip samples. Don't skip more than a full update at once.
+			int skip = std::min(int(delay*samplerate)*framesize, len);
+			while (skip > 0)
+			{
+				if (avail >= skip)
+				{
+					AudioTrack.AdjustOffset(skip / framesize);
+					if (avail > skip)
+					{
+						adata.nRead += skip / 2;
+						avail -= skip;
+					}
+					else
+						adata.nRead = adata.nWrite = avail = 0;
+					break;
+				}
+
+				AudioTrack.AdjustOffset(avail / framesize);
+				adata.nWrite = 0;
+				adata.nRead = 0;
+				skip -= avail;
+				avail = 0;
+
+				auto read = Smacker_GetAudioData(hSMK, 0, audioBuffer.Data());
+				if (read == 0) break;
+
+				adata.nWrite = read / 2;
+				avail = read;
+			}
+		}
+		else if(delay < 0.0)
+		{
+			// If diff < 0, duplicate samples. Don't duplicate more than a full update.
+			int dup = std::min(int(-delay*samplerate)*framesize, len-framesize);
+
+			if(avail == 0)
+			{
+				auto read = Smacker_GetAudioData(hSMK, 0, audioBuffer.Data());
+				if (read == 0) return false;
+
+				adata.nWrite = read / 2;
+				avail = read;
+			}
+
+			// Offset the measured audio position to account for the duplicated samples.
+			AudioTrack.AdjustOffset(-dup/framesize);
+
+			char *src = (char*)&audioBuffer[adata.nRead];
+			char *dst = (char*)buff;
+
+			for(int i=0;i < dup;++i)
+				*(dst++) = src[i%framesize];
+
+			buff = dst;
+			len -= dup;
+		}
+
+		int wrote = 0;
+		while(wrote < len)
+		{
+			if (avail == 0)
+			{
+				auto read = Smacker_GetAudioData(hSMK, 0, audioBuffer.Data());
+				if (read == 0)
+				{
+					if (wrote == 0)
+						return false;
+					break;
+				}
+
+				adata.nWrite = read / 2;
+				avail = read;
+			}
+
+			int todo = std::min(len-wrote, avail);
+
+			memcpy((char*)buff+wrote, &audioBuffer[adata.nRead], todo);
+			adata.nRead += todo / 2;
+			if(adata.nRead == adata.nWrite)
+				adata.nRead = adata.nWrite = 0;
+			avail -= todo;
+			wrote += todo;
+		}
+
+		if (wrote < len)
+			memset((char*)buff+wrote, 0, len-wrote);
 		return true;
 	}
-
-	void copy8bitSamples(unsigned count)
-	{
-		for (unsigned i = 0; i < count; i++)
-		{
-			adata.samples[adata.nWrite] = (audioBuffer[i] - 128) << 8;
-			if (++adata.nWrite >= (int)countof(adata.samples)) adata.nWrite = 0;
-		}
-	}
-
-	void copy16bitSamples(unsigned count)
-	{
-		auto ptr = (uint16_t*)audioBuffer.Data();
-		for (unsigned i = 0; i < count/2; i++)
-		{
-			adata.samples[adata.nWrite] = *ptr++;
-			if (++adata.nWrite >= (int)countof(adata.samples)) adata.nWrite = 0;
-		}
-	}
+	static bool StreamCallbackC(SoundStream* stream, void* buff, int len, void* userdata)
+	{ return static_cast<SmkPlayer*>(userdata)->StreamCallback(stream, buff, len); }
 
 
 	SmkPlayer(const char *fn, TArray<int>& ans, int flags_) : animSnd(std::move(ans))
@@ -564,25 +880,26 @@ public:
 		Smacker_GetPalette(hSMK, palette);
 
 		numAudioTracks = Smacker_GetNumAudioTracks(hSMK);
-		if (numAudioTracks)
+		if (numAudioTracks && SoundEnabled())
 		{
 			adata.nWrite = 0;
 			adata.nRead = 0;
 			adata.inf = Smacker_GetAudioTrackDetails(hSMK, 0);
 			if (adata.inf.idealBufferSize > 0)
 			{
-				audioBuffer.Resize(adata.inf.idealBufferSize);
-				auto read = Smacker_GetAudioData(hSMK, 0, (int16_t*)audioBuffer.Data());
-				if (adata.inf.bitsPerSample == 8) copy8bitSamples(read);
-				else copy16bitSamples(read);
+				audioBuffer.Resize(adata.inf.idealBufferSize / 2);
 				hassound = true;
 			}
+			for (int i = 1;i < numAudioTracks;++i)
+				Smacker_DisableAudioTrack(hSMK, i);
+			numAudioTracks = 1;
 		}
 		if (!hassound)
 		{
 			adata.inf = {};
+			Smacker_DisableAudioTrack(hSMK, 0);
+			numAudioTracks = 0;
 		}
-
 	}
 
 	//---------------------------------------------------------------------------
@@ -594,6 +911,8 @@ public:
 	void Start() override
 	{
 		animtex.SetSize(AnimTexture::Paletted, nWidth, nHeight);
+		if (SoundStream *stream = AudioTrack.GetAudioStream())
+			stream->SetPaused(false);
 	}
 
 	//---------------------------------------------------------------------------
@@ -604,30 +923,29 @@ public:
 
 	bool Frame(uint64_t clock) override
 	{
+		AudioTrack.SetClock(clock);
 		int frame = int(clock / nFrameNs);
 
 		twod->ClearScreen();
-		if (frame > nFrame)
-		{
-			Smacker_GetPalette(hSMK, palette);
-			Smacker_GetFrame(hSMK, pFrame.Data());
-			animtex.SetFrame(palette, pFrame.Data());
-			if (numAudioTracks && SoundEnabled())
-			{
-				auto read = Smacker_GetAudioData(hSMK, 0, (int16_t*)audioBuffer.Data());
-				if (adata.inf.bitsPerSample == 8) copy8bitSamples(read);
-				else copy16bitSamples(read);
-				if (!stream && read) // the sound may not start in the first frame, but the stream cannot start without any sound data present.
-					stream = S_CreateCustomStream(6000, adata.inf.sampleRate, adata.inf.nChannels, StreamCallbackFunc, this);
-
-			}
-
-		}
-
-		if (frame > nFrame)
+		if (frame >= nFrame)
 		{
 			nFrame++;
 			Smacker_GetNextFrame(hSMK);
+			Smacker_GetPalette(hSMK, palette);
+			Smacker_GetFrame(hSMK, pFrame.Data());
+			animtex.SetFrame(palette, pFrame.Data());
+
+			if (!AudioTrack.GetAudioStream() && numAudioTracks)
+			{
+				S_StopMusic(true);
+
+				if (!AudioTrack.Start(adata.inf.sampleRate, adata.inf.nChannels, MusicSamples16bit, StreamCallbackC, this))
+				{
+					Smacker_DisableAudioTrack(hSMK, 0);
+					numAudioTracks = 0;
+				}
+			}
+
 			bool nostopsound = (flags & NOSOUNDCUTOFF);
 			if (!hassound) for (unsigned i = 0; i < animSnd.Size(); i += 2)
 			{
@@ -647,13 +965,15 @@ public:
 
 	void Stop() override
 	{
-		if (stream) S_StopCustomStream(stream);
+		if (SoundStream *stream = AudioTrack.GetAudioStream())
+			stream->SetPaused(true);
 		bool nostopsound = (flags & NOSOUNDCUTOFF);
 		if (!nostopsound && !hassound) soundEngine->StopAllChannels();
 	}
 
 	~SmkPlayer()
 	{
+		AudioTrack.Finish();
 		Smacker_Close(hSMK);
 		animtex.Clean();
 	}

--- a/src/common/cutscenes/playmve.cpp
+++ b/src/common/cutscenes/playmve.cpp
@@ -89,31 +89,112 @@ static const int16_t delta_table[] = {
 };
 
 
-// macro to fetch 16-bit little-endian words from a bytestream
-#define LE_16(x)  ((*x) | ((*(x+1)) << 8))
+// macros to fetch little-endian words from a bytestream
+#define LE_16(x)  ((uint16_t)((*(x)) | ((*((x)+1)) << 8)))
+#define LE_32(x)  (LE_16(x) | ((uint32_t)LE_16(x+2) << 16))
+#define LE_64(x)  (LE_32(x) | ((uint64_t)LE_32(x+4) << 32))
 
-static bool StreamCallbackFunc(SoundStream* stream, void* buff, int len, void* userdata)
+
+bool InterplayDecoder::FillSamples(void *buff, int len)
 {
-    InterplayDecoder* pId = (InterplayDecoder*)userdata;
-    memcpy(buff, &pId->audio.samples[pId->audio.nRead], len);
-    pId->audio.nRead += len / 2;
-    if (pId->audio.nRead >= (int)countof(pId->audio.samples)) pId->audio.nRead = 0;
+    for (int i = 0; i < len;)
+    {
+        if(audio.nRead < audio.nWrite)
+        {
+            int todo = std::min(audio.nWrite-audio.nRead, (len-i) / 2);
+            memcpy((char*)buff+i, &audio.samples[audio.nRead], todo*2);
+            audio.nRead += todo;
+            if (audio.nRead == audio.nWrite)
+                audio.nRead = audio.nWrite = 0;
+            i += todo*2;
+            continue;
+        }
+
+        std::unique_lock plock(PacketMutex);
+        while (audio.Packets.empty())
+        {
+            if (!bIsPlaying || ProcessNextChunk() >= CHUNK_SHUTDOWN)
+            {
+                bIsPlaying = false;
+                if (i == 0)
+                    return false;
+                memset((char*)buff+i, 0, len-i);
+                return true;
+            }
+        }
+        AudioPacket pkt = std::move(audio.Packets.front());
+        audio.Packets.pop_front();
+        plock.unlock();
+
+        int nSamples = pkt.nSize;
+        const uint8_t *samplePtr = pkt.pData.get();
+        if (audio.bCompressed)
+        {
+            int predictor[2];
+
+            for (int ch = 0; ch < audio.nChannels; ch++)
+            {
+                predictor[ch] = (int16_t)LE_16(samplePtr);
+                samplePtr += 2;
+
+                audio.samples[audio.nWrite++] = predictor[ch];
+            }
+
+            bool stereo = audio.nChannels == 2;
+            nSamples -= 2*audio.nChannels;
+            nSamples &= ~(int)stereo;
+
+            int ch = 0;
+            for (int j = 0; j < nSamples; ++j)
+            {
+                predictor[ch] += delta_table[*samplePtr++];
+                predictor[ch] = clamp(predictor[ch], -32768, 32767);
+
+                audio.samples[audio.nWrite++] = predictor[ch];
+
+                // toggle channel
+                ch ^= stereo;
+            }
+        }
+        else if (audio.nBitDepth == 8)
+        {
+            for (int j = 0; j < nSamples; ++j)
+                audio.samples[audio.nWrite++] = ((*samplePtr++)-128) << 8;
+        }
+        else
+        {
+            nSamples /= 2;
+            for (int j = 0; j < nSamples; ++j)
+            {
+                audio.samples[audio.nWrite++] = (int16_t)LE_16(samplePtr);
+                samplePtr += 2;
+            }
+        }
+    }
     return true;
 }
+
+void InterplayDecoder::DisableAudio()
+{
+    if (bAudioEnabled)
+    {
+        std::unique_lock plock(PacketMutex);
+        bAudioEnabled = false;
+        audio.Packets.clear();
+    }
+}
+
 
 InterplayDecoder::InterplayDecoder(bool soundenabled)
 {
     bIsPlaying = false;
-    bAudioStarted = !soundenabled;  // This prevents the stream from getting created
+    bAudioEnabled = soundenabled;
 
     nWidth  = 0;
     nHeight = 0;
     nFrame  = 0;
 
     memset(palette, 0, sizeof(palette));
-    memset(&audio, 0, sizeof(audio));
-    audio.nRead = 18000;    // skip the initial silence. This is needed to sync audio and video because OpenAL's lag is a bit on the high side.
-
 
     nFps = 0.0;
     nFrameDuration = 0;
@@ -144,13 +225,277 @@ void InterplayDecoder::SwapFrames()
     nCurrentVideoBuffer = t;
 }
 
+int InterplayDecoder::ProcessNextChunk()
+{
+    uint8_t chunkPreamble[CHUNK_PREAMBLE_SIZE];
+    if (fr.Read(chunkPreamble, CHUNK_PREAMBLE_SIZE) != CHUNK_PREAMBLE_SIZE) {
+        Printf(TEXTCOLOR_RED "InterplayDecoder: could not read from file (EOF?)\n");
+        return CHUNK_EOF;
+    }
+
+    int chunkSize = LE_16(&chunkPreamble[0]);
+    int chunkType = LE_16(&chunkPreamble[2]);
+
+    ChunkData.resize(chunkSize);
+    if (fr.Read(ChunkData.data(), chunkSize) != chunkSize) {
+        Printf(TEXTCOLOR_RED "InterplayDecoder: could not read from file (EOF?)\n");
+        return CHUNK_BAD;
+    }
+
+    const uint8_t *palPtr = nullptr;
+    const uint8_t *mapPtr = nullptr;
+    const uint8_t *vidPtr = nullptr;
+    int palStart = 0, palCount = 0;
+    int mapSize = 0, vidSize = 0;
+
+    // iterate through individual opcodes
+    const uint8_t *chunkPtr = ChunkData.data();
+    while (chunkSize > 0 && chunkType != CHUNK_BAD)
+    {
+        if (chunkSize < OPCODE_PREAMBLE_SIZE)
+        {
+            Printf(TEXTCOLOR_RED "InterplayDecoder: opcode size too small\n");
+            return CHUNK_BAD;
+        }
+        int opcodeSize = LE_16(chunkPtr);
+        int opcodeType = chunkPtr[2];
+        int opcodeVersion = chunkPtr[3];
+
+        chunkPtr += OPCODE_PREAMBLE_SIZE;
+        chunkSize -= OPCODE_PREAMBLE_SIZE;
+        if (chunkSize < opcodeSize)
+        {
+            Printf(TEXTCOLOR_RED "InterplayDecoder: opcode size too large for chunk\n");
+            return CHUNK_BAD;
+        }
+        chunkSize -= opcodeSize;
+
+        switch (opcodeType)
+        {
+        case OPCODE_END_OF_STREAM:
+            chunkPtr += opcodeSize;
+            break;
+
+        case OPCODE_END_OF_CHUNK:
+            chunkPtr += opcodeSize;
+            break;
+
+        case OPCODE_CREATE_TIMER:
+            nTimerRate = LE_32(chunkPtr);
+            nTimerDiv  = LE_16(chunkPtr+4);
+            chunkPtr += 6;
+            nFrameDuration = ((uint64_t)nTimerRate * nTimerDiv) * 1000;
+            break;
+
+        case OPCODE_INIT_AUDIO_BUFFERS:
+        {
+            // Skip 2 bytes
+            uint16_t flags = LE_16(chunkPtr+2);
+            audio.nSampleRate = LE_16(chunkPtr+4);
+            chunkPtr += 6;
+
+            uint32_t nBufferBytes = (opcodeVersion == 0) ? LE_16(chunkPtr) : LE_32(chunkPtr);
+            chunkPtr += (opcodeVersion == 0) ? 2 : 4;
+
+            audio.nChannels = (flags & 0x1) ? 2 : 1;
+            audio.nBitDepth = (flags & 0x2) ? 16 : 8;
+            audio.bCompressed = (opcodeVersion > 0 && (flags & 0x4));
+            audio.samples = std::make_unique<int16_t[]>(nBufferBytes / (audio.nBitDepth/8));
+            audio.nRead = audio.nWrite = 0;
+            break;
+        }
+
+        case OPCODE_START_STOP_AUDIO:
+            chunkPtr += opcodeSize;
+            break;
+
+        case OPCODE_INIT_VIDEO_BUFFERS:
+        {
+            assert(((opcodeVersion == 0 && opcodeSize >= 4) ||
+                (opcodeVersion == 1 && opcodeSize >= 6) ||
+                (opcodeVersion == 2 && opcodeSize >= 8)) &&
+                opcodeSize <= 8 && ! videoStride);
+
+            nWidth  = LE_16(chunkPtr) * 8;
+            nHeight = LE_16(chunkPtr+2) * 8;
+
+            int count, truecolour;
+            if (opcodeVersion > 0)
+            {
+                count = LE_16(chunkPtr+4);
+                if (opcodeVersion > 1)
+                {
+                    truecolour = LE_16(chunkPtr+6);
+                    assert(truecolour == 0);
+                }
+            }
+            chunkPtr += opcodeSize;
+
+            pVideoBuffers[0] = new uint8_t[nWidth * nHeight];
+            pVideoBuffers[1] = new uint8_t[nWidth * nHeight];
+
+            videoStride = nWidth;
+
+            animtex.SetSize(AnimTexture::Paletted, nWidth, nHeight);
+            break;
+        }
+
+        case OPCODE_UNKNOWN_06:
+        case OPCODE_UNKNOWN_0E:
+        case OPCODE_UNKNOWN_10:
+        case OPCODE_UNKNOWN_12:
+        case OPCODE_UNKNOWN_13:
+        case OPCODE_UNKNOWN_14:
+        case OPCODE_UNKNOWN_15:
+            chunkPtr += opcodeSize;
+            break;
+
+        case OPCODE_SEND_BUFFER:
+            //int nPalStart = LE_16(chunkPtr);
+            //int nPalCount = LE_16(chunkPtr+2);
+
+            {
+                VideoPacket pkt;
+                pkt.pData = std::make_unique<uint8_t[]>(palCount*3 + mapSize + vidSize);
+                pkt.nPalStart = palStart;
+                pkt.nPalCount = palCount;
+                pkt.nDecodeMapSize = mapSize;
+                pkt.nVideoDataSize = vidSize;
+
+                if (palPtr)
+                    memcpy(pkt.pData.get(), palPtr, palCount*3);
+                if (mapPtr)
+                    memcpy(pkt.pData.get() + palCount*3, mapPtr, mapSize);
+                if (vidPtr)
+                    memcpy(pkt.pData.get() + palCount*3 + mapSize, vidPtr, vidSize);
+                pkt.bSendFlag = true;
+                VideoPackets.emplace_back(std::move(pkt));
+            }
+
+            palPtr = nullptr;
+            palStart = palCount = 0;
+            mapPtr = nullptr;
+            mapSize = 0;
+            vidPtr = nullptr;
+            vidSize = 0;
+
+            chunkPtr += opcodeSize;
+            break;
+
+        case OPCODE_AUDIO_FRAME:
+        {
+            uint16_t seqIndex   = LE_16(chunkPtr);
+            uint16_t streamMask = LE_16(chunkPtr+2);
+            uint16_t nSamples   = LE_16(chunkPtr+4); // number of samples this chunk(?)
+            chunkPtr += 6;
+
+            // We only bother with stream 0
+            if (!(streamMask & 1) || !bAudioEnabled)
+            {
+                chunkPtr += opcodeSize - 6;
+                break;
+            }
+
+            AudioPacket pkt;
+            pkt.nSize = opcodeSize - 6;
+            pkt.pData = std::make_unique<uint8_t[]>(pkt.nSize);
+            memcpy(pkt.pData.get(), chunkPtr, pkt.nSize);
+            audio.Packets.emplace_back(std::move(pkt));
+
+            chunkPtr += opcodeSize - 6;
+            break;
+        }
+
+        case OPCODE_SILENCE_FRAME:
+            chunkPtr += opcodeSize;
+            break;
+
+        case OPCODE_INIT_VIDEO_MODE:
+            chunkPtr += opcodeSize;
+            break;
+
+        case OPCODE_CREATE_GRADIENT:
+            chunkPtr += opcodeSize;
+            Printf("InterplayDecoder: Create gradient not supported.\n");
+            break;
+
+        case OPCODE_SET_PALETTE:
+            if (opcodeSize > 0x304 || opcodeSize < 4) {
+                Printf("set_palette opcode with invalid size\n");
+                chunkType = CHUNK_BAD;
+                break;
+            }
+
+            palStart = LE_16(chunkPtr);
+            palCount = LE_16(chunkPtr+2);
+            palPtr = chunkPtr + 4;
+            if (palStart > 255 || palStart+palCount > 256) {
+                Printf("set_palette indices out of range (%d -> %d)\n", palStart, palStart+palCount-1);
+                chunkType = CHUNK_BAD;
+                break;
+            }
+            if (opcodeSize-4 < palCount*3) {
+                Printf("set_palette opcode too small (%d < %d)\n", opcodeSize-4, palCount*3);
+                chunkType = CHUNK_BAD;
+                break;
+            }
+
+            chunkPtr += opcodeSize;
+            break;
+
+        case OPCODE_SET_PALETTE_COMPRESSED:
+            chunkPtr += opcodeSize;
+            Printf("InterplayDecoder: Set palette compressed not supported.\n");
+            break;
+
+        case OPCODE_SET_DECODING_MAP:
+            mapPtr = chunkPtr;
+            mapSize = opcodeSize;
+
+            chunkPtr += opcodeSize;
+            break;
+
+        case OPCODE_VIDEO_DATA:
+            vidPtr = chunkPtr;
+            vidSize = opcodeSize;
+
+            chunkPtr += opcodeSize;
+            break;
+
+        default:
+            Printf("InterplayDecoder: Unknown opcode (0x%x v%d, %d bytes).\n", opcodeType, opcodeVersion, opcodeSize);
+            chunkPtr += opcodeSize;
+            break;
+        }
+    }
+
+    if (chunkType < CHUNK_SHUTDOWN && (palPtr || mapPtr || vidPtr))
+    {
+        VideoPacket pkt;
+        pkt.pData = std::make_unique<uint8_t[]>(palCount*3 + mapSize + vidSize);
+        pkt.nPalStart = palStart;
+        pkt.nPalCount = palCount;
+        pkt.nDecodeMapSize = mapSize;
+        pkt.nVideoDataSize = vidSize;
+
+        if (palPtr)
+            memcpy(pkt.pData.get(), palPtr, palCount*3);
+        if(mapPtr)
+            memcpy(pkt.pData.get() + palCount*3, mapPtr, mapSize);
+        if(vidPtr)
+            memcpy(pkt.pData.get() + palCount*3 + mapSize, vidPtr, vidSize);
+        pkt.bSendFlag = false;
+        VideoPackets.emplace_back(std::move(pkt));
+    }
+
+    return chunkType;
+}
+
+
 void InterplayDecoder::Close()
 {
-    fr.Close();
     bIsPlaying = false;
-    if (stream)
-        S_StopCustomStream(stream);
-    stream = nullptr;
+    fr.Close();
 
     if (decodeMap.pData) {
         delete[] decodeMap.pData;
@@ -185,373 +530,191 @@ bool InterplayDecoder::Open(FileReader &fr_)
     fr_.Seek(6, FileReader::SeekCur);
     fr = std::move(fr_);
 
-    //Run();
+    if (ProcessNextChunk() != CHUNK_INIT_VIDEO)
+    {
+        Printf(TEXTCOLOR_RED "InterplayDecoder: First chunk not CHUNK_INIT_VIDEO\n");
+        return false;
+    }
+
+    uint8_t chunkPreamble[CHUNK_PREAMBLE_SIZE];
+    if (fr.Read(chunkPreamble, CHUNK_PREAMBLE_SIZE) != CHUNK_PREAMBLE_SIZE) {
+        Printf(TEXTCOLOR_RED "InterplayDecoder: could not read from file (EOF?)\n");
+        return false;
+    }
+    fr.Seek(-CHUNK_PREAMBLE_SIZE, FileReader::SeekCur);
+
+    int chunkType = LE_16(&chunkPreamble[2]);
+    if (chunkType == CHUNK_VIDEO)
+        bAudioEnabled = false;
+    else
+    {
+        if (ProcessNextChunk() != CHUNK_INIT_AUDIO)
+        {
+            Printf(TEXTCOLOR_RED "InterplayDecoder: Second non-video chunk not CHUNK_INIT_AUDIO\n");
+            return false;
+        }
+        bAudioEnabled = audio.nSampleRate > 0;
+    }
+
+    bIsPlaying = true;
 
     return true;
 }
 
 bool InterplayDecoder::RunFrame(uint64_t clock)
 {
-    uint8_t chunkPreamble[CHUNK_PREAMBLE_SIZE];
-    uint8_t opcodePreamble[OPCODE_PREAMBLE_SIZE];
-    uint8_t opcodeType;
-    uint8_t opcodeVersion;
-    int opcodeSize, chunkSize;
-    int chunkType = 0;
+    // handle timing - wait until we're ready to process the next frame.
+    if (nNextFrameTime > clock) {
+        return true;
+    }
+    nNextFrameTime += nFrameDuration;
 
-    // iterate through the chunks in the file
+    bool doFrame = false;
     do
     {
-        // handle timing - wait until we're ready to process the next frame.
-        if (nNextFrameTime > clock) {
-            return true;
-        }
-        else {
-            nNextFrameTime += nFrameDuration;
-        }
-
-        if (fr.Read(chunkPreamble, CHUNK_PREAMBLE_SIZE) != CHUNK_PREAMBLE_SIZE) {
-            Printf(TEXTCOLOR_RED "InterplayDecoder: could not read from file (EOF?)\n");
-            return false;
-        }
-
-        chunkSize = LE_16(&chunkPreamble[0]);
-        chunkType = LE_16(&chunkPreamble[2]);
-
-        // iterate through individual opcodes
-        while (chunkSize > 0)
+        std::unique_lock plock(PacketMutex);
+        while (VideoPackets.empty())
         {
-            if (fr.Read(opcodePreamble, OPCODE_PREAMBLE_SIZE) != OPCODE_PREAMBLE_SIZE)
+            if (!bIsPlaying || ProcessNextChunk() >= CHUNK_SHUTDOWN)
             {
-                Printf(TEXTCOLOR_RED "InterplayDecoder: could not read from file (EOF?)\n");
+                bIsPlaying = false;
                 return false;
             }
+        }
+        VideoPacket pkt = std::move(VideoPackets.front());
+        VideoPackets.pop_front();
+        plock.unlock();
 
-            opcodeSize = LE_16(&opcodePreamble[0]);
-            opcodeType = opcodePreamble[2];
-            opcodeVersion = opcodePreamble[3];
+        const uint8_t *palData = pkt.pData.get();
+        const uint8_t *mapData = palData + pkt.nPalCount*3;
+        const uint8_t *vidData = mapData + pkt.nDecodeMapSize;
 
-            chunkSize -= OPCODE_PREAMBLE_SIZE;
-            chunkSize -= opcodeSize;
-
-            switch (opcodeType)
+        if (pkt.nPalCount > 0)
+        {
+            int nPalEnd = pkt.nPalStart + pkt.nPalCount;
+            for (int i = pkt.nPalStart; i < nPalEnd; i++)
             {
-            case OPCODE_END_OF_STREAM:
-            {
-                fr.Seek(opcodeSize, FileReader::SeekCur);
-                break;
-            }
-
-            case OPCODE_END_OF_CHUNK:
-            {
-                fr.Seek(opcodeSize, FileReader::SeekCur);
-                break;
-            }
-
-            case OPCODE_CREATE_TIMER:
-            {
-                nTimerRate = fr.ReadUInt32();
-                nTimerDiv  = fr.ReadUInt16();
-                nFrameDuration = ((uint64_t)nTimerRate * nTimerDiv) * 1000;
-                break;
-            }
-
-            case OPCODE_INIT_AUDIO_BUFFERS:
-            {
-                fr.Seek(2, FileReader::SeekCur);
-                uint16_t flags = fr.ReadUInt16();
-                audio.nSampleRate = fr.ReadUInt16();
-
-                uint32_t nBufferBytes;
-
-                if (opcodeVersion == 0) {
-                    nBufferBytes = fr.ReadUInt16();
-                }
-                else {
-                    nBufferBytes = fr.ReadUInt32();
-                }
-
-                if (flags & 0x1) {
-                    audio.nChannels = 2;
-                }
-                else {
-                    audio.nChannels = 1;
-                }
-                if (flags & 0x2) {
-                    audio.nBitDepth = 16;
-                }
-                else {
-                    audio.nBitDepth = 8;
-                }
-                break;
-            }
-
-            case OPCODE_START_STOP_AUDIO:
-            {
-                if (!bAudioStarted)
-                {
-                    // start audio playback
-                    stream = S_CreateCustomStream(6000, audio.nSampleRate, audio.nChannels, StreamCallbackFunc, this);
-                    bAudioStarted = true;
-                }
-
-                fr.Seek(opcodeSize, FileReader::SeekCur);
-                break;
-            }
-
-            case OPCODE_INIT_VIDEO_BUFFERS:
-            {
-                assert(opcodeSize == 8);
-                nWidth  = fr.ReadUInt16() * 8;
-                nHeight = fr.ReadUInt16() * 8;
-
-                int count = fr.ReadUInt16();
-                int truecolour = fr.ReadUInt16();
-                assert(truecolour == 0);
-
-                pVideoBuffers[0] = new uint8_t[nWidth * nHeight];
-                pVideoBuffers[1] = new uint8_t[nWidth * nHeight];
-
-                videoStride = nWidth;
-
-                animtex.SetSize(AnimTexture::Paletted, nWidth, nHeight);
-                break;
-            }
-
-            case OPCODE_UNKNOWN_06:
-            case OPCODE_UNKNOWN_0E:
-            case OPCODE_UNKNOWN_10:
-            case OPCODE_UNKNOWN_12:
-            case OPCODE_UNKNOWN_13:
-            case OPCODE_UNKNOWN_14:
-            case OPCODE_UNKNOWN_15:
-            {
-                fr.Seek(opcodeSize, FileReader::SeekCur);
-                break;
-            }
-
-            case OPCODE_SEND_BUFFER:
-            {
-                int nPalStart = fr.ReadUInt16();
-                int nPalCount = fr.ReadUInt16();
-
-                animtex.SetFrame(&palette[0].r , GetCurrentFrame());
-
-                nFrame++;
-                SwapFrames();
-
-                fr.Seek(opcodeSize-4, FileReader::SeekCur);
-                break;
-            }
-
-            case OPCODE_AUDIO_FRAME:
-            {
-                int nStart = (int)fr.Tell();
-                uint16_t seqIndex   = fr.ReadUInt16();
-                uint16_t streamMask = fr.ReadUInt16();
-                uint16_t nSamples   = fr.ReadUInt16(); // number of samples this chunk
-
-                int predictor[2];
-                int i = 0;
-
-                for (int ch = 0; ch < audio.nChannels; ch++)
-                {
-                    predictor[ch] = fr.ReadUInt16();
-                    i++;
-
-                    if (predictor[ch] & 0x8000) {
-                        predictor[ch] |= 0xFFFF0000; // sign extend
-                    }
-
-                    audio.samples[audio.nWrite++] = predictor[ch];
-                    if (audio.nWrite >= (int)countof(audio.samples)) audio.nWrite = 0;
-                }
-
-                int ch = 0;
-                for (; i < (nSamples / 2); i++)
-                {
-                    predictor[ch] += delta_table[fr.ReadUInt8()];
-                    predictor[ch] = clamp(predictor[ch], -32768, 32768);
-
-                    audio.samples[audio.nWrite++] = predictor[ch];
-                    if (audio.nWrite >= (int)countof(audio.samples)) audio.nWrite = 0;
-
-                    // toggle channel
-                    ch ^= audio.nChannels - 1;
-                }
-
-                int nEnd = (int)fr.Tell();
-                int nRead = nEnd - nStart;
-                assert(opcodeSize == nRead);
-                break;
-            }
-
-            case OPCODE_SILENCE_FRAME:
-            {
-                uint16_t seqIndex = fr.ReadUInt16();
-                uint16_t streamMask = fr.ReadUInt16();
-                uint16_t nStreamLen = fr.ReadUInt16();
-                break;
-            }
-
-            case OPCODE_INIT_VIDEO_MODE:
-            {
-                fr.Seek(opcodeSize, FileReader::SeekCur);
-                break;
-            }
-
-            case OPCODE_CREATE_GRADIENT:
-            {
-                fr.Seek(opcodeSize, FileReader::SeekCur);
-                Printf("InterplayDecoder: Create gradient not supported.\n");
-                break;
-            }
-
-            case OPCODE_SET_PALETTE:
-            {
-                if (opcodeSize > 0x304 || opcodeSize < 4) {
-                    Printf("set_palette opcode with invalid size\n");
-                    chunkType = CHUNK_BAD;
-                    break;
-                }
-
-                int nPalStart = fr.ReadUInt16();
-                int nPalCount = fr.ReadUInt16();
-                for (int i = nPalStart; i <= nPalCount; i++)
-                {
-                    palette[i].r = fr.ReadUInt8() << 2;
-                    palette[i].g = fr.ReadUInt8() << 2;
-                    palette[i].b = fr.ReadUInt8() << 2;
-                }
-                break;
-            }
-
-            case OPCODE_SET_PALETTE_COMPRESSED:
-            {
-                fr.Seek(opcodeSize, FileReader::SeekCur);
-                Printf("InterplayDecoder: Set palette compressed not supported.\n");
-                break;
-            }
-
-            case OPCODE_SET_DECODING_MAP:
-            {
-                if (!decodeMap.pData)
-                {
-                    decodeMap.pData = new uint8_t[opcodeSize];
-                    decodeMap.nSize = opcodeSize;
-                }
-                else
-                {
-                    if (opcodeSize != (int)decodeMap.nSize) {
-                        delete[] decodeMap.pData;
-                        decodeMap.pData = new uint8_t[opcodeSize];
-                        decodeMap.nSize = opcodeSize;
-                    }
-                }
-
-                int nRead = (int)fr.Read(decodeMap.pData, opcodeSize);
-                assert(nRead == opcodeSize);
-                break;
-            }
-
-            case OPCODE_VIDEO_DATA:
-            {
-                int nStart = (int)fr.Tell();
-
-                // need to skip 14 bytes
-                fr.Seek(14, FileReader::SeekCur);
-
-                if (decodeMap.nSize)
-                {
-                    int i = 0;
-
-                    for (uint32_t y = 0; y < nHeight; y += 8)
-                    {
-                        for (uint32_t x = 0; x < nWidth; x += 8)
-                        {
-                            uint32_t opcode;
-
-                            // alternate between getting low and high 4 bits
-                            if (i & 1) {
-                                opcode = decodeMap.pData[i >> 1] >> 4;
-                            }
-                            else {
-                                opcode = decodeMap.pData[i >> 1] & 0x0F;
-                            }
-                            i++;
-
-                            int32_t offset = x + (y * videoStride);
-
-                            switch (opcode)
-                            {
-                                default:
-                                    break;
-                                case 0:
-                                    DecodeBlock0(offset);
-                                    break;
-                                case 1:
-                                    DecodeBlock1(offset);
-                                    break;
-                                case 2:
-                                    DecodeBlock2(offset);
-                                    break;
-                                case 3:
-                                    DecodeBlock3(offset);
-                                    break;
-                                case 4:
-                                    DecodeBlock4(offset);
-                                    break;
-                                case 5:
-                                    DecodeBlock5(offset);
-                                    break;
-                                case 7:
-                                    DecodeBlock7(offset);
-                                    break;
-                                case 8:
-                                    DecodeBlock8(offset);
-                                    break;
-                                case 9:
-                                    DecodeBlock9(offset);
-                                    break;
-                                case 10:
-                                    DecodeBlock10(offset);
-                                    break;
-                                case 11:
-                                    DecodeBlock11(offset);
-                                    break;
-                                case 12:
-                                    DecodeBlock12(offset);
-                                    break;
-                                case 13:
-                                    DecodeBlock13(offset);
-                                    break;
-                                case 14:
-                                    DecodeBlock14(offset);
-                                    break;
-                                case 15:
-                                    DecodeBlock15(offset);
-                                    break;
-                            }
-                        }
-                    }
-                }
-
-                int nEnd = (int)fr.Tell();
-                int nSkipBytes = opcodeSize - (nEnd - nStart); // we can end up with 1 byte left we need to skip
-                assert(nSkipBytes <= 1);
-
-                fr.Seek(nSkipBytes, FileReader::SeekCur);
-                break;
-            }
-
-            default:
-                break;
+                palette[i].r = (*palData++) << 2;
+                palette[i].g = (*palData++) << 2;
+                palette[i].b = (*palData++) << 2;
+                palette[i].r |= palette[i].r >> 6;
+                palette[i].g |= palette[i].g >> 6;
+                palette[i].b |= palette[i].b >> 6;
             }
         }
 
-    }
-    while (chunkType < CHUNK_VIDEO && bIsPlaying);
-    return chunkType != CHUNK_END;
+        if (pkt.nDecodeMapSize > 0)
+        {
+            if (!decodeMap.pData)
+            {
+                decodeMap.pData = new uint8_t[pkt.nDecodeMapSize];
+                decodeMap.nSize = pkt.nDecodeMapSize;
+            }
+            else
+            {
+                if (pkt.nDecodeMapSize != decodeMap.nSize) {
+                    delete[] decodeMap.pData;
+                    decodeMap.pData = new uint8_t[pkt.nDecodeMapSize];
+                    decodeMap.nSize = pkt.nDecodeMapSize;
+                }
+            }
+
+            memcpy(decodeMap.pData, mapData, pkt.nDecodeMapSize);
+        }
+
+        if (pkt.nVideoDataSize > 0 && decodeMap.nSize > 0)
+        {
+            auto pStart = vidData;
+
+            // need to skip 14 bytes
+            ChunkPtr = pStart + 14;
+
+            int i = 0;
+            for (uint32_t y = 0; y < nHeight; y += 8)
+            {
+                for (uint32_t x = 0; x < nWidth; x += 8)
+                {
+                    uint32_t opcode;
+
+                    // alternate between getting low and high 4 bits
+                    if (i & 1) {
+                        opcode = decodeMap.pData[i >> 1] >> 4;
+                    }
+                    else {
+                        opcode = decodeMap.pData[i >> 1] & 0x0F;
+                    }
+                    i++;
+
+                    int32_t offset = x + (y * videoStride);
+
+                    switch (opcode)
+                    {
+                        default:
+                            break;
+                        case 0:
+                            DecodeBlock0(offset);
+                            break;
+                        case 1:
+                            DecodeBlock1(offset);
+                            break;
+                        case 2:
+                            DecodeBlock2(offset);
+                            break;
+                        case 3:
+                            DecodeBlock3(offset);
+                            break;
+                        case 4:
+                            DecodeBlock4(offset);
+                            break;
+                        case 5:
+                            DecodeBlock5(offset);
+                            break;
+                        case 7:
+                            DecodeBlock7(offset);
+                            break;
+                        case 8:
+                            DecodeBlock8(offset);
+                            break;
+                        case 9:
+                            DecodeBlock9(offset);
+                            break;
+                        case 10:
+                            DecodeBlock10(offset);
+                            break;
+                        case 11:
+                            DecodeBlock11(offset);
+                            break;
+                        case 12:
+                            DecodeBlock12(offset);
+                            break;
+                        case 13:
+                            DecodeBlock13(offset);
+                            break;
+                        case 14:
+                            DecodeBlock14(offset);
+                            break;
+                        case 15:
+                            DecodeBlock15(offset);
+                            break;
+                    }
+                }
+            }
+
+            auto pEnd = ChunkPtr;
+            // we can end up with 1 byte left we need to skip
+            int nSkipBytes = pkt.nVideoDataSize - (int)(pEnd - pStart);
+            assert(nSkipBytes <= 1);
+        }
+
+        doFrame = pkt.bSendFlag;
+    } while(!doFrame);
+
+    animtex.SetFrame(&palette[0].r , GetCurrentFrame());
+
+    nFrame++;
+    SwapFrames();
+
+    return true;
 }
 
 void InterplayDecoder::CopyBlock(uint8_t* pDest, uint8_t* pSrc)
@@ -581,7 +744,7 @@ void InterplayDecoder::DecodeBlock1(int32_t offset)
 void InterplayDecoder::DecodeBlock2(int32_t offset)
 {
     // copy block from 2 frames ago using a motion vector; need 1 more byte
-    uint8_t B = fr.ReadUInt8();
+    uint8_t B = *ChunkPtr++;
 
     int x, y;
 
@@ -603,7 +766,7 @@ void InterplayDecoder::DecodeBlock2(int32_t offset)
 void InterplayDecoder::DecodeBlock3(int32_t offset)
 {
     // copy 8x8 block from current frame from an up/left block
-    uint8_t B = fr.ReadUInt8();
+    uint8_t B = *ChunkPtr++;
 
     int x, y;
 
@@ -629,7 +792,7 @@ void InterplayDecoder::DecodeBlock4(int32_t offset)
     int x, y;
     uint8_t B, BL, BH;
 
-    B = fr.ReadUInt8();
+    B = *ChunkPtr++;
 
     BL = B & 0x0F;
     BH = (B >> 4) & 0x0F;
@@ -645,8 +808,8 @@ void InterplayDecoder::DecodeBlock4(int32_t offset)
 void InterplayDecoder::DecodeBlock5(int32_t offset)
 {
     // copy a block from the previous frame using an expanded range; need 2 more bytes
-    int8_t x = fr.ReadUInt8();
-    int8_t y = fr.ReadUInt8();
+    int8_t x = *ChunkPtr++;
+    int8_t y = *ChunkPtr++;
 
     uint8_t* pDest = GetCurrentFrame() + (intptr_t)offset;
     uint8_t* pSrc = GetPreviousFrame() + (intptr_t)(int64_t)offset + (int64_t)x + (int64_t(y) * (int64_t)videoStride);
@@ -662,8 +825,8 @@ void InterplayDecoder::DecodeBlock7(int32_t offset)
     uint32_t flags = 0;
 
     uint8_t P[2];
-    P[0] = fr.ReadUInt8();
-    P[1] = fr.ReadUInt8();
+    P[0] = *ChunkPtr++;
+    P[1] = *ChunkPtr++;
 
     // 2-color encoding
     if (P[0] <= P[1])
@@ -671,7 +834,7 @@ void InterplayDecoder::DecodeBlock7(int32_t offset)
         // need 8 more bytes from the stream
         for (int y = 0; y < 8; y++)
         {
-            flags = fr.ReadUInt8() | 0x100;
+            flags = (*ChunkPtr++) | 0x100;
             for (; flags != 1; flags >>= 1) {
                 *pBuffer++ = P[flags & 1];
             }
@@ -681,7 +844,8 @@ void InterplayDecoder::DecodeBlock7(int32_t offset)
     else
     {
         // need 2 more bytes from the stream
-        flags = fr.ReadUInt16();
+        flags = LE_16(ChunkPtr);
+        ChunkPtr += 2;
 
         for (int y = 0; y < 8; y += 2)
         {
@@ -704,8 +868,8 @@ void InterplayDecoder::DecodeBlock8(int32_t offset)
     uint8_t P[4];
 
     // 2-color encoding for each 4x4 quadrant, or 2-color encoding on either top and bottom or left and right halves
-    P[0] = fr.ReadUInt8();
-    P[1] = fr.ReadUInt8();
+    P[0] = *ChunkPtr++;
+    P[1] = *ChunkPtr++;
 
     if (P[0] <= P[1])
     {
@@ -715,10 +879,11 @@ void InterplayDecoder::DecodeBlock8(int32_t offset)
             if (!(y & 3))
             {
                 if (y) {
-                    P[0] = fr.ReadUInt8();
-                    P[1] = fr.ReadUInt8();
+                    P[0] = *ChunkPtr++;
+                    P[1] = *ChunkPtr++;
                 }
-                flags = fr.ReadUInt16();
+                flags = LE_16(ChunkPtr);
+                ChunkPtr += 2;
             }
 
             for (int x = 0; x < 4; x++, flags >>= 1) {
@@ -732,9 +897,10 @@ void InterplayDecoder::DecodeBlock8(int32_t offset)
     }
     else
     {
-        flags = fr.ReadUInt32();
-        P[2] = fr.ReadUInt8();
-        P[3] = fr.ReadUInt8();
+        flags = LE_32(ChunkPtr);
+        ChunkPtr += 4;
+        P[2] = *ChunkPtr++;
+        P[3] = *ChunkPtr++;
 
         if (P[2] <= P[3])
         {
@@ -752,7 +918,8 @@ void InterplayDecoder::DecodeBlock8(int32_t offset)
                     pBuffer -= 8 * videoStride - 4;
                     P[0] = P[2];
                     P[1] = P[3];
-                    flags = fr.ReadUInt32();
+                    flags = LE_32(ChunkPtr);
+                    ChunkPtr += 4;
                 }
             }
         }
@@ -764,7 +931,8 @@ void InterplayDecoder::DecodeBlock8(int32_t offset)
                 if (y == 4) {
                     P[0] = P[2];
                     P[1] = P[3];
-                    flags = fr.ReadUInt32();
+                    flags = LE_32(ChunkPtr);
+                    ChunkPtr += 4;
                 }
 
                 for (int x = 0; x < 8; x++, flags >>= 1)
@@ -781,7 +949,8 @@ void InterplayDecoder::DecodeBlock9(int32_t offset)
     uint8_t* pBuffer = GetCurrentFrame() + (intptr_t)offset;
     uint8_t P[4];
 
-    fr.Read(P, 4);
+    memcpy(P, ChunkPtr, 4);
+    ChunkPtr += 4;
 
     // 4-color encoding
     if (P[0] <= P[1])
@@ -792,7 +961,8 @@ void InterplayDecoder::DecodeBlock9(int32_t offset)
             for (int y = 0; y < 8; y++)
             {
                 // get the next set of 8 2-bit flags
-                int flags = fr.ReadUInt16();
+                int flags = LE_16(ChunkPtr);
+                ChunkPtr += 2;
 
                 for (int x = 0; x < 8; x++, flags >>= 2) {
                     *pBuffer++ = P[flags & 0x03];
@@ -804,7 +974,8 @@ void InterplayDecoder::DecodeBlock9(int32_t offset)
         else
         {
             // 1 of 4 colors for each 2x2 block, need 4 more bytes
-            uint32_t flags = fr.ReadUInt32();
+            uint32_t flags = LE_32(ChunkPtr);
+            ChunkPtr += 4;
 
             for (int y = 0; y < 8; y += 2)
             {
@@ -823,7 +994,8 @@ void InterplayDecoder::DecodeBlock9(int32_t offset)
     else
     {
         // 1 of 4 colors for each 2x1 or 1x2 block, need 8 more bytes
-        uint64_t flags = fr.ReadUInt64();
+        uint64_t flags = LE_64(ChunkPtr);
+        ChunkPtr += 8;
 
         if (P[2] <= P[3])
         {
@@ -857,7 +1029,8 @@ void InterplayDecoder::DecodeBlock10(int32_t offset)
     uint8_t* pBuffer = GetCurrentFrame() + (intptr_t)offset;
     uint8_t P[8];
 
-    fr.Read(P, 4);
+    memcpy(P, ChunkPtr, 4);
+    ChunkPtr += 4;
 
     // 4-color encoding for each 4x4 quadrant, or 4-color encoding on either top and bottom or left and right halves
     if (P[0] <= P[1])
@@ -869,8 +1042,12 @@ void InterplayDecoder::DecodeBlock10(int32_t offset)
         {
             // new values for each 4x4 block
             if (!(y & 3)) {
-                if (y) fr.Read(P, 4);
-                flags = fr.ReadUInt32();
+                if (y) {
+                    memcpy(P, ChunkPtr, 4);
+                    ChunkPtr += 4;
+                }
+                flags = LE_32(ChunkPtr);
+                ChunkPtr += 4;
             }
 
             for (int x = 0; x < 4; x++, flags >>= 2) {
@@ -886,9 +1063,11 @@ void InterplayDecoder::DecodeBlock10(int32_t offset)
     {
         // vertical split?
         int vert;
-        uint64_t flags = fr.ReadUInt64();
+        uint64_t flags = LE_64(ChunkPtr);
+        ChunkPtr += 8;
 
-        fr.Read(P + 4, 4);
+        memcpy(P + 4, ChunkPtr, 4);
+        ChunkPtr += 4;
         vert = P[4] <= P[5];
 
         // 4-color encoding for either left and right or top and bottom halves
@@ -908,7 +1087,8 @@ void InterplayDecoder::DecodeBlock10(int32_t offset)
             // load values for second half
             if (y == 7) {
                 memcpy(P, P + 4, 4);
-                flags = fr.ReadUInt64();
+                flags = LE_64(ChunkPtr);
+                ChunkPtr += 8;
             }
         }
     }
@@ -921,7 +1101,8 @@ void InterplayDecoder::DecodeBlock11(int32_t offset)
 
     for (int y = 0; y < 8; y++)
     {
-        fr.Read(pBuffer, 8);
+        memcpy(pBuffer, ChunkPtr, 8);
+        ChunkPtr += 8;
         pBuffer += videoStride;
     }
 }
@@ -938,7 +1119,7 @@ void InterplayDecoder::DecodeBlock12(int32_t offset)
             pBuffer[x] =
                 pBuffer[x + 1] =
                 pBuffer[x + videoStride] =
-                pBuffer[x + 1 + videoStride] = fr.ReadUInt8();
+                pBuffer[x + 1 + videoStride] = *ChunkPtr++;
         }
         pBuffer += videoStride * 2;
     }
@@ -954,8 +1135,8 @@ void InterplayDecoder::DecodeBlock13(int32_t offset)
     {
         if (!(y & 3))
         {
-            P[0] = fr.ReadUInt8();
-            P[1] = fr.ReadUInt8();
+            P[0] = *ChunkPtr++;
+            P[1] = *ChunkPtr++;
         }
 
         memset(pBuffer,     P[0], 4);
@@ -968,7 +1149,7 @@ void InterplayDecoder::DecodeBlock14(int32_t offset)
 {
     // 1-color encoding : the whole block is 1 solid color
     uint8_t* pBuffer = GetCurrentFrame() + (intptr_t)offset;
-    uint8_t pix = fr.ReadUInt8();
+    uint8_t pix = *ChunkPtr++;
 
     for (int y = 0; y < 8; y++)
     {
@@ -983,8 +1164,8 @@ void InterplayDecoder::DecodeBlock15(int32_t offset)
     uint8_t* pBuffer = GetCurrentFrame() + (intptr_t)offset;
     uint8_t P[2];
 
-    P[0] = fr.ReadUInt8();
-    P[1] = fr.ReadUInt8();
+    P[0] = *ChunkPtr++;
+    P[1] = *ChunkPtr++;
 
     for (int y = 0; y < 8; y++)
     {

--- a/src/common/cutscenes/playmve.h
+++ b/src/common/cutscenes/playmve.h
@@ -44,6 +44,11 @@
 
 #pragma once
 
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <vector>
+
 #include "files.h"
 #include "animtexture.h"
 #include "s_music.h"
@@ -103,26 +108,49 @@ public:
 
     bool Open(FileReader &fr);
     void Close();
+
     bool RunFrame(uint64_t clock);
 
-    struct AudioData
-    {
-        int hFx;
-        int nChannels;
-        uint16_t nSampleRate;
-        uint8_t nBitDepth;
+    bool FillSamples(void *buff, int len);
 
-        int16_t samples[6000 * kAudioBlocks]; // must be a multiple of the stream buffer size
-        int nWrite;
-        int nRead;
-    };
-
-    AudioData audio;
-    AnimTextures animtex;
+    bool HasAudio() const noexcept { return bAudioEnabled; }
+    int NumChannels() const noexcept { return audio.nChannels; }
+    int GetSampleRate() const noexcept { return audio.nSampleRate; }
+    void DisableAudio();
 
     AnimTextures& animTex() { return animtex; }
 
 private:
+    struct AudioPacket
+    {
+        size_t nSize = 0;
+        std::unique_ptr<uint8_t[]> pData;
+    };
+
+    struct VideoPacket
+    {
+        uint16_t nPalStart=0, nPalCount=0;
+        uint32_t nDecodeMapSize = 0;
+        uint32_t nVideoDataSize = 0;
+        bool bSendFlag = false;
+        std::unique_ptr<uint8_t[]> pData;
+    };
+
+    struct AudioData
+    {
+        int nChannels = 0;
+        uint16_t nSampleRate = 0;
+        uint8_t nBitDepth = 0;
+        bool bCompressed = false;
+
+        std::unique_ptr<int16_t[]> samples;
+        int nWrite = 0;
+        int nRead = 0;
+
+        std::deque<AudioPacket> Packets;
+    };
+    AudioData audio;
+
     struct DecodeMap
     {
         uint8_t* pData;
@@ -156,24 +184,30 @@ private:
     void DecodeBlock14(int32_t offset);
     void DecodeBlock15(int32_t offset);
 
+    std::mutex PacketMutex;
     FileReader fr;
 
-    bool bIsPlaying, bAudioStarted;
+    bool bIsPlaying, bAudioEnabled;
 
     uint32_t nTimerRate, nTimerDiv;
     uint32_t nWidth, nHeight, nFrame;
     double nFps;
     uint64_t nFrameDuration;
 
+    std::vector<uint8_t> ChunkData;
+    int ProcessNextChunk();
+
+    std::deque<VideoPacket> VideoPackets;
     uint8_t* pVideoBuffers[2];
     uint32_t nCurrentVideoBuffer, nPreviousVideoBuffer;
     int32_t videoStride;
 
+    const uint8_t *ChunkPtr = nullptr;
     DecodeMap decodeMap;
 
+    AnimTextures animtex;
     Palette palette[256];
     uint64_t nNextFrameTime = 0;
-    SoundStream* stream = nullptr;
 };
 
 #endif

--- a/src/common/thirdparty/libsmackerdec/include/BitReader.h
+++ b/src/common/thirdparty/libsmackerdec/include/BitReader.h
@@ -29,8 +29,8 @@ namespace SmackerCommon {
 class BitReader
 {
 	public:
-		BitReader(SmackerCommon::FileStream &file, uint32_t size);
-		~BitReader();
+		BitReader(const uint8_t *data, uint32_t size) : bitData(data), totalSize(size) { }
+		~BitReader() = default;
 		uint32_t GetBit();
 		uint32_t GetBits(uint32_t n);
 		void SkipBits(uint32_t n);
@@ -39,15 +39,10 @@ class BitReader
 		uint32_t GetPosition();
 
 	private:
-		uint32_t totalSize;
-		uint32_t currentOffset;
-		uint32_t bytesRead;
-
-		SmackerCommon::FileStream *file;
-
-        TArray<uint8_t> Cache;
-
-		void FillCache();
+		const uint8_t *bitData = nullptr;
+		uint32_t totalSize = 0;
+		uint32_t currentOffset = 0;
+		uint32_t bytesRead = 0;
 };
 
 } // close namespace SmackerCommon

--- a/src/common/thirdparty/libsmackerdec/include/SmackerDecoder.h
+++ b/src/common/thirdparty/libsmackerdec/include/SmackerDecoder.h
@@ -48,6 +48,9 @@
 #include <stdint.h>
 #include "FileStream.h"
 #include "BitReader.h"
+#include <deque>
+#include <memory>
+#include <mutex>
 #include <vector>
 
 // exportable interface
@@ -61,7 +64,6 @@ struct SmackerAudioInfo
 {
 	uint32_t sampleRate;
 	uint8_t  nChannels;
-	uint8_t  bitsPerSample;
 
 	uint32_t idealBufferSize;
 };
@@ -71,6 +73,7 @@ void              Smacker_Close                (SmackerHandle &handle);
 uint32_t          Smacker_GetNumAudioTracks    (SmackerHandle &handle);
 SmackerAudioInfo  Smacker_GetAudioTrackDetails (SmackerHandle &handle, uint32_t trackIndex);
 uint32_t          Smacker_GetAudioData         (SmackerHandle &handle, uint32_t trackIndex, int16_t *data);
+void              Smacker_DisableAudioTrack    (SmackerHandle &handle, uint32_t trackIndex);
 uint32_t          Smacker_GetNumFrames         (SmackerHandle &handle);
 void              Smacker_GetFrameSize         (SmackerHandle &handle, uint32_t &width, uint32_t &height);
 uint32_t          Smacker_GetCurrentFrameNum   (SmackerHandle &handle);
@@ -86,6 +89,12 @@ const int kMaxAudioTracks = 7;
 struct HuffContext;
 struct DBCtx;
 
+struct SmackerPacket
+{
+	size_t size = 0;
+	std::unique_ptr<uint8_t[]> data;
+};
+
 struct SmackerAudioTrack
 {
 	uint32_t sizeInBytes;
@@ -99,6 +108,7 @@ struct SmackerAudioTrack
 	uint32_t bufferSize;
 
 	uint32_t bytesReadThisFrame;
+	std::deque<SmackerPacket> packetData;
 };
 
 class SmackerDecoder
@@ -114,8 +124,10 @@ class SmackerDecoder
 		void GetPalette(uint8_t *palette);
 		void GetFrame(uint8_t *frame);
 
+		uint32_t GetNumAudioTracks();
 		SmackerAudioInfo GetAudioTrackDetails(uint32_t trackIndex);
 		uint32_t GetAudioData(uint32_t trackIndex, int16_t *audioBuffer);
+		void DisableAudioTrack(uint32_t trackIndex);
 		uint32_t GetNumFrames();
 		uint32_t GetCurrentFrameNum();
 		float GetFrameRate();
@@ -125,6 +137,7 @@ class SmackerDecoder
 	private:
 		SmackerCommon::FileStream file;
 		char signature[4];
+		std::mutex fileMutex;
 
 		// video related members
 		uint32_t nFrames;
@@ -135,6 +148,10 @@ class SmackerDecoder
 
 		bool isVer4;
 
+		uint32_t currentReadFrame;
+		std::vector<uint8_t> packetData;
+
+		std::deque<SmackerPacket> framePacketData;
 		SmackerAudioTrack audioTracks[kMaxAudioTracks];
 
 		uint32_t treeSize;
@@ -160,9 +177,9 @@ class SmackerDecoder
 		int DecodeBigTree(SmackerCommon::BitReader &bits, HuffContext *hc, DBCtx *ctx);
 		int GetCode(SmackerCommon::BitReader &bits, std::vector<int> &recode, int *last);
 		int ReadPacket();
-		int DecodeFrame(uint32_t frameSize);
+		int DecodeFrame(const uint8_t *dataPtr, uint32_t frameSize);
 		void GetFrameSize(uint32_t &width, uint32_t &height);
-		int DecodeAudio(uint32_t size, SmackerAudioTrack &track);
+		int DecodeAudio(const uint8_t *dataPtr, uint32_t size, SmackerAudioTrack &track);
 };
 
 #endif

--- a/src/common/thirdparty/libsmackerdec/src/BitReader.cpp
+++ b/src/common/thirdparty/libsmackerdec/src/BitReader.cpp
@@ -22,25 +22,6 @@
 
 namespace SmackerCommon {
 
-BitReader::BitReader(SmackerCommon::FileStream &file, uint32_t size)
-{
-	this->file = &file;
-	this->totalSize = size;
-	this->currentOffset = 0;
-	this->bytesRead = 0;
-
-    this->Cache.Resize(size);
-    file.ReadBytes(this->Cache.Data(), size);
-}
-
-BitReader::~BitReader()
-{
-}
-
-void BitReader::FillCache()
-{
-}
-
 uint32_t BitReader::GetSize()
 {
 	return totalSize * 8;
@@ -53,7 +34,7 @@ uint32_t BitReader::GetPosition()
 
 uint32_t BitReader::GetBit()
 {
-	uint32_t ret = (Cache[currentOffset>>3]>>(currentOffset&7))&1;
+	uint32_t ret = (bitData[currentOffset>>3]>>(currentOffset&7))&1;
     currentOffset++;
 	return ret;
 }

--- a/src/common/thirdparty/libsmackerdec/src/SmackerDecoder.cpp
+++ b/src/common/thirdparty/libsmackerdec/src/SmackerDecoder.cpp
@@ -49,6 +49,7 @@
 #include "limits.h"
 #include <assert.h>
 #include <algorithm>
+#include <memory>
 
 std::vector<class SmackerDecoder*> classInstances;
 
@@ -93,10 +94,9 @@ void Smacker_Close(SmackerHandle &handle)
 	handle.isValid = false;
 }
 
-uint32_t Smacker_GetNumAudioTracks(SmackerHandle &)
+uint32_t Smacker_GetNumAudioTracks(SmackerHandle &handle)
 {
-	// TODO: fixme
-	return 1;
+	return classInstances[handle.instanceIndex]->GetNumAudioTracks();
 }
 
 SmackerAudioInfo Smacker_GetAudioTrackDetails(SmackerHandle &handle, uint32_t trackIndex)
@@ -113,6 +113,18 @@ SmackerAudioInfo Smacker_GetAudioTrackDetails(SmackerHandle &handle, uint32_t tr
 uint32_t Smacker_GetAudioData(SmackerHandle &handle, uint32_t trackIndex, int16_t *data)
 {
 	return classInstances[handle.instanceIndex]->GetAudioData(trackIndex, data);
+}
+
+/* Disables an audio track if it's enabled.
+ *
+ * When getting video or audio data, encoded data is stored for other tracks so
+ * they can be read and decoded later. This function prevents a build-up of
+ * encoded audio data for the specified track if such data isn't going to be
+ * decoded and read by the caller.
+ */
+void Smacker_DisableAudioTrack(SmackerHandle &handle, uint32_t trackIndex)
+{
+	classInstances[handle.instanceIndex]->DisableAudioTrack(trackIndex);
 }
 
 uint32_t Smacker_GetNumFrames(SmackerHandle &handle)
@@ -165,6 +177,7 @@ void Smacker_GotoFrame(SmackerHandle &handle, uint32_t frameNum)
 SmackerDecoder::SmackerDecoder()
 {
 	isVer4 = false;
+	currentReadFrame = 0;
 	currentFrame = 0;
 	picture = 0;
 	nextPos = 0;
@@ -223,6 +236,7 @@ static const uint8_t smk_pal[64] = {
 
 enum SAudFlags {
     SMK_AUD_PACKED  = 0x80000000, 
+    SMK_AUD_PRESENT = 0x40000000,
     SMK_AUD_16BITS  = 0x20000000, 
     SMK_AUD_STEREO  = 0x10000000, 
     SMK_AUD_BINKAUD = 0x08000000, 
@@ -372,12 +386,21 @@ bool SmackerDecoder::Open(const char *fileName)
 		frameFlags[i] = file.ReadByte();
 	}
 
+	auto maxFrameSize = std::max_element(frameSizes.begin(), frameSizes.end());
+	if (maxFrameSize != frameSizes.end())
+		packetData.reserve(*maxFrameSize);
+
 	// handle possible audio streams
 	for (int i = 0; i < kMaxAudioTracks; i++)
 	{
 		audioTracks[i].buffer = 0;
 		audioTracks[i].bufferSize = 0;
 		audioTracks[i].bytesReadThisFrame = 0;
+
+		// Disable non-consecutive enabled tracks. Not sure how to otherwise report
+		// them properly for Smacker_GetNumAudioTracks.
+		if (i > 0 && !(audioTracks[i-1].flags & SMK_AUD_PRESENT))
+			audioTracks[i].flags &= ~SMK_AUD_PRESENT;
 
 		if (audioTracks[i].flags & 0xFFFFFF)
 		{
@@ -426,13 +449,18 @@ bool SmackerDecoder::Open(const char *fileName)
 	{
 		if (frameFlag & 1) 
 		{
-			// skip size
-			file.Skip(4);
-			
+			uint32_t size = file.ReadUint32LE();
 			uint32_t unpackedSize = file.ReadUint32LE();
+
+			// If the track isn't 16-bit, double the buffer size for converting 8-bit to 16-bit.
+			if (!(audioTracks[i].flags & SMK_AUD_16BITS))
+				unpackedSize *= 2;
 
 			audioTracks[i].bufferSize = unpackedSize;
 			audioTracks[i].buffer = new uint8_t[unpackedSize];
+
+			// skip size
+			file.Skip(size - 8);
 		}	
 		frameFlag >>= 1;
 	}
@@ -633,7 +661,10 @@ int SmackerDecoder::DecodeHeaderTree(SmackerCommon::BitReader &bits, std::vector
 // static int decode_header_trees(SmackVContext *smk) {
 bool SmackerDecoder::DecodeHeaderTrees()
 {
-	SmackerCommon::BitReader bits(file, treeSize);
+	auto treeData = std::make_unique<uint8_t[]>(treeSize);
+	file.ReadBytes(treeData.get(), treeSize);
+
+	SmackerCommon::BitReader bits(treeData.get(), treeSize);
 
 	if (!bits.GetBit())
 	{
@@ -683,58 +714,53 @@ bool SmackerDecoder::DecodeHeaderTrees()
 		DecodeHeaderTree(bits, type_tbl, type_last, typeSize);
 	}
 
-	/* FIXME - we don't seems to read/use EVERY bit we 'load' into the bit reader
-	 * and as my bitreader reads from the file rather than a buffer read from file
-	 * of size 'treeSize', I need to make sure I consume the remaining bits (and thus increment
-	 * the file read position to where the code expects it to be when this function returns (ie 
-	 * 'treeSize' number of bytes must be read
-	 */
-	uint32_t left = bits.GetSize() - bits.GetPosition();
-	bits.SkipBits(left);
-
 	return true;
 }
 
 void SmackerDecoder::GetNextFrame()
 {
-	ReadPacket();
-}
-
-int SmackerDecoder::ReadPacket()
-{
-	// test-remove
 	if (currentFrame >= nFrames)
-		return 1;
+		return;
 
-	// seek to next frame position
-	file.Seek(nextPos, SmackerCommon::FileStream::kSeekStart);
+	std::unique_lock flock(fileMutex);
+	while (framePacketData.empty())
+	{
+		if (ReadPacket() > 0)
+			return;
+	}
+	SmackerPacket pkt = std::move(framePacketData.front());
+	framePacketData.pop_front();
+	flock.unlock();
 
-	uint32_t frameSize = frameSizes[currentFrame] & (~3);
+	uint32_t frameSize = pkt.size;
 	uint8_t frameFlag  = frameFlags[currentFrame];
+
+	const uint8_t *packetDataPtr = pkt.data.get();
 
 	// handle palette change
 	if (frameFlag & kSMKpal)
 	{
-		int size, sz, t, off, j, pos;
+		int size, sz, t, off, j;
         uint8_t *pal = palette;
         uint8_t oldpal[768];
+        const uint8_t *dataEnd;
 
         memcpy(oldpal, pal, 768);
-        size = file.ReadByte();
+        size = *(packetDataPtr++);
         size = size * 4 - 1;
         frameSize -= size;
         frameSize--;
         sz = 0;
-        pos = file.GetPosition() + size;
+        dataEnd = packetDataPtr + size;
 
         while (sz < 256)
 		{
-            t = file.ReadByte();
+            t = *(packetDataPtr++);
             if (t & 0x80){ /* skip palette entries */
                 sz  += (t & 0x7F)  + 1;
                 pal += ((t & 0x7F) + 1) * 3;
             } else if (t & 0x40){ /* copy with offset */
-                off = file.ReadByte() * 3;
+                off = *(packetDataPtr++) * 3;
                 j = (t & 0x3F) + 1;
                 while (j-- && sz < 256) {
                     *pal++ = oldpal[off + 0];
@@ -745,47 +771,92 @@ int SmackerDecoder::ReadPacket()
                 }
             } else { /* new entries */
                 *pal++ = smk_pal[t];
-                *pal++ = smk_pal[file.ReadByte() & 0x3F];
-                *pal++ = smk_pal[file.ReadByte() & 0x3F];
+                *pal++ = smk_pal[*(packetDataPtr++) & 0x3F];
+                *pal++ = smk_pal[*(packetDataPtr++) & 0x3F];
                 sz++;
             }
         }
-        
-		file.Seek(pos, SmackerCommon::FileStream::kSeekStart);
+
+		packetDataPtr = dataEnd;
+	}
+
+	if (frameSize > 0)
+		DecodeFrame(packetDataPtr, frameSize);
+
+	currentFrame++;
+}
+
+int SmackerDecoder::ReadPacket()
+{
+	// test-remove
+	if (currentReadFrame >= nFrames)
+		return 1;
+
+	// seek to next frame position
+	file.Seek(nextPos, SmackerCommon::FileStream::kSeekStart);
+
+	uint32_t frameSize = frameSizes[currentReadFrame] & (~3);
+	uint8_t frameFlag  = frameFlags[currentReadFrame];
+
+	packetData.resize(frameSize);
+	file.ReadBytes(packetData.data(), frameSize);
+
+	const uint8_t *packetDataPtr = packetData.data();
+
+	// skip pal data for later, after getting audio data
+	if (frameFlag & kSMKpal)
+	{
+		int size = (*packetDataPtr * 4);
+		packetDataPtr += size;
+		frameSize -= size;
 	}
 
 	frameFlag >>= 1;
-
-	// check for and handle audio
-	for (int i = 0; i < kMaxAudioTracks; i++) 
+	for (int i = 0; i < kMaxAudioTracks; i++)
 	{
-		audioTracks[i].bytesReadThisFrame = 0;
-
-		if (frameFlag & 1) 
+		if (frameFlag & 1)
 		{
-			uint32_t size = file.ReadUint32LE() - 4;
+			uint32_t size = *(packetDataPtr++);
+			size |= *(packetDataPtr++) << 8;
+			size |= *(packetDataPtr++) << 16;
+			size |= *(packetDataPtr++) << 24;
 			frameSize -= size;
-			frameSize -= 4;
+			size -= 4;
 
-			DecodeAudio(size, audioTracks[i]);
+			if (audioTracks[i].flags & SMK_AUD_PRESENT)
+			{
+				SmackerPacket pkt;
+				pkt.size = size;
+				pkt.data = std::make_unique<uint8_t[]>(size);
+				memcpy(pkt.data.get(), packetDataPtr, size);
+				audioTracks[i].packetData.emplace_back(std::move(pkt));
+			}
+			packetDataPtr += size;
 		}
 		frameFlag >>= 1;
 	}
 
-	if (frameSize == 0) {
-		return -1;
+	SmackerPacket pkt;
+	frameFlag = frameFlags[currentReadFrame];
+	if (frameSize != 0 || (frameFlag & kSMKpal))
+	{
+		int palsize = (frameFlag & kSMKpal) ? packetData[0] * 4 : 0;
+		int totalSize = frameSize + palsize;
+		pkt.size = totalSize;
+		pkt.data = std::make_unique<uint8_t[]>(totalSize);
+		memcpy(pkt.data.get(), packetData.data(), palsize);
+		memcpy(pkt.data.get()+palsize, packetDataPtr, frameSize);
 	}
+	framePacketData.emplace_back(std::move(pkt));
 
-	DecodeFrame(frameSize);
-
-	currentFrame++;
+	++currentReadFrame;
 
 	nextPos = file.GetPosition();
 
 	return 0;
 }
 
-int SmackerDecoder::DecodeFrame(uint32_t frameSize)
+int SmackerDecoder::DecodeFrame(const uint8_t *dataPtr, uint32_t frameSize)
 {
 	last_reset(mmap_tbl, mmap_last);
     last_reset(mclr_tbl, mclr_last);
@@ -805,7 +876,8 @@ int SmackerDecoder::DecodeFrame(uint32_t frameSize)
 
 	stride = frameWidth;
 
-	SmackerCommon::BitReader bits(file, frameSize);
+	SmackerCommon::BitReader bits(dataPtr, frameSize);
+	dataPtr += frameSize;
 
 	while (blk < blocks)
 	{
@@ -935,24 +1007,14 @@ int SmackerDecoder::DecodeFrame(uint32_t frameSize)
         }
 	}
 
-	/* FIXME - we don't seems to read/use EVERY bit we 'load' into the bit reader
-	 * and as my bitreader reads from the file rather than a buffer read from file
-	 * of size 'frameSize', I need to make sure I consume the remaining bits (and thus increment
-	 * the file read position to where the code expects it to be when this function returns (ie 
-	 * 'frameSize' number of bytes must be read
-	 */
-	uint32_t left = bits.GetSize() - bits.GetPosition();
-	bits.SkipBits(left);
-
 	return 0;
 }
 
 /**
  * Decode Smacker audio data
  */
-int SmackerDecoder::DecodeAudio(uint32_t size, SmackerAudioTrack &track)
+int SmackerDecoder::DecodeAudio(const uint8_t *dataPtr, uint32_t size, SmackerAudioTrack &track)
 {
-    HuffContext h[4];
 	SmackerCommon::VLCtable vlc[4];
     int val;
     int i, res;
@@ -961,18 +1023,14 @@ int SmackerDecoder::DecodeAudio(uint32_t size, SmackerAudioTrack &track)
     int pred[2] = {0, 0};
 
 	int16_t *samples = reinterpret_cast<int16_t*>(track.buffer);
-    int8_t *samples8 = reinterpret_cast<int8_t*>(track.buffer);
 
-	int buf_size = track.bufferSize;
+	SmackerCommon::BitReader bits(dataPtr, size);
 
-    if (buf_size <= 4) {
+    unpackedSize = bits.GetBits(32);
+    if (unpackedSize <= 4) {
         Printf("SmackerDecoder::DecodeAudio() - Packet is too small\n");
 		return -1;
     }
-
-	SmackerCommon::BitReader bits(file, size);
-
-    unpackedSize = bits.GetBits(32);
 
     if (!bits.GetBit()) {
 		// no sound data
@@ -987,7 +1045,7 @@ int SmackerDecoder::DecodeAudio(uint32_t size, SmackerAudioTrack &track)
 		return -1;
     }
 
-    memset(h, 0, sizeof(HuffContext) * 4);
+    HuffContext h[4];
 
     // Initialize
     for (i = 0; i < (1 << (sampleBits + stereo)); i++) {
@@ -1045,7 +1103,7 @@ int SmackerDecoder::DecodeAudio(uint32_t size, SmackerAudioTrack &track)
         for (i = stereo; i >= 0; i--)
             pred[i] = bits.GetBits(8);
         for (i = 0; i <= stereo; i++)
-            *samples8++ = pred[i];
+            *samples++ = (pred[i]-128) << 8;
         for (; i < unpackedSize; i++) {
             if (i & stereo){
 				if (VLC_GetSize(vlc[1]))
@@ -1053,22 +1111,20 @@ int SmackerDecoder::DecodeAudio(uint32_t size, SmackerAudioTrack &track)
                 else
                     res = 0;
                 pred[1] += (int8_t)h[1].values[res];
-                *samples8++ = pred[1];
+                *samples++ = (pred[1]-128) << 8;
             } else {
 				if (VLC_GetSize(vlc[0]))
 				res = VLC_GetCodeBits(bits, vlc[0]);
                 else
                     res = 0;
                 pred[0] += (int8_t)h[0].values[res];
-                *samples8++ = pred[0];
+                *samples++ = (pred[0]-128) << 8;
             }
         }
+        unpackedSize *= 2;
     }
 
 	track.bytesReadThisFrame = unpackedSize;
-
-	uint32_t left = bits.GetSize() - bits.GetPosition();
-	bits.SkipBits(left);
 
 	return 0;
 }
@@ -1113,11 +1169,32 @@ void SmackerDecoder::GotoFrame(uint32_t frameNum)
 
 //    file.Seek(firstFrameFilePos, SmackerCommon::FileStream::kSeekStart);
 
+    currentReadFrame = 0;
     currentFrame = 0;
     nextPos = firstFrameFilePos;
 
-    for (unsigned i = 0; i < frameNum + 1; i++)
+    framePacketData.clear();
+    for (unsigned j = 0; j < kMaxAudioTracks; j++)
+        audioTracks[j].packetData.clear();
+
+    for (unsigned i = 0; i < frameNum; i++)
+    {
         GetNextFrame();
+        for (unsigned j = 0; j < kMaxAudioTracks; j++)
+            audioTracks[j].packetData.clear();
+    }
+
+    GetNextFrame();
+}
+
+uint32_t SmackerDecoder::GetNumAudioTracks()
+{
+	for(uint32_t i = 0;i < kMaxAudioTracks;++i)
+	{
+		if (!(audioTracks[i].flags & SMK_AUD_PRESENT))
+			return i;
+	}
+	return kMaxAudioTracks;
 }
 
 SmackerAudioInfo SmackerDecoder::GetAudioTrackDetails(uint32_t trackIndex)
@@ -1127,7 +1204,6 @@ SmackerAudioInfo SmackerDecoder::GetAudioTrackDetails(uint32_t trackIndex)
 
 	info.sampleRate = track->sampleRate;
 	info.nChannels  = track->nChannels;
-	info.bitsPerSample = track->bitsPerSample;
 
 	// audio buffer size in bytes
 	info.idealBufferSize = track->bufferSize;
@@ -1143,9 +1219,37 @@ uint32_t SmackerDecoder::GetAudioData(uint32_t trackIndex, int16_t *audioBuffer)
 
 	SmackerAudioTrack *track = &audioTracks[trackIndex];
 
+	std::unique_lock flock(fileMutex);
+	if (!(track->flags & SMK_AUD_PRESENT))
+		return 0;
+
+	while (track->packetData.empty())
+	{
+		if (ReadPacket() > 0)
+			return 0;
+	}
+	SmackerPacket pkt = std::move(track->packetData.front());
+	track->packetData.pop_front();
+	flock.unlock();
+
+	track->bytesReadThisFrame = 0;
+
+	const uint8_t *packetDataPtr = pkt.data.get();
+	uint32_t size = pkt.size;
+
+	DecodeAudio(packetDataPtr, size, *track);
+
 	if (track->bytesReadThisFrame) {
 		memcpy(audioBuffer, track->buffer, std::min(track->bufferSize, track->bytesReadThisFrame));
 	}
 
 	return track->bytesReadThisFrame;
+}
+
+void SmackerDecoder::DisableAudioTrack(uint32_t trackIndex)
+{
+	SmackerAudioTrack *track = &audioTracks[trackIndex];
+	std::unique_lock flock(fileMutex);
+	track->flags &= ~SMK_AUD_PRESENT;
+	track->packetData.clear();
 }


### PR DESCRIPTION
This syncs the video playback to audio, rather than the audio to the video/frame clock. This prevents the audio glitching at the start of playback as a result of the screen wipe causing the video to delay immediately after starting.

Note that this depends on fixing the screen wipe occurring with movie playback. Either properly disabling the wipe when a movie starts, or having the first/pre-wipe `Frame` call being given `0` for the clock. Otherwise, the audio will start with the wipe, and the video will rush forward to catch up after the wipe finishes.