### PR TITLE
Fixed IsActorPlayingSound

### DIFF
--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1129,7 +1129,7 @@ class Actor : Thinker native
 	native void A_StopSounds(int chanmin, int chanmax);
 	deprecated("2.3", "Use A_StartSound() instead") native void A_PlaySoundEx(sound whattoplay, name slot, bool looping = false, int attenuation = 0);
 	deprecated("2.3", "Use A_StopSound() instead") native void A_StopSoundEx(name slot);
-	native clearscope bool IsActorPlayingSound(int channel, Sound snd = 0);
+	native clearscope bool IsActorPlayingSound(int channel, Sound snd = -1);
 	native void A_SeekerMissile(int threshold, int turnmax, int flags = 0, int chance = 50, int distance = 10);
 	native action state A_Jump(int chance, statelabel label, ...);
 	native Actor A_SpawnProjectile(class<Actor> missiletype, double spawnheight = 32, double spawnofs_xy = 0, double angle = 0, int flags = 0, double pitch = 0, int ptr = AAPTR_TARGET);


### PR DESCRIPTION
Previously a value of 0 for the sound id would tell it to ignore the id check but this value has since been updated to -1.