### PR TITLE
Extended MENUDEF Functionality

### DIFF
--- a/src/common/menu/menu.h
+++ b/src/common/menu/menu.h
@@ -94,6 +94,7 @@ public:
 	int mVirtWidth;
 	int mVirtHeight;
 	bool mCustomSizeSet;
+	bool mForceList;
 
 	void Reset();
 };

--- a/src/menu/doommenu.cpp
+++ b/src/menu/doommenu.cpp
@@ -616,9 +616,9 @@ void M_StartupEpisodeMenu(FNewGameStartup *gs)
 			// center the menu on the screen if the top space is larger than the bottom space
 			int totalheight = posy + AllEpisodes.Size() * spacing - topy;
 
-			if (totalheight < 190 || AllEpisodes.Size() == 1)
+			if (ld->mForceList || totalheight < 190 || AllEpisodes.Size() == 1)
 			{
-				int newtop = (200 - totalheight) / 2;
+				int newtop = max(10, 200 - totalheight) / 2;
 				int topdelta = newtop - topy;
 				if (topdelta < 0)
 				{
@@ -760,9 +760,9 @@ static void BuildPlayerclassMenu()
 				ld->mAutoselect = ld->mItems.Push(it);
 				success = true;
 			}
-			else if (totalheight <= 190)
+			else if (ld->mForceList || totalheight <= 190)
 			{
-				int newtop = (200 - totalheight + topy) / 2;
+				int newtop = (max(10, 200 - totalheight) + topy) / 2;
 				int topdelta = newtop - topy;
 				if (topdelta < 0)
 				{
@@ -1146,9 +1146,9 @@ void M_StartupSkillMenu(FNewGameStartup *gs)
 				// center the menu on the screen if the top space is larger than the bottom space
 				int totalheight = posy + MenuSkills.Size() * spacing - topy;
 
-				if (totalheight < 190 || MenuSkills.Size() == 1)
+				if (ld->mForceList || totalheight < 190 || MenuSkills.Size() == 1)
 				{
-					int newtop = (200 - totalheight) / 2;
+					int newtop = max(10, 200 - totalheight) / 2;
 					int topdelta = newtop - topy;
 					if (topdelta < 0)
 					{


### PR DESCRIPTION
This PR mostly focuses on wrapping up some loose ends in MENUDEF. Option and Image Scroller items now have access to the same parameter types as List items and Option items can now get their menu descriptor. Image Scrollers can now have a custom class assigned to them like other menus.

`ForceList` is a new instruction for Lists specifically designed for getting around the issue where episode, skill, and playerclass menus get turned into Option menus if they grow too large. This behavior can completely break custom menus. This gives an explicit way to avoid the issue rather than using the current workaround of setting Linespacing to 0.