### PR TITLE
Expose StripLeft and StripLeftRight to ZScript

### DIFF
--- a/src/common/scripting/interface/stringformat.cpp
+++ b/src/common/scripting/interface/stringformat.cpp
@@ -578,6 +578,34 @@ DEFINE_ACTION_FUNCTION_NATIVE(FStringStruct, StripRight, StringStripRight)
 	return 0;
 }
 
+static void StringStripLeft(FString* self, const FString& junk)
+{
+	if (junk.IsNotEmpty()) self->StripLeft(junk);
+	else self->StripLeft();
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FStringStruct, StripLeft, StringStripLeft)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FString);
+	PARAM_STRING(junk);
+	StringStripLeft(self, junk);
+	return 0;
+}
+
+static void StringStripLeftRight(FString* self, const FString& junk)
+{
+	if (junk.IsNotEmpty()) self->StripLeftRight(junk);
+	else self->StripLeftRight();
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FStringStruct, StripLeftRight, StringStripLeftRight)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FString);
+	PARAM_STRING(junk);
+	StringStripLeftRight(self, junk);
+	return 0;
+}
+
 static void StringSplit(FString* self, TArray<FString>* tokens, const FString& delimiter, int keepEmpty)
 {
 	self->Split(*tokens, delimiter, static_cast<FString::EmptyTokenType>(keepEmpty));

--- a/src/common/utility/zstring.cpp
+++ b/src/common/utility/zstring.cpp
@@ -843,7 +843,7 @@ void FString::StripLeftRight ()
 	}
 	for (j = max - 1; j >= i; --j)
 	{
-		if (Chars[i] < 0 || !isspace((unsigned char)Chars[j]))
+		if (Chars[j] < 0 || !isspace((unsigned char)Chars[j]))
 			break;
 	}
 	if (i == 0 && j == max - 1)
@@ -863,7 +863,7 @@ void FString::StripLeftRight ()
 	{
 		FStringData *old = Data();
 		AllocBuffer(j - i + 1);
-		StrCopy(Chars, old->Chars(), j - i + 1);
+		StrCopy(Chars, old->Chars() + i, j - i + 1);
 		old->Release();
 	}
 }
@@ -899,8 +899,8 @@ void FString::StripLeftRight (const char *charset)
 	else
 	{
 		FStringData *old = Data();
-		AllocBuffer (j - i);
-		StrCopy (Chars, old->Chars(), j - i);
+		AllocBuffer (j - i + 1);
+		StrCopy (Chars, old->Chars() + i, j - i + 1);
 		old->Release();
 	}
 }

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -881,7 +881,9 @@ struct StringStruct native
 	native int CodePointCount() const;
 	native int, int GetNextCodePoint(int position) const;
 	native void Substitute(String str, String replace);
+	native void StripLeft(String junk = "");
 	native void StripRight(String junk = "");
+	native void StripLeftRight(String junk = "");
 }
 
 struct Translation version("2.4")


### PR DESCRIPTION
Also fixes bad logic in StripLeftRight.
Example: [StringStripTest.zip](https://github.com/ZDoom/gzdoom/files/10255019/StringStripTest.zip)
