### PR TITLE
Look up named frames using the Animation ID (if any)

### DIFF
--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -820,6 +820,10 @@ static void ParseModelDefLump(int Lump)
 						if (smf.modelIDs[index] != -1)
 						{
 							FModel *model = Models[smf.modelIDs[index]];
+							if (smf.animationIDs[index] != -1)
+							{
+								model = Models[smf.animationIDs[index]];
+							}
 							smf.modelframes[index] = model->FindFrame(sc.String);
 							if (smf.modelframes[index]==-1) sc.ScriptError("Unknown frame '%s' in %s", sc.String, type->TypeName.GetChars());
 						}


### PR DESCRIPTION
If an Animation ID is present, the model referenced by it should be used to look up frames. Simple as that.