### PR TITLE
Add GFF_NOEXTCHANGE to Phasing Zorcher flash

### DIFF
--- a/wadsrc/static/zscript/actors/chex/chexweapons.zs
+++ b/wadsrc/static/zscript/actors/chex/chexweapons.zs
@@ -106,7 +106,7 @@ class PhasingZorcher : PlasmaRifle
 	States
 	{
 	Fire:
-		PLSG A 0 A_GunFlash;
+		PLSG A 0 A_GunFlash('Flash', GFF_NOEXTCHANGE);
 		PLSG A 3 A_FireProjectile("PhaseZorchMissile");
 		PLSG B 20 A_ReFire;
 		Goto Ready;


### PR DESCRIPTION
The Plasma Rifle does not light the player's sprite, so we must assume the Phasing Zorcher also should not.