### PR TITLE
- 8bit special "fullbright" dupe-color colormap fix

### DIFF
--- a/src/rendering/swrenderer/r_swcolormaps.cpp
+++ b/src/rendering/swrenderer/r_swcolormaps.cpp
@@ -353,7 +353,7 @@ void SetDefaultColormap (const char *name)
 		// [RH] If using BUILD's palette, generate the colormap
 		if (lump == -1 || fileSystem.CheckNumForFullName("palette.dat") >= 0 || fileSystem.CheckNumForFullName("blood.pal") >= 0)
 		{
-			Printf ("Make colormap\n");
+			DPrintf (DMSG_NOTIFY, "Make colormap\n");
 			FDynamicColormap foo;
 
 			foo.Color = 0xFFFFFF;


### PR DESCRIPTION
- fix colormap remapping when colormap entries may have fullbright entries which should not be considered duplicates
- this is a tentative fix, this likely needs some cleanup, but it's a starting point
- this is also not compatible with Raze, but it should be harmless in its current form (unless some Raze mod includes a "colormap" lump)
- this should address the "fullbright teeth" issue with the imps in KDiKDiZD: https://forum.zdoom.org/viewtopic.php?t=76790