### PR TITLE
Use RollBefore, Angle, Pitch, RollAfter for BobWeapon3D instead of Angle, Pitch, RollAfter

### DIFF
--- a/src/common/scripting/vm/vm.h
+++ b/src/common/scripting/vm/vm.h
@@ -220,6 +220,11 @@ struct VMReturn
 		Location = loc;
 		RegType = REGT_FLOAT | REGT_MULTIREG3;
 	}
+	void Vec4At(DVector4 *loc)
+	{
+		Location = loc;
+		RegType = REGT_FLOAT | REGT_MULTIREG4;
+	}
 	void StringAt(FString *loc)
 	{
 		Location = loc;

--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -641,14 +641,15 @@ void P_BobWeapon (player_t *player, float *x, float *y, double ticfrac)
 	*x = *y = 0;
 }
 
-void P_BobWeapon3D (player_t *player, FVector3 *translation, FVector3 *rotation, double ticfrac) {
+void P_BobWeapon3D (player_t *player, FVector3 *translation, FVector4 *rotation, double ticfrac) {
 	IFVIRTUALPTRNAME(player->mo, NAME_PlayerPawn, BobWeapon3D)
 	{
 		VMValue param[] = { player->mo, ticfrac };
-		DVector3 t, r;
+		DVector3 t;
+		DVector4 r;
 		VMReturn returns[2];
 		returns[0].Vec3At(&t);
-		returns[1].Vec3At(&r);
+		returns[1].Vec4At(&r);
 		VMCall(func, param, 2, returns, 2);
 		translation->X = (float)t.X;
 		translation->Y = (float)t.Y;
@@ -656,9 +657,11 @@ void P_BobWeapon3D (player_t *player, FVector3 *translation, FVector3 *rotation,
 		rotation->X = (float)r.X;
 		rotation->Y = (float)r.Y;
 		rotation->Z = (float)r.Z;
+		rotation->W = (float)r.W;
 		return;
 	}
-	*translation = *rotation = {};
+	*translation = {};
+	*rotation = {};
 }
 
 //---------------------------------------------------------------------------

--- a/src/playsim/p_pspr.h
+++ b/src/playsim/p_pspr.h
@@ -156,7 +156,7 @@ void P_SetPsprite(player_t *player, PSPLayers id, FState *state, bool pending = 
 void P_BringUpWeapon (player_t *player);
 void P_FireWeapon (player_t *player);
 void P_BobWeapon (player_t *player, float *x, float *y, double ticfrac);
-void P_BobWeapon3D (player_t *player, FVector3 *translation, FVector3 *rotation, double ticfrac);
+void P_BobWeapon3D (player_t *player, FVector3 *translation, FVector4 *rotation, double ticfrac);
 DAngle P_BulletSlope (AActor *mo, FTranslatedLineTarget *pLineTarget = NULL, int aimflags = 0);
 AActor *P_AimTarget(AActor *mo);
 

--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -193,7 +193,7 @@ void RenderModel(FModelRenderer *renderer, float x, float y, float z, FSpriteMod
 	renderer->EndDrawModel(actor->RenderStyle, smf);
 }
 
-void RenderHUDModel(FModelRenderer *renderer, DPSprite *psp, FVector3 translation, FVector3 rotation, FVector3 rotation_pivot, FSpriteModelFrame *smf)
+void RenderHUDModel(FModelRenderer *renderer, DPSprite *psp, FVector3 translation, FVector4 rotation, FVector3 rotation_pivot, FSpriteModelFrame *smf)
 {
 	AActor * playermo = players[consoleplayer].camera;
 
@@ -224,10 +224,11 @@ void RenderHUDModel(FModelRenderer *renderer, DPSprite *psp, FVector3 translatio
 	
 
 	objectToWorldMatrix.translate(rotation_pivot.X, rotation_pivot.Y, rotation_pivot.Z);
-	
-	objectToWorldMatrix.rotate(rotation.X, 0, 1, 0);
-	objectToWorldMatrix.rotate(rotation.Y, 1, 0, 0);
-	objectToWorldMatrix.rotate(rotation.Z, 0, 0, 1);
+
+	objectToWorldMatrix.rotate(rotation.X, 0, 0, 1); // rollBefore
+	objectToWorldMatrix.rotate(rotation.Y, 0, 1, 0); // angle
+	objectToWorldMatrix.rotate(rotation.Z, 1, 0, 0); // pitch
+	objectToWorldMatrix.rotate(rotation.W, 0, 0, 1); // rollAfter
 
 	objectToWorldMatrix.translate(-rotation_pivot.X, -rotation_pivot.Y, -rotation_pivot.Z);
 	

--- a/src/r_data/models.h
+++ b/src/r_data/models.h
@@ -110,7 +110,7 @@ void BSPWalkCircle(FLevelLocals *Level, float x, float y, float radiusSquared, c
 }
 
 void RenderModel(FModelRenderer* renderer, float x, float y, float z, FSpriteModelFrame* smf, AActor* actor, double ticFrac);
-void RenderHUDModel(FModelRenderer* renderer, DPSprite* psp, FVector3 translation, FVector3 rotation, FVector3 rotation_pivot, FSpriteModelFrame *smf);
+void RenderHUDModel(FModelRenderer* renderer, DPSprite* psp, FVector3 translation, FVector4 rotation, FVector3 rotation_pivot, FSpriteModelFrame *smf);
 
 EXTERN_CVAR(Float, cl_scaleweaponfov)
 

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -89,7 +89,7 @@ void HWDrawInfo::DrawPSprite(HUDSprite *huds, FRenderState &state)
 		state.AlphaFunc(Alpha_GEqual, 0);
 
 		FHWModelRenderer renderer(this, state, huds->lightindex);
-		RenderHUDModel(&renderer, huds->weapon, huds->translation, huds->rotation + FVector3(huds->mx / 4., (huds->my - WEAPONTOP) / 4., 0), FVector3(0, 0, 0), huds->mframe);
+		RenderHUDModel(&renderer, huds->weapon, huds->translation, huds->rotation + FVector4(0, huds->mx / 4., (huds->my - WEAPONTOP) / 4., 0), FVector3(0, 0, 0), huds->mframe);
 		state.SetVertexBuffer(screen->mVertexData);
 	}
 	else
@@ -255,7 +255,7 @@ static FVector2 BobWeapon2D(WeaponPosition2D &weap, DPSprite *psp, double ticFra
 	return { sx, sy };
 }
 
-static FVector2 BobWeapon3D(WeaponPosition3D &weap, DPSprite *psp, FVector3 &translation, FVector3 &rotation, FVector3 &pivot, double ticFrac)
+static FVector2 BobWeapon3D(WeaponPosition3D &weap, DPSprite *psp, FVector3 &translation, FVector4 &rotation, FVector3 &pivot, double ticFrac)
 {
 	if (psp->firstTic)
 	{ // Can't interpolate the first tic.
@@ -269,13 +269,14 @@ static FVector2 BobWeapon3D(WeaponPosition3D &weap, DPSprite *psp, FVector3 &tra
 
 	if (psp->Flags & PSPF_ADDBOB)
 	{
-		translation = (psp->Flags & PSPF_MIRROR) ? FVector3(-weap.translation.X, weap.translation.Y, weap.translation.Z) : weap.translation ; // TODO handle PSPF_MIRROR?
+		translation = (psp->Flags & PSPF_MIRROR) ? FVector3(-weap.translation.X, weap.translation.Y, weap.translation.Z) : weap.translation ;
 		rotation = weap.rotation;
 		pivot = weap.pivot;
 	}
 	else
 	{
-		translation = rotation = pivot = FVector3(0,0,0);
+		translation = pivot = FVector3(0,0,0);
+		rotation = FVector4(0,0,0,0);
 	}
 
 	if (psp->Flags & PSPF_ADDWEAPON && psp->GetID() != PSP_WEAPON)

--- a/src/rendering/hwrenderer/scene/hw_weapon.h
+++ b/src/rendering/hwrenderer/scene/hw_weapon.h
@@ -24,8 +24,8 @@ struct WeaponPosition3D
 		  wy;
 
 	FVector3 translation,
-			 rotation,
 			 pivot;
+	FVector4 rotation;
 
 	DPSprite *weapon;
 };
@@ -55,7 +55,8 @@ struct HUDSprite
 	float mx, my;
 	float dynrgb[3];
 
-	FVector3 rotation, translation, pivot;
+	FVector3 translation, pivot;
+	FVector4 rotation;
 
 	int lightindex;
 

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2438,9 +2438,9 @@ class PlayerPawn : Actor
 		return p1 * (1. - ticfrac) + p2 * ticfrac;
 	}
 
-	virtual Vector3 /*translation*/ , Vector3 /*rotation*/ BobWeapon3D (double ticfrac)
+	virtual Vector3 /*translation*/ , Vector4 /* rollBefore , angle, pitch, rollAfter */ BobWeapon3D (double ticfrac)
 	{
-		return (0, 0, 0) , (BobWeapon(ticfrac) / 4, 0);
+		return (0, 0, 0) , (0, BobWeapon(ticfrac) / 4, 0);
 	}
 	
 	//----------------------------------------------------------------------------


### PR DESCRIPTION
gifs showing the difference between roll before angle/pitch and after it are in the ZDoom Discord, #gzdoom-development (they're too big for github)