### PR TITLE
Harmony: Fix Echidna's class name

### DIFF
--- a/wadsrc_extra/static/filter/harmony/decaldef.txt
+++ b/wadsrc_extra/static/filter/harmony/decaldef.txt
@@ -388,7 +388,7 @@ generator Beastling			BulletChip
 generator Follower			BulletChip
 generator Soldier			BulletChip
 generator WalkingPhage2		BulletChip
-generator Echida			BulletChip
+generator Echidna			BulletChip
 
 generator PhageNeutron		ArachnotronScorch
 generator GrenadeExplosion	CacoScorch

--- a/wadsrc_extra/static/filter/harmony/decorate.txt
+++ b/wadsrc_extra/static/filter/harmony/decorate.txt
@@ -548,7 +548,7 @@ actor Mine replaces LostSoul
 	}
 }
 
-actor Echida replaces SpiderMastermind
+actor Echidna replaces SpiderMastermind
 {
 	scale 0.33
 	health 5000

--- a/wadsrc_lights/static/filter/harmony/gldefs.txt
+++ b/wadsrc_lights/static/filter/harmony/gldefs.txt
@@ -131,7 +131,7 @@ object Soldier
 	frame CPOSF { light ZOMBIEATK }
 }
 
-object Echida
+object Echidna
 {
 	frame SPIDG { light ZOMBIEATK }
 }


### PR DESCRIPTION
Echidna's class name was not fixed when the Harmony DECORATE was fixed.
This is probably inconsequential, but if future Harmony updates are at all possible, it seems smarter to fix this now than later.