### PR TITLE
Process events every frame as well to ensure that menus can run at any framerate

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1217,6 +1217,7 @@ void D_DoomLoop ()
 			}
 			// Update display, next frame, with current state.
 			I_StartTic ();
+			D_ProcessEvents();
 			D_Display ();
 			S_UpdateMusic();
 			if (wantToRestart)


### PR DESCRIPTION
This is my proposed fix to the issue at https://forum.zdoom.org/viewtopic.php?t=75696. I've been running this slight change locally for months and it's never caused any issues, although of course that doesn't guarantee it doesn't screw up an edge case.