### PR TITLE
Allow Getting Portal Group Offsets

### DIFF
--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2436,6 +2436,12 @@ DEFINE_ACTION_FUNCTION(FLevelLocals, GetDisplacement)
 	ACTION_RETURN_VEC2(ofs);
 }
 
+DEFINE_ACTION_FUNCTION(FLevelLocals, GetPortalGroupCount)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	ACTION_RETURN_INT(self->Displacements.size);
+}
+
 void SphericalCoords(FLevelLocals *self, double vpX, double vpY, double vpZ, double tX, double tY, double tZ, double viewYaw, double viewPitch, int absolute, DVector3 *result)
 {
 	

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2419,6 +2419,23 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, Vec3Diff, Vec3Diff)
 	ACTION_RETURN_VEC3(VecDiff(self, DVector3(x1, y1, z1), DVector3(x2, y2, z2)));
 }
 
+DEFINE_ACTION_FUNCTION(FLevelLocals, GetDisplacement)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_INT(pg1);
+	PARAM_INT(pg2);
+
+	DVector2 ofs(0, 0);
+	if (pg1 != pg2)
+	{
+		int i = pg1 + self->Displacements.size * pg2;
+		if (i < self->Displacements.data.Size())
+			ofs = self->Displacements.data[i].pos;
+	}
+
+	ACTION_RETURN_VEC2(ofs);
+}
+
 void SphericalCoords(FLevelLocals *self, double vpX, double vpY, double vpZ, double tX, double tY, double tZ, double viewYaw, double viewPitch, int absolute, DVector3 *result)
 {
 	

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -491,6 +491,7 @@ struct LevelLocals native
 	native clearscope vector2 Vec2Offset(vector2 pos, vector2 dir, bool absolute = false) const;
 	native clearscope vector3 Vec2OffsetZ(vector2 pos, vector2 dir, double atz, bool absolute = false) const;
 	native clearscope vector3 Vec3Offset(vector3 pos, vector3 dir, bool absolute = false) const;
+	native clearscope Vector2 GetDisplacement(int pg1, int pg2) const;
 
 	native String GetChecksum() const;
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -492,6 +492,7 @@ struct LevelLocals native
 	native clearscope vector3 Vec2OffsetZ(vector2 pos, vector2 dir, double atz, bool absolute = false) const;
 	native clearscope vector3 Vec3Offset(vector3 pos, vector3 dir, bool absolute = false) const;
 	native clearscope Vector2 GetDisplacement(int pg1, int pg2) const;
+	native clearscope int GetPortalGroupCount() const;
 
 	native String GetChecksum() const;
 


### PR DESCRIPTION
Adds GetDisplacement to LevelLocals for getting the offset between two portal groups. 