### PR TITLE
Exposed LevelLocals' LookupString to ZScript

### DIFF
--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2450,6 +2450,19 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, SphericalCoords, SphericalCoords)
 	ACTION_RETURN_VEC3(result);
 }
 
+static void LookupString(FLevelLocals *level, uint32_t index, FString *res)
+{
+	*res = level->Behaviors.LookupString(index);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, LookupString, LookupString)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_UINT(index);
+	FString res;
+	LookupString(self, index, &res);
+	ACTION_RETURN_STRING(res);
+}
 
 static int isFrozen(FLevelLocals *self)
 {

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -474,6 +474,7 @@ struct LevelLocals native
 	native vector3, int PickPlayerStart(int pnum, int flags = 0);
 	native int isFrozen() const;
 	native void setFrozen(bool on);
+	native string LookupString(uint index);
 
 	native clearscope Sector PointInSector(Vector2 pt) const;
 


### PR DESCRIPTION
With this change strings returned from ACS_(Named)ExecuteWithResult can now be converted to the string that was returned within ZScript.

```
// in ACS
script 1 (void)
{
  SetResultValue("Hello World");
}

// in ZScript
string myString = level.LookupString(ACS_ExecuteWithResult(1));
console.printf(myString); // this will print Hello World
```