### PR TITLE
Allow assigning IQM frames by animation name plus frame offset

### DIFF
--- a/src/common/models/models_iqm.cpp
+++ b/src/common/models/models_iqm.cpp
@@ -434,10 +434,19 @@ void IQMModel::UnloadGeometry()
 
 int IQMModel::FindFrame(const char* name, bool nodefault)
 {
-	// This doesn't really mean all that much for IQM
+	// [MK] allow looking up frames by animation name plus offset (using a colon as separator)
+	const char* colon = strrchr(name,':');
+	int nlen = (colon==nullptr)?strlen(name):(colon-name);
 	for (unsigned i = 0; i < Anims.Size(); i++)
 	{
-		if (!stricmp(name, Anims[i].Name.GetChars())) return i;
+		if (!strnicmp(name, Anims[i].Name.GetChars(), nlen))
+		{
+			// if no offset is given, return the first frame
+			if (colon == nullptr) return Anims[i].FirstFrame;
+			unsigned offset = atoi(colon+1);
+			if (offset >= Anims[i].NumFrames) return FErr_NotFound;
+			return Anims[i].FirstFrame+offset;
+		}
 	}
 	return FErr_NotFound;
 }


### PR DESCRIPTION
Seeing as the functionality was very barebones, I decided to "complete" it myself. Hopefully, the code is acceptable.

An example is here: [iqmframetest.zip](https://github.com/ZDoom/gzdoom/files/10087712/iqmframetest.zip)

Type `summon playertest` in console to spawn the test actor, which should be an UT2004 player model with a looping idle animation.
