### PR TITLE
Allow custom MessageBox menu selector

### DIFF
--- a/wadsrc/static/zscript/engine/ui/menu/custommessagebox.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/custommessagebox.zs
@@ -78,7 +78,7 @@ class CustomMessageBoxMenuBase : Menu abstract
 		}
 		else
 		{
-			arrowFont = ConFont;
+			arrowFont = ((textFont && textFont.GetGlyphHeight(0xd) > 0) ? textFont : ConFont);
 			destWidth = CleanWidth;
 			destHeight = CleanHeight;
 			selector = "\xd";
@@ -133,7 +133,7 @@ class CustomMessageBoxMenuBase : Menu abstract
 			if ((MenuTime() % 8) < 6)
 			{
 				screen.DrawText(arrowFont, OptionMenuSettings.mFontColorSelection,
-					(destWidth/2 - 11) + OptionXOffset(messageSelection), y + fontheight * messageSelection, selector, DTA_VirtualWidth, destWidth, DTA_VirtualHeight, destHeight, DTA_KeepRatio, true);
+					(destWidth/2 - 3 - arrowFont.StringWidth(selector)) + OptionXOffset(messageSelection), y + fontheight * messageSelection, selector, DTA_VirtualWidth, destWidth, DTA_VirtualHeight, destHeight, DTA_KeepRatio, true);
 			}
 		}
 	}

--- a/wadsrc/static/zscript/engine/ui/menu/messagebox.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/messagebox.zs
@@ -79,7 +79,7 @@ class MessageBoxMenu : Menu
 		}
 		else
 		{
-			arrowFont = ConFont;
+			arrowFont = ((textFont && textFont.GetGlyphHeight(0xd) > 0) ? textFont : ConFont);
 			destWidth = CleanWidth;
 			destHeight = CleanHeight;
 			selector = "\xd";
@@ -134,7 +134,7 @@ class MessageBoxMenu : Menu
 				if ((MenuTime() % 8) < 6)
 				{
 					screen.DrawText(arrowFont, OptionMenuSettings.mFontColorSelection,
-						destWidth/2 - 11, y + fontheight * messageSelection, selector, DTA_VirtualWidth, destWidth, DTA_VirtualHeight, destHeight, DTA_KeepRatio, true);
+						destWidth/2 - 3 - arrowFont.StringWidth(selector), y + fontheight * messageSelection, selector, DTA_VirtualWidth, destWidth, DTA_VirtualHeight, destHeight, DTA_KeepRatio, true);
 				}
 			}
 		}


### PR DESCRIPTION
### Brief

Allow custom MessageBox menu selector by taking it (if possible) from the same font menu is drawn with, instead of hardcoded CONSOLEFONT.

### Explanation

GZDoom used to have hardcoded MessageBox menu selector, `0x0d` character of CONSOLEFONT, while the other menu is displayed is SMALLFONT. It looked too ugly if `SmallFont` and `ConFont` heights in `*messagebox.zs` are different, and also there was no method of modifying the selector.

Now, the selector is `0x0d` from `SmallFont`, if `SmallFont` contains this glyph (its height is greater than zero), otherwise it falls back to previous behavior (using `ConFont` as a source of this glyph).

To define custom MessageBox menu selector, just define `0x0d` glyph for SMALLFONT, and it will be displayed as the selector of the menu instead of CONSOLEFONT's one.

The gap between selector and menu options text is 3 "pixels" (as it was before: there was hardcoded 11, that turns out to be 8, a `ConFont.StringWidth("\xd")`, and 3 additional "pixels"), and if you wish to enlarge this gap, just add some transparent columns at the right side of `0x0d` glyph.

### Assets

As a proof of concept, here's the file, [Raridoom-Fonts-PoC.zip](https://github.com/ZDoom/gzdoom/files/10311537/Raridoom-Fonts-PoC.zip) that may be used in `-file` argument while starting GZDoom to test it. The supplied ZIP does the only thing: redefined SMALLFONT with an additional glyph of `0x0d`. It's a part of my port of _Raridoom Custom Edition_ mod which uses such a font (just in case you're curious, [youtube demo with download link in the description](https://www.youtube.com/watch?v=ZzQ7uS0J2Ss)) to the modern versions of GZDoom.

Here are the screenshots of how it looks like:
* [Standard font, gzdoom:master](https://user-images.githubusercontent.com/16463967/209743958-1870f080-a42c-4a1f-80d0-331534c8b55b.png): just as a reference.
* [Standard font, this patch](https://user-images.githubusercontent.com/16463967/209743959-53e40f9b-b9f0-4cbc-9996-94c57ced85ea.png): it looks perfectly same, if `0x0d` glyph is not defined in SMALLFONT.
* [Supplied font, gzdoom:master](https://user-images.githubusercontent.com/16463967/209743954-6851c432-91c7-4328-aee8-ee5025e67f92.png): see how misplaced and out of size selector is.
* [Supplied font, this patch](https://user-images.githubusercontent.com/16463967/209743957-2b542388-fdb4-42b2-88e4-44f9214393d2.png): it now uses a gem as a selector glyph and looks way better.