### PR TITLE
Fix GetActorAngle range

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -620,7 +620,7 @@ inline DAngle ACSToAngle(int acsval)
 
 inline int AngleToACS(DAngle ang)
 {
-	return ang.Q16();
+	return ang.Normalized360().Q16();
 }
 
 inline int PitchToACS(DAngle ang)


### PR DESCRIPTION
Normalize angle in `AngleToACS`

Fixes `GetActorAngle` returning negative or large values with no range limit, depending on how many times the actor has done a full rotation in either direction.

(This regression affects 4.9.x and should probably be backported, btw.)