### PR TITLE
Rename ValidLock to IsLockDefined (more descriptive)

### DIFF
--- a/src/gamedata/a_keys.cpp
+++ b/src/gamedata/a_keys.cpp
@@ -517,7 +517,7 @@ int P_CheckKeys (AActor *owner, int keynum, bool remote, bool quiet)
 }
 
 // [MK] for ZScript, simply returns if a lock is defined or not
-int P_ValidLock(int keynum)
+int P_IsLockDefined(int keynum)
 {
 	return !!Locks.CheckKey(keynum);
 }

--- a/src/gamedata/a_keys.h
+++ b/src/gamedata/a_keys.h
@@ -5,7 +5,7 @@ class AActor;
 class PClassActor;
 
 int P_CheckKeys (AActor *owner, int keynum, bool remote, bool quiet = false);
-int P_ValidLock (int lock);
+int P_IsLockDefined (int lock);
 void P_InitKeyMessages ();
 int P_GetMapColorForLock (int lock);
 int P_GetMapColorForKey (AActor *key);

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1749,11 +1749,11 @@ DEFINE_ACTION_FUNCTION_NATIVE(AInventory, PrintPickupMessage, PrintPickupMessage
 //
 //=====================================================================================
 
-DEFINE_ACTION_FUNCTION_NATIVE(AKey, ValidLock, P_ValidLock)
+DEFINE_ACTION_FUNCTION_NATIVE(AKey, IsLockDefined, P_IsLockDefined)
 {
 	PARAM_PROLOGUE;
 	PARAM_INT(locknum);
-	ACTION_RETURN_BOOL(P_ValidLock(locknum));
+	ACTION_RETURN_BOOL(P_IsLockDefined(locknum));
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(AKey, GetMapColorForLock, P_GetMapColorForLock)

--- a/wadsrc/static/zscript/actors/inventory/inv_misc.zs
+++ b/wadsrc/static/zscript/actors/inventory/inv_misc.zs
@@ -37,7 +37,7 @@ class Key : Inventory
 		Inventory.PickupSound "misc/k_pkup";
 	}
 
-	static native clearscope bool ValidLock(int locknum);
+	static native clearscope bool IsLockDefined(int locknum);
 	static native clearscope Color GetMapColorForLock(int locknum);
 	static native clearscope Color GetMapColorForKey(Key key);
 	static native clearscope int GetKeyTypeCount();


### PR DESCRIPTION
Bit of a small correction to my previous PR. A "valid lock" is one that is between 1 and 255, while this function actually returns if there is a lock definition for the requested lock number. The previous function name would be misleading.