### PR TITLE
Improvements to slamming functionality

### DIFF
--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -348,6 +348,7 @@ xx(Idle)
 xx(GenericFreezeDeath)
 xx(GenericCrush)
 xx(DieFromSpawn)
+xx(Slam)
 
 // Bounce state names
 xx(Bounce)

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -429,6 +429,7 @@ enum ActorFlag8
 	MF8_CROSSLINECHECK	= 0x10000000,	// [MC]Enables CanCrossLine virtual
 	MF8_MASTERNOSEE		= 0x20000000,	// Don't show object in first person if their master is the current camera.
 	MF8_ADDLIGHTLEVEL	= 0x40000000,	// [MC] Actor light level is additive with sector.
+	MF8_ONLYSLAMSOLID	= 0x80000000,	// [B] Things with skullfly will ignore non-solid Actors.
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3140,6 +3140,12 @@ DEFINE_ACTION_FUNCTION(AActor, Howl)
 
 bool AActor::Slam (AActor *thing)
 {
+	if ((flags8 & MF8_ONLYSLAMSOLID)
+		&& !(thing->flags & MF_SOLID) && !(thing->flags & MF_SHOOTABLE))
+	{
+		return true;
+	}
+
 	flags &= ~MF_SKULLFLY;
 	Vel.Zero();
 	if (health > 0)
@@ -3152,8 +3158,13 @@ bool AActor::Slam (AActor *thing)
 			// The charging monster may have died by the target's actions here.
 			if (health > 0)
 			{
-				if (SeeState != NULL && !(flags8 & MF8_RETARGETAFTERSLAM)) SetState (SeeState);
-				else SetIdle();
+				FState *slam = FindState(NAME_Slam);
+				if (slam != NULL)
+					SetState(slam);
+				else if (SeeState != NULL && !(flags8 & MF8_RETARGETAFTERSLAM))
+					SetState (SeeState);
+				else
+					SetIdle();
 			}
 		}
 		else

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -343,6 +343,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, CROSSLINECHECK, AActor, flags8),
 	DEFINE_FLAG(MF8, MASTERNOSEE, AActor, flags8),
 	DEFINE_FLAG(MF8, ADDLIGHTLEVEL, AActor, flags8),
+	DEFINE_FLAG(MF8, ONLYSLAMSOLID, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
Currently the only way to truly extend Slam behavior is to override the function entirely which involves diving into the engine itself to rip out the code. Two common issues are:
- Actors with SkullFly stopping when hitting Actors like items (this is easier to solve but adds boilerplate code to mods)
- Not being able to easily change behavior when confirmed to have slammed another Actor
This commit adds the ONLYSLAMSOLID flag which will allow Actors with SkullFly to ignore non-solid, unshootable things, solving the first issue. The added Slam state improves overriding behavior for the second issue since modders can now redirect Actors to new behavior on slam such as entering an explosion state.