### PR TITLE
Fix SNDINFO $rolloff always changing global rolloff

### DIFF
--- a/src/sound/s_advsound.cpp
+++ b/src/sound/s_advsound.cpp
@@ -952,7 +952,7 @@ static void S_AddSNDINFO (int lump)
 				{
 					sfx = soundEngine->FindSoundTentative(sc.String);
 					auto sfxp = soundEngine->GetWritableSfx(sfx);
-					sfxp->Rolloff;
+					rolloff = &sfxp->Rolloff;
 				}
 				type = ROLLOFF_Doom;
 				if (!sc.CheckFloat())


### PR DESCRIPTION
I investigated the issue a bit more by copying the grenade sounds from Wolfenstein: Blade of Agony and the definitions for the sounds from its SNDINFO lump, and then copying the entire SNDINFO lump from Wolfenstein: Blade of Agony into a small test mod, and disabling tags like $volume and $rolloff using sed. It turns out disabling $rolloff tags fixed the issue, and looking into the code, it seems as though the global rolloff was always being changed, or that `rolloff` was picking up a garbage pointer.

Fixes #1849