### PR TITLE
Add scrollbar for Linux IWAD Selection.

### DIFF
--- a/src/common/platform/posix/unix/gtk_dialogs.cpp
+++ b/src/common/platform/posix/unix/gtk_dialogs.cpp
@@ -86,10 +86,6 @@ DYN_GTK_SYM(g_type_check_instance_cast);
 DYN_GTK_SYM(g_type_check_instance_is_a);
 DYN_GTK_SYM(g_value_get_int);
 DYN_GTK_SYM(g_value_unset);
-DYN_GTK_SYM(gdk_display_get_default);
-DYN_GTK_SYM(gdk_display_get_primary_monitor);
-DYN_GTK_SYM(gdk_monitor_get_geometry);
-DYN_GTK_SYM(gdk_monitor_get_type);
 DYN_GTK_SYM(gtk_box_get_type);
 DYN_GTK_SYM(gtk_box_pack_end);
 DYN_GTK_SYM(gtk_box_pack_start);
@@ -213,8 +209,6 @@ static int PickIWad (WadStuff *wads, int numwads, bool showwin, int defaultiwad)
 	GtkTreeViewColumn *column;
 	GtkTreeSelection *selection;
 	GtkTreeIter iter, defiter;
-	GdkMonitor *monitor;
-	GdkRectangle monitor_geom{};
 	int close_style = 0;
 	int i;
 	char caption[100];
@@ -228,11 +222,7 @@ static int PickIWad (WadStuff *wads, int numwads, bool showwin, int defaultiwad)
 	gtk_container_set_border_width (GTK_CONTAINER(window), 10);
 	g_signal_connect (window, "delete_event", G_CALLBACK(gtk_main_quit), NULL);
 	g_signal_connect (window, "key_press_event", G_CALLBACK(CheckEscape), NULL);
-
-	// Get the display height and use it to set the default size for the window.
-	monitor = gdk_display_get_primary_monitor (gdk_display_get_default());
-	gdk_monitor_get_geometry (GDK_MONITOR(monitor), &monitor_geom);
-	gtk_window_set_default_size (GTK_WINDOW(window), -1, (monitor_geom.height / 2));
+	gtk_window_set_default_size (GTK_WINDOW(window), -1, 280);
 
 	// Create the vbox container.
 	if (gtk_box_new) // Gtk3

--- a/src/common/platform/posix/unix/gtk_dialogs.cpp
+++ b/src/common/platform/posix/unix/gtk_dialogs.cpp
@@ -133,11 +133,11 @@ DYN_GTK_SYM(gtk_widget_set_vexpand);
 DYN_GTK_SYM(gtk_window_activate_default);
 DYN_GTK_SYM(gtk_window_get_type);
 DYN_GTK_SYM(gtk_window_new);
+DYN_GTK_SYM(gtk_window_set_default_size);
 DYN_GTK_SYM(gtk_window_set_gravity);
 DYN_GTK_SYM(gtk_window_set_position);
 DYN_GTK_SYM(gtk_window_set_title);
 DYN_GTK_SYM(gtk_window_set_resizable);
-DYN_GTK_SYM(gtk_window_set_default_size);
 DYN_GTK_SYM(gtk_dialog_run);
 DYN_GTK_SYM(gtk_dialog_get_type);
 
@@ -230,8 +230,8 @@ static int PickIWad (WadStuff *wads, int numwads, bool showwin, int defaultiwad)
 	g_signal_connect (window, "key_press_event", G_CALLBACK(CheckEscape), NULL);
 
 	// Get the display height and use it to set the default size for the window.
-	monitor = gdk_display_get_primary_monitor(gdk_display_get_default());
-	gdk_monitor_get_geometry(GDK_MONITOR(monitor), &monitor_geom);
+	monitor = gdk_display_get_primary_monitor (gdk_display_get_default());
+	gdk_monitor_get_geometry (GDK_MONITOR(monitor), &monitor_geom);
 	gtk_window_set_default_size (GTK_WINDOW(window), -1, (monitor_geom.height / 2));
 
 	// Create the vbox container.


### PR DESCRIPTION
To fulfill #1451. Please review carefully. Have not tested this with a GTK2-only system yet. Note that this currently sets height to screen height / 2, which may need to be adjusted for stylistic purposes (it could look ridiculous on massive displays). This also technically enables horizontal scrolling (why not!).