### PR TITLE
Level name printout on load shouldn't be sent to the HUD

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1395,7 +1395,7 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 	{
 		FString mapname = nextmapname;
 		mapname.ToUpper();
-		Printf("\n%s\n\n" TEXTCOLOR_BOLD "%s - %s\n\n", console_bar, mapname.GetChars(), LevelName.GetChars());
+		Printf(PRINT_NONOTIFY, "\n%s\n\n" TEXTCOLOR_BOLD "%s - %s\n\n", console_bar, mapname.GetChars(), LevelName.GetChars());
 	}
 
 	// Set the sky map.

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1395,7 +1395,7 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 	{
 		FString mapname = nextmapname;
 		mapname.ToUpper();
-		Printf(PRINT_NONOTIFY, "\n%s\n\n" TEXTCOLOR_BOLD "%s - %s\n\n", console_bar, mapname.GetChars(), LevelName.GetChars());
+		Printf(PRINT_NONOTIFY, "\n" TEXTCOLOR_NORMAL "%s\n\n" TEXTCOLOR_BOLD "%s - %s\n\n", console_bar, mapname.GetChars(), LevelName.GetChars());
 	}
 
 	// Set the sky map.


### PR DESCRIPTION
Other messages using a similar format already have the `PRINT_NONOTIFY` flag added, just not this one in `DoLoadLevel`.

To be honest, this is really a nitpick, and `C_FlushDisplay` is called later, so any adequately coded ZScript HUD would know to clear out the message so it doesn't get displayed.