### PR TITLE
Make model stretch fix opt-in with a flag

### DIFF
--- a/src/r_data/models.h
+++ b/src/r_data/models.h
@@ -1,4 +1,4 @@
-// 
+//
 //---------------------------------------------------------------------------
 //
 // Copyright(C) 2005-2016 Christoph Oelckers
@@ -58,6 +58,7 @@ enum
 	MDL_NOPERPIXELLIGHTING			= 1024, // forces a model to not use per-pixel lighting. useful for voxel-converted-to-model objects.
 	MDL_SCALEWEAPONFOV				= 2048,	// scale weapon view model with higher user FOVs
 	MDL_MODELSAREATTACHMENTS		= 4096,	// any model index after 0 is treated as an attachment, and therefore will use the bone results of index 0
+	MDL_CORRECTPIXELSTRETCH			= 8192,	// ensure model does not distort with pixel stretch when pitch/roll is applied
 };
 
 FSpriteModelFrame * FindModelFrame(const PClass * ti, int sprite, int frame, bool dropped);


### PR DESCRIPTION
Because it can actually cause issues otherwise, add a `CORRECTPIXELSTRETCH` flag to modeldef to not break older mods. There are cases where this behavior could be intended.