### PR TITLE
Zscript Custom CVars

### DIFF
--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -215,13 +215,11 @@ FBaseCVar::~FBaseCVar ()
 void FBaseCVar::SetCallback(void (*callback)(FBaseCVar&))
 {
 	m_Callback = callback;
-	m_UseCallback = true;
 }
 
 void FBaseCVar::ClearCallback()
 {
 	m_Callback = nullptr;
-	m_UseCallback = false;
 }
 
 void FBaseCVar::SetExtraDataPointer(void *pointer)

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1584,6 +1584,8 @@ void ParseCVarInfo()
 			ECVarType cvartype = CVAR_Dummy;
 			int cvarflags = CVAR_MOD|CVAR_ARCHIVE;
 			FBaseCVar *cvar;
+			bool customCVar = false;
+			FName customCVarClassName;
 
 			// Check for flag tokens.
 			while (sc.TokenType == TK_Identifier)
@@ -1611,6 +1613,14 @@ void ParseCVarInfo()
 				else if (stricmp(sc.String, "nosave") == 0)
 				{
 					cvarflags |= CVAR_CONFIG_ONLY;
+				}
+				else if (stricmp(sc.String, "handlerClass") == 0)
+				{
+					sc.MustGetStringName("(");
+					sc.MustGetString();
+					customCVar = true;
+					customCVarClassName = sc.String;
+					sc.MustGetStringName(")");
 				}
 				else
 				{
@@ -1694,7 +1704,7 @@ void ParseCVarInfo()
 				}
 			}
 			// Now create the cvar.
-			cvar = C_CreateCVar(cvarname, cvartype, cvarflags);
+			cvar = customCVar ? C_CreateZSCustomCVar(cvarname, cvartype, cvarflags, customCVarClassName) : C_CreateCVar(cvarname, cvartype, cvarflags);
 			if (cvardefault != NULL)
 			{
 				UCVarValue val;
@@ -3252,6 +3262,8 @@ static int D_InitGame(const FIWADInfo* iwad_info, TArray<FString>& allwads, TArr
 
 	R_ParseTrnslate();
 	PClassActor::StaticInit ();
+	FBaseCVar::InitZSCallbacks ();
+	
 	Job_Init();
 
 	// [GRB] Initialize player class list

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -688,6 +688,31 @@ struct CVar native
 	native int ResetToDefault();
 }
 
+class CustomIntCVar abstract
+{
+    abstract int ModifyValue(Name CVarName, int val);
+}
+
+class CustomFloatCVar abstract
+{
+    abstract double ModifyValue(Name CVarName, double val);
+}
+
+class CustomStringCVar abstract
+{
+    abstract String ModifyValue(Name CVarName, String val);
+}
+
+class CustomBoolCVar abstract
+{
+    abstract bool ModifyValue(Name CVarName, bool val);
+}
+
+class CustomColorCVar abstract
+{
+    abstract Color ModifyValue(Name CVarName, Color val);
+}
+
 struct GIFont version("2.4")
 {
 	Name fontname;


### PR DESCRIPTION
Allows a ZScript handler to constrain or observe changes to a CVar.
Example: [CustomCVarTest.zip](https://github.com/ZDoom/gzdoom/files/10251919/CustomCVarTest.zip)

Due to the way User CVars are currently implemented, it was infeasible to handle changes to them outside of the Console -- should they be overhauled in the future, it might be possible to add support for them outside of the console as well.
