### PR TITLE
Enable ANIMDEFS for particles

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -1327,7 +1327,7 @@ void HWSprite::ProcessParticle (HWDrawInfo *di, particle_t *particle, sector_t *
 			ur = 1;
 			vt = 0;
 			vb = 1;
-			texture = TexMan.GetGameTexture(lump, false);
+			texture = TexMan.GetGameTexture(lump, true);
 		}
 	}
 


### PR DESCRIPTION
Just changes `animate:false` to `animate:true` when calling `GetGameTexture` to enable ANIMDEFS