### PR TITLE
Fix inconsistent distance and hit position on traces that skip everything

### DIFF
--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -894,9 +894,14 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 		}
 		Results = res;
 	}
-	if (Results->HitType == TRACE_HitNone && Results->Distance == 0)
+	if (Results->HitType == TRACE_HitNone)
 	{
-		Results->HitPos = Start + Vec * MaxDist;
+		// [MK] If we didn't cross anything, it's an easy guess,
+		// otherwise, complete the line using the remaining distance
+		if (Results->Distance == 0)
+			Results->HitPos = Start + Vec * MaxDist;
+		else
+			Results->HitPos += Vec * (MaxDist - Results->Distance);
 		SetSourcePosition();
 		Results->Distance = MaxDist;
 		Results->Fraction = 1.;


### PR DESCRIPTION
Test map: [traceskiptest.zip](https://github.com/ZDoom/gzdoom/files/9895625/traceskiptest.zip)

Three actors cast a 500-unit trace that skips everything it crosses. Ideally, all three traces should result in a 500-unit line, but instead the second stops at a non-colliding corpse, and the third stops at a non-blocking line. With this patch, all traces work consistently.