### PR TITLE
Update and clean up UE1 model loader

### DIFF
--- a/src/common/models/model_ue1.h
+++ b/src/common/models/model_ue1.h
@@ -35,7 +35,6 @@ public:
 	{
 		mDataLump = -1;
 		mAnivLump = -1;
-		mDataLoaded = false;
 		dhead = NULL;
 		dpolys = NULL;
 		ahead = NULL;
@@ -49,7 +48,6 @@ public:
 
 private:
 	int mDataLump, mAnivLump;
-	bool mDataLoaded;
 
 	// raw data structures
 	struct d3dhead
@@ -105,9 +103,10 @@ private:
 	int numFrames;
 	int numPolys;
 	int numGroups;
-	TArray<int> specialPolys;	// for future model attachment support, unused for now
+	bool hasWeaponTriangle;
 
 	TArray<UE1Vertex> verts;
 	TArray<UE1Poly> polys;
 	TArray<UE1Group> groups;
+	//TArray<TRS> weapondata;	// pseudo-bone generated from weapon triangle (not yet implemented)
 };


### PR DESCRIPTION
The main thing here is unloading geometry from RAM after building the vertex buffer, as this would otherwise linger around and eat up a lot of memory (measurements with my mods give me between 10% and 20% less RAM usage with this change, depending on the number and complexity of models).