### PR TITLE
Additional lock-related ZScript functions

### DIFF
--- a/src/gamedata/a_keys.cpp
+++ b/src/gamedata/a_keys.cpp
@@ -516,6 +516,12 @@ int P_CheckKeys (AActor *owner, int keynum, bool remote, bool quiet)
 	return false;
 }
 
+// [MK] for ZScript, simply returns if a lock is defined or not
+int P_ValidLock(int keynum)
+{
+	return !!Locks.CheckKey(keynum);
+}
+
 //==========================================================================
 //
 // These functions can be used to get color information for

--- a/src/gamedata/a_keys.h
+++ b/src/gamedata/a_keys.h
@@ -5,6 +5,7 @@ class AActor;
 class PClassActor;
 
 int P_CheckKeys (AActor *owner, int keynum, bool remote, bool quiet = false);
+int P_ValidLock (int lock);
 void P_InitKeyMessages ();
 int P_GetMapColorForLock (int lock);
 int P_GetMapColorForKey (AActor *key);

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1749,6 +1749,27 @@ DEFINE_ACTION_FUNCTION_NATIVE(AInventory, PrintPickupMessage, PrintPickupMessage
 //
 //=====================================================================================
 
+DEFINE_ACTION_FUNCTION_NATIVE(AKey, ValidLock, P_ValidLock)
+{
+	PARAM_PROLOGUE;
+	PARAM_INT(locknum);
+	ACTION_RETURN_BOOL(P_ValidLock(locknum));
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(AKey, GetMapColorForLock, P_GetMapColorForLock)
+{
+	PARAM_PROLOGUE;
+	PARAM_INT(locknum);
+	ACTION_RETURN_INT(P_GetMapColorForLock(locknum));
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(AKey, GetMapColorForKey, P_GetMapColorForKey)
+{
+	PARAM_PROLOGUE;
+	PARAM_OBJECT(key, AActor);
+	ACTION_RETURN_INT(P_GetMapColorForKey(key));
+}
+
 DEFINE_ACTION_FUNCTION_NATIVE(AKey, GetKeyTypeCount, P_GetKeyTypeCount)
 {
 	PARAM_PROLOGUE;

--- a/wadsrc/static/zscript/actors/inventory/inv_misc.zs
+++ b/wadsrc/static/zscript/actors/inventory/inv_misc.zs
@@ -37,6 +37,9 @@ class Key : Inventory
 		Inventory.PickupSound "misc/k_pkup";
 	}
 
+	static native clearscope bool ValidLock(int locknum);
+	static native clearscope Color GetMapColorForLock(int locknum);
+	static native clearscope Color GetMapColorForKey(Key key);
 	static native clearscope int GetKeyTypeCount();
 	static native clearscope class<Key> GetKeyType(int index);
 	


### PR DESCRIPTION
Adds the following:
* `Key.ValidLock`: returns whether a lock number is valid (can be unlocked) or belongs to a "does not work" door.
* `Key.GetMapColorForLock`: returns the automap color for a lock number (or -1 if the lock isn't valid).
* `Key.GetMapColorForKey`: likewise, but for a specific key.

Without these functions being available, I had to write my own LOCKDEFS parser instead (kind of a gross hack). I don't actually need the third one (yet?), but it was exposed as well for the sake of completeness.