### PR TITLE
Fix UV "fix" for OBJ models

### DIFF
--- a/src/common/models/models_obj.cpp
+++ b/src/common/models/models_obj.cpp
@@ -544,7 +544,7 @@ inline FVector3 FOBJModel::RealignVector(FVector3 vecToRealign)
  */
 inline FVector2 FOBJModel::FixUV(FVector2 vecToRealign)
 {
-	vecToRealign.Y *= -1;
+	vecToRealign.Y = 1-vecToRealign.Y;
 	return vecToRealign;
 }
 


### PR DESCRIPTION
As discussed on Discord, this is a simple fix for the incorrect "fix" in UVs that the OBJ loader has when transforming between top-left and bottom-left coords.