### PR TITLE
Remove leftover variable from MessageBox in CustomMessageBox

### DIFF
--- a/wadsrc/static/zscript/engine/ui/menu/custommessagebox.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/custommessagebox.zs
@@ -35,7 +35,6 @@
 class CustomMessageBoxMenuBase : Menu abstract
 {
 	BrokenLines mMessage;
-	voidptr Handler;
 	uint messageSelection;
 	int mMouseLeft, mMouseRight, mMouseY;
 


### PR DESCRIPTION
A variable from MessageBox (`Handler`) got left behind when making the CustomMessageBox class, this removes it.