### PR TITLE
Added SendConsoleEvent for EventHandlers

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2704,7 +2704,7 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 			for (int i = 0; i < 3; i++)
 				arg[i] = ReadLong(stream);
 			bool manual = !!ReadByte(stream);
-			primaryLevel->localEventManager->Console(player, s, arg[0], arg[1], arg[2], manual);
+			primaryLevel->localEventManager->Console(player, s, arg[0], arg[1], arg[2], manual, false);
 		}
 		break;
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -686,6 +686,21 @@ DEFINE_ACTION_FUNCTION(DEventHandler, SendNetworkEvent)
 	ACTION_RETURN_BOOL(currentVMLevel->localEventManager->SendNetworkEvent(name, arg1, arg2, arg3, false));
 }
 
+DEFINE_ACTION_FUNCTION(DEventHandler, SendConsoleEvent)
+{
+	PARAM_PROLOGUE;
+	PARAM_INT(playerNum);
+	PARAM_STRING(name);
+	PARAM_INT(arg1);
+	PARAM_INT(arg2);
+	PARAM_INT(arg3);
+
+	if (playerNum == consoleplayer)
+		primaryLevel->localEventManager->Console(-1, name, arg1, arg2, arg3, false);
+
+	return 0;
+}
+
 DEFINE_ACTION_FUNCTION(DEventHandler, Find)
 {
 	PARAM_PROLOGUE;

--- a/src/events.h
+++ b/src/events.h
@@ -111,7 +111,7 @@ public:
 	void PostUiTick();
 	
 	// 
-	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3, bool manual);
+	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3, bool manual, bool ui);
 
 	//
 	void CheckReplacement(PClassActor* replacee, PClassActor** replacement, bool* final);
@@ -281,7 +281,7 @@ struct EventManager
 	// this executes on events.
 	bool Responder(const event_t* ev); // splits events into InputProcess and UiProcess
 	// this executes on console/net events.
-	void Console(int player, FString name, int arg1, int arg2, int arg3, bool manual);
+	void Console(int player, FString name, int arg1, int arg2, int arg3, bool manual, bool ui);
 
 	// called when looking up the replacement for an actor class
 	bool CheckReplacement(PClassActor* replacee, PClassActor** replacement);

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -148,4 +148,5 @@ class EventHandler : StaticEventHandler native version("2.4")
 {
     clearscope static native StaticEventHandler Find(class<StaticEventHandler> type);
     clearscope static native void SendNetworkEvent(String name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
+    clearscope static native void SendConsoleEvent(int playerNum, string name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
 }

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -124,6 +124,7 @@ class StaticEventHandler : Object native play version("2.4")
     
     //
     virtual ui void ConsoleProcess(ConsoleEvent e) {}
+    virtual ui void InterfaceProcess(ConsoleEvent e) {}
     virtual void NetworkProcess(ConsoleEvent e) {}
     
     //
@@ -148,5 +149,5 @@ class EventHandler : StaticEventHandler native version("2.4")
 {
     clearscope static native StaticEventHandler Find(class<StaticEventHandler> type);
     clearscope static native void SendNetworkEvent(String name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
-    clearscope static native void SendConsoleEvent(int playerNum, string name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
+    clearscope static native void SendInterfaceEvent(int playerNum, string name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
 }


### PR DESCRIPTION
Allows for playsim-based events to pass information to the UI in a "fire and forget" manner instead of needing to cache values to be read from by the UI (which sometimes might not be an option). Can be sent via `EventHandler.SendConsoleEvent()`. A player number is manually specified to know who triggers the event.