### PR TITLE
Fixed the ACS PLAYERINFO_FVIEWBOB to be a bool instead of a double.

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -9959,7 +9959,7 @@ scriptwait:
 				case PLAYERINFO_PLAYERCLASS:	STACK(2) = userinfo->GetPlayerClassNum(); break;
 				case PLAYERINFO_DESIREDFOV:		STACK(2) = (int)pl->DesiredFOV; break;
 				case PLAYERINFO_FOV:			STACK(2) = (int)pl->FOV; break;
-				case PLAYERINFO_FVIEWBOB:		STACK(2) = DoubleToACS(userinfo->GetFViewBob()); break;
+				case PLAYERINFO_FVIEWBOB:		STACK(2) = (bool)userinfo->GetFViewBob(); break;
 				default:						STACK(2) = 0; break;
 				}
 			}


### PR DESCRIPTION
ACS_PLAYERINFO_FVIEWBOB was submitted unintentionally as a double.  This is code to fix it back to a bool.