### PR TITLE
Fixed A_Changemodel crash from invalid modeldef names

### DIFF
--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -5123,6 +5123,11 @@ DEFINE_ACTION_FUNCTION(AActor, A_ChangeModel)
 
 	if (self == nullptr)
 		ACTION_RETURN_BOOL(false);
+	else if (modeldef != NAME_None && PClass::FindClass(modeldef.GetChars()) == nullptr)
+	{
+		Printf("Attempt to pass invalid modeldef name %s in %s.", modeldef.GetChars(), self->GetCharacterName());
+		ACTION_RETURN_BOOL(false);
+	}
 	else if (modelindex < 0)
 	{
 		Printf("Attempt to pass invalid model index %d in %s, index must be non-negative.", modelindex, self->GetCharacterName());


### PR DESCRIPTION
- Invalid modeldef names no longer result in a crash

https://forum.zdoom.org/viewtopic.php?t=76810