### PR TITLE
AST debug dump cleanup

### DIFF
--- a/src/common/scripting/frontend/zcc_parser.cpp
+++ b/src/common/scripting/frontend/zcc_parser.cpp
@@ -1128,7 +1128,7 @@ ZCC_TreeNode *TreeNodeDeepCopy_Internal(ZCC_AST *ast, ZCC_TreeNode *orig, bool c
 	{
 		TreeNodeDeepCopy_Start(ArrayIterationStmt);
 
-		// ZCC_IterationStmt
+		// ZCC_ArrayIterationStmt
 		copy->ItName = static_cast<ZCC_VarName*>(TreeNodeDeepCopy_Internal(ast, origCasted->ItName, true, copiedNodesList));
 		copy->LoopStatement = static_cast<ZCC_Statement*>(TreeNodeDeepCopy_Internal(ast, origCasted->LoopStatement, true, copiedNodesList));
 		copy->ItArray = static_cast<ZCC_Expression*>(TreeNodeDeepCopy_Internal(ast, origCasted->ItArray, true, copiedNodesList));

--- a/src/common/scripting/frontend/zcc_parser.h
+++ b/src/common/scripting/frontend/zcc_parser.h
@@ -601,7 +601,7 @@ struct ZCC_MixinStmt : ZCC_Statement
 	ENamedName MixinName;
 };
 
-FString ZCC_PrintAST(ZCC_TreeNode *root);
+FString ZCC_PrintAST(const ZCC_TreeNode *root);
 
 
 struct ZCC_AST


### PR DESCRIPTION
- Add ArrayIterationStmt printer.
- Mark ZCC_TreeNodes as const for the AST printers.
- Use static_assert to catch missing printers without needing to run with -dumpast.