### PR TITLE
Add Alternate Light Blending Options for Mappers

### DIFF
--- a/src/common/rendering/gl/gl_shader.cpp
+++ b/src/common/rendering/gl/gl_shader.cpp
@@ -235,6 +235,8 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 			float uClipHeight;
 			float uClipHeightDirection;
 			int uShadowmapFilter;
+			
+			int uLightBlendMode;
 		};
 
 		uniform int uTextureMode;

--- a/src/common/rendering/hwrenderer/data/hw_viewpointbuffer.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_viewpointbuffer.cpp
@@ -30,6 +30,7 @@
 #include "hw_renderstate.h"
 #include "hw_viewpointbuffer.h"
 #include "hw_cvars.h"
+#include "g_levellocals.h"
 
 static const int INITIAL_BUFFER_SIZE = 100;	// 100 viewpoints per frame should nearly always be enough
 
@@ -91,6 +92,7 @@ void HWViewpointBuffer::Set2D(FRenderState &di, int width, int height, int pll)
 	matrices.mPalLightLevels = pll;
 	matrices.mClipLine.X = -10000000.0f;
 	matrices.mShadowmapFilter = gl_shadowmap_filter;
+	matrices.mLightBlendMode = (level.info ? (int)level.info->lightblendmode : 0);
 
 	matrices.mProjectionMatrix.ortho(0, (float)width, (float)height, 0, -1.0f, 1.0f);
 	matrices.CalcDependencies();

--- a/src/common/rendering/hwrenderer/data/hw_viewpointuniforms.h
+++ b/src/common/rendering/hwrenderer/data/hw_viewpointuniforms.h
@@ -19,6 +19,8 @@ struct HWViewpointUniforms
 	float mClipHeightDirection = 0.f;
 	int mShadowmapFilter = 1;
 
+	int mLightBlendMode = 0;
+
 	void CalcDependencies()
 	{
 		mNormalViewMatrix.computeNormalMatrix(mViewMatrix);

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.h
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.h
@@ -555,16 +555,6 @@ private:
 	PPShader Uncharted2Shader = { "shaders/pp/tonemap.fp", "#define UNCHARTED2\n", {} };
 	PPShader PaletteShader = { "shaders/pp/tonemap.fp", "#define PALETTE\n", {} };
 
-	enum TonemapMode
-	{
-		None,
-		Uncharted2,
-		HejlDawson,
-		Reinhard,
-		Linear,
-		Palette,
-		NumTonemapModes
-	};
 };
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/common/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_shader.cpp
@@ -175,6 +175,8 @@ static const char *shaderBindings = R"(
 		float uClipHeight;
 		float uClipHeightDirection;
 		int uShadowmapFilter;
+		
+		int uLightBlendMode;
 	};
 
 	layout(set = 1, binding = 1, std140) uniform MatricesUBO {

--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -53,4 +53,13 @@ enum class ELightMode : int8_t
 	DoomSoftware = 16
 };
 
+enum class ELightBlendMode : uint8_t
+{
+	CLAMP = 0,
+	CLAMP_COLOR = 1,
+	NOCLAMP = 2,
+
+	DEFAULT = CLAMP,
+};
+
 #endif

--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -62,4 +62,15 @@ enum class ELightBlendMode : uint8_t
 	DEFAULT = CLAMP,
 };
 
+enum class ETonemapMode : uint8_t
+{
+	None,
+	Uncharted2,
+	HejlDawson,
+	Reinhard,
+	Linear,
+	Palette,
+	NumTonemapModes
+};
+
 #endif

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -303,6 +303,7 @@ void level_info_t::Reset()
 	skyrotatevector = FVector3(0, 0, 1);
 	skyrotatevector2 = FVector3(0, 0, 1);
 	lightblendmode = ELightBlendMode::DEFAULT;
+	tonemap = ETonemapMode::None;
 }
 
 
@@ -1501,17 +1502,41 @@ DEFINE_MAP_OPTION(lightblendmode, false)
 	parse.ParseAssign();
 	parse.sc.MustGetString();
 
-	if(strcmp(parse.sc.String,"DEFAULT") == 0 || strcmp(parse.sc.String,"CLAMP") == 0)
+	if (parse.sc.Compare("Default") || parse.sc.Compare("Clamp"))
 	{
 		info->lightblendmode = ELightBlendMode::DEFAULT;
 	}
-	else if(strcmp(parse.sc.String,"COLOR_CORRECT_CLAMP") == 0)
+	else if (parse.sc.Compare("ColoredClamp"))
 	{
 		info->lightblendmode = ELightBlendMode::CLAMP_COLOR;
 	}
-	else if(strcmp(parse.sc.String,"UNCLAMPED") == 0)
+	else if (parse.sc.Compare("Unclamped"))
 	{
 		info->lightblendmode = ELightBlendMode::NOCLAMP;
+		if(parse.sc.CheckString(","))
+		{
+			parse.sc.MustGetString();
+			if (parse.sc.Compare("None"))
+			{
+				info->tonemap = ETonemapMode::None;
+			}
+			else if (parse.sc.Compare("Linear"))
+			{
+				info->tonemap = ETonemapMode::Linear;
+			}
+			else if (parse.sc.Compare("Uncharted2"))
+			{
+				info->tonemap = ETonemapMode::Uncharted2;
+			}
+			else if (parse.sc.Compare("HejlDawson"))
+			{
+				info->tonemap = ETonemapMode::HejlDawson;
+			}
+			else if (parse.sc.Compare("Reinhard"))
+			{
+				info->tonemap = ETonemapMode::Reinhard;
+			}
+		}
 	}
 	else
 	{

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -302,7 +302,7 @@ void level_info_t::Reset()
 	lightadditivesurfaces = -1;
 	skyrotatevector = FVector3(0, 0, 1);
 	skyrotatevector2 = FVector3(0, 0, 1);
-
+	lightblendmode = ELightBlendMode::DEFAULT;
 }
 
 
@@ -1493,6 +1493,29 @@ DEFINE_MAP_OPTION(lightmode, false)
 	else
 	{
 		parse.sc.ScriptMessage("Invalid light mode %d", parse.sc.Number);
+	}
+}
+
+DEFINE_MAP_OPTION(lightblendmode, false)
+{
+	parse.ParseAssign();
+	parse.sc.MustGetString();
+
+	if(strcmp(parse.sc.String,"DEFAULT") == 0 || strcmp(parse.sc.String,"CLAMP") == 0)
+	{
+		info->lightblendmode = ELightBlendMode::DEFAULT;
+	}
+	else if(strcmp(parse.sc.String,"COLOR_CORRECT_CLAMP") == 0)
+	{
+		info->lightblendmode = ELightBlendMode::CLAMP_COLOR;
+	}
+	else if(strcmp(parse.sc.String,"UNCLAMPED") == 0)
+	{
+		info->lightblendmode = ELightBlendMode::NOCLAMP;
+	}
+	else
+	{
+		parse.sc.ScriptMessage("Invalid light blend mode %s", parse.sc.String);
 	}
 }
 

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1536,6 +1536,10 @@ DEFINE_MAP_OPTION(lightblendmode, false)
 			{
 				info->tonemap = ETonemapMode::Reinhard;
 			}
+			else
+			{
+				parse.sc.ScriptMessage("Invalid tonemap %s", parse.sc.String);
+			}
 		}
 	}
 	else

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -405,6 +405,7 @@ struct level_info_t
 	FString		EDName;
 	FString		acsName;
 	bool		fs_nocheckposition;
+	ELightBlendMode lightblendmode;
 	
 	CutsceneDef intro, outro;
 

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -406,6 +406,7 @@ struct level_info_t
 	FString		acsName;
 	bool		fs_nocheckposition;
 	ELightBlendMode lightblendmode;
+	ETonemapMode tonemap;
 	
 	CutsceneDef intro, outro;
 

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -48,6 +48,7 @@
 #include "a_corona.h"
 #include "texturemanager.h"
 #include "actorinlines.h"
+#include "g_levellocals.h"
 
 EXTERN_CVAR(Float, r_visibility)
 CVAR(Bool, gl_bandedswlight, false, CVAR_ARCHIVE)
@@ -164,6 +165,7 @@ void HWDrawInfo::StartScene(FRenderViewpoint &parentvp, HWViewpointUniforms *uni
 		}
 		VPUniforms.mClipLine.X = -10000000.0f;
 		VPUniforms.mShadowmapFilter = gl_shadowmap_filter;
+		VPUniforms.mLightBlendMode = (level.info ? (int)level.info->lightblendmode : 0);
 	}
 	mClipper->SetViewpoint(Viewpoint);
 

--- a/wadsrc/static/shaders/glsl/material_normal.fp
+++ b/wadsrc/static/shaders/glsl/material_normal.fp
@@ -59,7 +59,21 @@ vec3 ProcessMaterialLight(Material material, vec3 color)
 		}
 	}
 
-	vec3 frag = material.Base.rgb * clamp(color + desaturate(dynlight).rgb, 0.0, 1.4);
+	vec3 frag;
+
+	if ( uLightBlendMode == 1 )
+	{	// COLOR_CORRECT_CLAMPING 
+		vec3 lightcolor = color + desaturate(dynlight).rgb;
+		frag = material.Base.rgb * ((lightcolor / max(max(max(lightcolor.r, lightcolor.g), lightcolor.b), 1.4) * 1.4));
+	}
+	else if ( uLightBlendMode == 2 )
+	{	// UNCLAMPED 
+		frag = material.Base.rgb * (color + desaturate(dynlight).rgb);
+	}
+	else
+	{
+		frag = material.Base.rgb * clamp(color + desaturate(dynlight).rgb, 0.0, 1.4);
+	}
 
 	if (uLightIndex >= 0)
 	{

--- a/wadsrc/static/shaders/glsl/material_specular.fp
+++ b/wadsrc/static/shaders/glsl/material_specular.fp
@@ -66,9 +66,25 @@ vec3 ProcessMaterialLight(Material material, vec3 color)
 			}
 		}
 	}
+	
+	if ( uLightBlendMode == 1 )
+	{	// COLOR_CORRECT_CLAMPING 
+		dynlight.rgb = color + desaturate(dynlight).rgb;
+		specular.rgb = desaturate(specular).rgb;
 
-	dynlight.rgb = clamp(color + desaturate(dynlight).rgb, 0.0, 1.4);
-	specular.rgb = clamp(desaturate(specular).rgb, 0.0, 1.4);
+		dynlight.rgb = ((dynlight.rgb / max(max(max(dynlight.r, dynlight.g), dynlight.b), 1.4) * 1.4));
+		specular.rgb = ((specular.rgb / max(max(max(specular.r, specular.g), specular.b), 1.4) * 1.4));
+	}
+	else if ( uLightBlendMode == 2 )
+	{	// UNCLAMPED 
+		dynlight.rgb = color + desaturate(dynlight).rgb;
+		specular.rgb = desaturate(specular).rgb;
+	}
+	else
+	{
+		dynlight.rgb = clamp(color + desaturate(dynlight).rgb, 0.0, 1.4);
+		specular.rgb = clamp(desaturate(specular).rgb, 0.0, 1.4);
+	}
 
 	vec3 frag = material.Base.rgb * dynlight.rgb + material.Specular * specular.rgb;
 


### PR DESCRIPTION
This doesn't change the lighting of existing maps, as the modes are opt-in per-map via MAPINFO