### PR TITLE
Scaled actor angles at framerate instead of forced interpolation

### DIFF
--- a/src/common/utility/vectors.h
+++ b/src/common/utility/vectors.h
@@ -1547,6 +1547,16 @@ inline TAngle<T> interpolatedvalue(const TAngle<T> &oang, const TAngle<T> &ang, 
 	return oang + (deltaangle(oang, ang) * interpfrac);
 }
 
+template<class T>
+inline TRotator<T> interpolatedvalue(const TRotator<T> &oang, const TRotator<T> &ang, const double interpfrac)
+{
+	return TRotator<T>(
+		interpolatedvalue(oang.Pitch, ang.Pitch, interpfrac),
+		interpolatedvalue(oang.Yaw, ang.Yaw, interpfrac),
+		interpolatedvalue(oang.Roll, ang.Roll, interpfrac)
+	);
+}
+
 template <class T>
 inline T interpolatedvalue(const T& oval, const T& val, const double interpfrac)
 {

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -923,6 +923,8 @@ public:
 	void SetPitch(DAngle p, int fflags);
 	void SetAngle(DAngle ang, int fflags);
 	void SetRoll(DAngle roll, int fflags);
+
+	// These also set CF_INTERPVIEWANGLES for players.
 	void SetViewPitch(DAngle p, int fflags);
 	void SetViewAngle(DAngle ang, int fflags);
 	void SetViewRoll(DAngle roll, int fflags);

--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -449,6 +449,10 @@ public:
 	void SetFOV(float fov);
 	bool HasWeaponsInSlot(int slot) const;
 	bool Resurrect();
+
+	// Scaled angle adjustment info. Not for direct manipulation.
+	DRotator angleTargets;
+	DRotator angleAppliedAmounts;
 };
 
 // Bookkeeping on players - state.

--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -481,4 +481,6 @@ inline bool AActor::IsNoClip2() const
 
 bool P_IsPlayerTotallyFrozen(const player_t *player);
 
+bool P_NoInterpolation(player_t const *player, AActor const *actor);
+
 #endif // __D_PLAYER_H__

--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -122,6 +122,7 @@ typedef enum
 	CF_TOTALLYFROZEN	= 1 << 12,		// [RH] All players can do is press +use
 	CF_PREDICTING		= 1 << 13,		// [RH] Player movement is being predicted
 	CF_INTERPVIEW		= 1 << 14,		// [RH] view was changed outside of input, so interpolate one frame
+	CF_INTERPVIEWANGLES	= 1 << 15,		// [RH] flag for interpolating view angles without interpolating the entire frame
 	CF_EXTREMELYDEAD	= 1 << 22,		// [RH] Reliably let the status bar know about extreme deaths.
 	CF_BUDDHA2			= 1 << 24,		// [MC] Absolute buddha. No voodoo can kill it either.
 	CF_GODMODE2			= 1 << 25,		// [MC] Absolute godmode. No voodoo can kill it either.

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3473,7 +3473,7 @@ void AActor::SetViewPitch(DAngle p, int fflags)
 		ViewAngles.Pitch = p;
 		if (player != nullptr && (fflags & SPF_INTERPOLATE))
 		{
-			player->cheats |= CF_INTERPVIEW;
+			player->cheats |= CF_INTERPVIEWANGLES;
 		}
 	}
 
@@ -3486,7 +3486,7 @@ void AActor::SetViewAngle(DAngle ang, int fflags)
 		ViewAngles.Yaw = ang;
 		if (player != nullptr && (fflags & SPF_INTERPOLATE))
 		{
-			player->cheats |= CF_INTERPVIEW;
+			player->cheats |= CF_INTERPVIEWANGLES;
 		}
 	}
 
@@ -3499,7 +3499,7 @@ void AActor::SetViewRoll(DAngle r, int fflags)
 		ViewAngles.Roll = r;
 		if (player != nullptr && (fflags & SPF_INTERPOLATE))
 		{
-			player->cheats |= CF_INTERPVIEW;
+			player->cheats |= CF_INTERPVIEWANGLES;
 		}
 	}
 }

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3427,10 +3427,25 @@ void AActor::SetPitch(DAngle p, int fflags)
 
 	if (p != Angles.Pitch)
 	{
-		Angles.Pitch = p;
-		if (player != nullptr && (fflags & SPF_INTERPOLATE))
+		if (player != nullptr)
 		{
-			player->cheats |= CF_INTERPVIEW;
+			if (fflags & SPF_INTERPOLATE)
+			{
+				if (P_NoInterpolation(player, this))
+				{
+					player->angleTargets.Pitch = deltaangle(Angles.Pitch, p);
+					player->angleAppliedAmounts.Pitch = nullAngle;
+				}
+				else
+				{
+					Angles.Pitch = p;
+					player->cheats |= CF_INTERPVIEW;
+				}
+			}
+		}
+		else
+		{
+			Angles.Pitch = p;
 		}
 	}
 	
@@ -3440,10 +3455,25 @@ void AActor::SetAngle(DAngle ang, int fflags)
 {
 	if (ang != Angles.Yaw)
 	{
-		Angles.Yaw = ang;
-		if (player != nullptr && (fflags & SPF_INTERPOLATE))
+		if (player != nullptr)
 		{
-			player->cheats |= CF_INTERPVIEW;
+			if (fflags & SPF_INTERPOLATE)
+			{
+				if (P_NoInterpolation(player, this))
+				{
+					player->angleTargets.Yaw = deltaangle(Angles.Yaw, ang);
+					player->angleAppliedAmounts.Yaw = nullAngle;
+				}
+				else
+				{
+					Angles.Yaw = ang;
+					player->cheats |= CF_INTERPVIEW;
+				}
+			}
+		}
+		else
+		{
+			Angles.Yaw = ang;
 		}
 	}
 	
@@ -3453,10 +3483,25 @@ void AActor::SetRoll(DAngle r, int fflags)
 {
 	if (r != Angles.Roll)
 	{
-		Angles.Roll = r;
-		if (player != nullptr && (fflags & SPF_INTERPOLATE))
+		if (player != nullptr)
 		{
-			player->cheats |= CF_INTERPVIEW;
+			if (fflags & SPF_INTERPOLATE)
+			{
+				if (P_NoInterpolation(player, this))
+				{
+					player->angleTargets.Roll = deltaangle(Angles.Roll, r);
+					player->angleAppliedAmounts.Roll = nullAngle;
+				}
+				else
+				{
+					Angles.Roll = r;
+					player->cheats |= CF_INTERPVIEW;
+				}
+			}
+		}
+		else
+		{
+			Angles.Roll = r;
 		}
 	}
 }

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1258,6 +1258,7 @@ void P_PlayerThink (player_t *player)
 	player->original_cmd = cmd->ucmd;
 	// Don't interpolate the view for more than one tic
 	player->cheats &= ~CF_INTERPVIEW;
+	player->cheats &= ~CF_INTERPVIEWANGLES;
 	player->mo->FloatVar("prevBob") = player->bob;
 
 	IFVIRTUALPTRNAME(player->mo, NAME_PlayerPawn, PlayerThink)

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -528,8 +528,8 @@ void R_InterpolateView (FRenderViewpoint &viewpoint, player_t *player, double Fr
 		(!netgame || !cl_noprediction) &&
 		!LocalKeyboardTurner)
 	{
-		viewpoint.Angles.Yaw = (nviewangle + DAngle::fromBam(LocalViewAngle & 0xFFFF0000)).Normalized180();
-		DAngle delta = player->centering ? nullAngle : DAngle::fromBam(int(LocalViewPitch & 0xFFFF0000));
+		viewpoint.Angles.Yaw = (nviewangle + DAngle::fromBam(LocalViewAngle)).Normalized180();
+		DAngle delta = player->centering ? nullAngle : DAngle::fromBam(LocalViewPitch);
 		viewpoint.Angles.Pitch = clamp<DAngle>((iview->New.Angles.Pitch - delta).Normalized180(), player->MinPitch, player->MaxPitch);
 		viewpoint.Angles.Roll = iview->New.Angles.Roll.Normalized180();
 	}

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1136,6 +1136,7 @@ enum EPlayerCheats
 	CF_TOTALLYFROZEN	= 1 << 12,		// [RH] All players can do is press +use
 	CF_PREDICTING		= 1 << 13,		// [RH] Player movement is being predicted
 	CF_INTERPVIEW		= 1 << 14,		// [RH] view was changed outside of input, so interpolate one frame
+	CF_INTERPVIEWANGLES	= 1 << 15,		// [RH] flag for interpolating view angles without interpolating the entire frame
 
 	CF_EXTREMELYDEAD	= 1 << 22,		// [RH] Reliably let the status bar know about extreme deaths.
 


### PR DESCRIPTION
This PR is to address the issues raised in https://forum.zdoom.org/viewtopic.php?t=72245 by using a setup that Raze has adopted for such situations. I've tested this implementation with the two test files Nash provided in the forums and the angle changes apply smoothly without forcing interpolation upon the player.

This solution is _not_ multiplayer or demo friendly, therefore the existing behaviour is preserved for such use cases, it's only for single player gaming where this can be safely applied.

I would love to have this tested against a variety of mods and use cases prior to merging as I've implemented this in as a drop-in uplift so that existing mods can benefit. If there's scenarios where this causes issues, it may need to be a separate flag that gets used when calling `AActor::SetYaw()` et. al.