### PR TITLE
Prevent important messages from being accidentally filtered

### DIFF
--- a/src/common/engine/serializer.cpp
+++ b/src/common/engine/serializer.cpp
@@ -683,7 +683,7 @@ void FSerializer::ReadObjects(bool hubtravel)
 							{
 								r->mObjects.Clamp(size);	// close all inner objects.
 								// In case something in here throws an error, let's continue and deal with it later.
-								Printf(PRINT_NONOTIFY, TEXTCOLOR_RED "'%s'\n while restoring %s\n", err.GetMessage(), obj ? obj->GetClass()->TypeName.GetChars() : "invalid object");
+								Printf(PRINT_NONOTIFY | PRINT_BOLD, TEXTCOLOR_RED "'%s'\n while restoring %s\n", err.GetMessage(), obj ? obj->GetClass()->TypeName.GetChars() : "invalid object");
 								mErrors++;
 							}
 						}

--- a/src/common/filesystem/filesystem.cpp
+++ b/src/common/filesystem/filesystem.cpp
@@ -1696,6 +1696,6 @@ CCMD(fs_dir)
 		auto fnid = fileSystem.GetResourceId(i);
 		auto length = fileSystem.FileLength(i);
 		bool hidden = fileSystem.FindFile(fn1) != i;
-		Printf(PRINT_NONOTIFY, "%s%-64s %-15s (%5d) %10d %s %s\n", hidden ? TEXTCOLOR_RED : TEXTCOLOR_UNTRANSLATED, fn1, fns, fnid, length, container, hidden ? "(h)" : "");
+		Printf(PRINT_HIGH | PRINT_NONOTIFY, "%s%-64s %-15s (%5d) %10d %s %s\n", hidden ? TEXTCOLOR_RED : TEXTCOLOR_UNTRANSLATED, fn1, fns, fnid, length, container, hidden ? "(h)" : "");
 	}
 }

--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -925,7 +925,7 @@ void M_Init (void)
 	catch (CVMAbortException &err)
 	{
 		err.MaybePrintMessage();
-		Printf(PRINT_NONOTIFY, "%s", err.stacktrace.GetChars());
+		Printf(PRINT_NONOTIFY | PRINT_BOLD, "%s", err.stacktrace.GetChars());
 		I_FatalError("Failed to initialize menus");
 	}
 	M_CreateMenus();

--- a/src/common/scripting/vm/vmframe.cpp
+++ b/src/common/scripting/vm/vmframe.cpp
@@ -682,7 +682,7 @@ void CVMAbortException::MaybePrintMessage()
 	auto m = GetMessage();
 	if (m != nullptr)
 	{
-		Printf(PRINT_NONOTIFY, TEXTCOLOR_RED "%s\n", m);
+		Printf(PRINT_NONOTIFY | PRINT_BOLD, TEXTCOLOR_RED "%s\n", m);
 		SetMessage("");
 	}
 }

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1234,7 +1234,7 @@ void D_DoomLoop ()
 		catch (CVMAbortException &error)
 		{
 			error.MaybePrintMessage();
-			Printf(PRINT_NONOTIFY, "%s", error.stacktrace.GetChars());
+			Printf(PRINT_NONOTIFY | PRINT_BOLD, "%s", error.stacktrace.GetChars());
 			D_ErrorCleanup();
 		}
 	}

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1385,7 +1385,7 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 	{
 		FString mapname = nextmapname;
 		mapname.ToUpper();
-		Printf(PRINT_NONOTIFY, "\n" TEXTCOLOR_NORMAL "%s\n\n" TEXTCOLOR_BOLD "%s - %s\n\n", console_bar, mapname.GetChars(), LevelName.GetChars());
+		Printf(PRINT_HIGH | PRINT_NONOTIFY, "\n" TEXTCOLOR_NORMAL "%s\n\n" TEXTCOLOR_BOLD "%s - %s\n\n", console_bar, mapname.GetChars(), LevelName.GetChars());
 	}
 
 	// Set the sky map.

--- a/src/p_conversation.cpp
+++ b/src/p_conversation.cpp
@@ -718,7 +718,7 @@ static void TerminalResponse (const char *str)
 
 		if (StatusBar != NULL)
 		{
-			Printf(PRINT_NONOTIFY, "%s\n", str);
+			Printf(PRINT_HIGH | PRINT_NONOTIFY, "%s\n", str);
 			// The message is positioned a bit above the menu choices, because
 			// merchants can tell you something like this but continue to show
 			// their dialogue screen. I think most other conversations use this

--- a/src/playsim/dthinker.cpp
+++ b/src/playsim/dthinker.cpp
@@ -538,7 +538,7 @@ bool FThinkerList::DoDestroyThinkers()
 			{
 				Printf("VM exception in DestroyThinkers:\n");
 				exception.MaybePrintMessage();
-				Printf(PRINT_NONOTIFY, "%s", exception.stacktrace.GetChars());
+				Printf(PRINT_NONOTIFY | PRINT_BOLD, "%s", exception.stacktrace.GetChars());
 				// forcibly delete this. Cleanup may be incomplete, though.
 				node->ObjectFlags |= OF_YesReallyDelete;
 				delete node;
@@ -546,7 +546,7 @@ bool FThinkerList::DoDestroyThinkers()
 			}
 			catch (CRecoverableError &exception)
 			{
-				Printf(PRINT_NONOTIFY, "Error in DestroyThinkers: %s\n", exception.GetMessage());
+				Printf(PRINT_NONOTIFY | PRINT_BOLD, "Error in DestroyThinkers: %s\n", exception.GetMessage());
 				// forcibly delete this. Cleanup may be incomplete, though.
 				node->ObjectFlags |= OF_YesReallyDelete;
 				delete node;

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -8770,7 +8770,7 @@ scriptwait:
 					if (type & HUDMSG_LOG)
 					{
 						int consolecolor = color >= CR_BRICK && color < NUM_TEXT_COLORS && color != CR_UNTRANSLATED ? color + 'A' : '-';
-						Printf(PRINT_NONOTIFY, "\n" TEXTCOLOR_ESCAPESTR "%c%s\n%s\n%s\n", consolecolor, console_bar, work.GetChars(), console_bar);
+						Printf(PRINT_HIGH | PRINT_NONOTIFY, "\n" TEXTCOLOR_ESCAPESTR "%c%s\n%s\n%s\n", consolecolor, console_bar, work.GetChars(), console_bar);
 					}
 				}
 			}

--- a/src/playsim/p_spec.cpp
+++ b/src/playsim/p_spec.cpp
@@ -622,7 +622,7 @@ void P_GiveSecret(FLevelLocals *Level, AActor *actor, bool printmessage, bool pl
 				C_MidPrint(nullptr, GStrings["SECRETMESSAGE"]);
 				if (showsecretsector && sectornum >= 0) 
 				{
-					Printf(PRINT_NONOTIFY, "Secret found in sector %d\n", sectornum);
+					Printf(PRINT_HIGH | PRINT_NONOTIFY, "Secret found in sector %d\n", sectornum);
 				}
 			}
 			if (playsound) S_Sound (CHAN_AUTO, CHANF_UI, "misc/secret", 1, ATTN_NORM);

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -422,7 +422,7 @@ void player_t::SetLogText (const char *text)
 	if (mo && mo->CheckLocalView())
 	{
 		// Print log text to console
-		Printf(PRINT_NONOTIFY, TEXTCOLOR_GOLD "%s\n", LogText[0] == '$' ? GStrings(text + 1) : text);
+		Printf(PRINT_HIGH | PRINT_NONOTIFY, TEXTCOLOR_GOLD "%s\n", LogText[0] == '$' ? GStrings(text + 1) : text);
 	}
 }
 


### PR DESCRIPTION
Although the "Minimum message level" setting should only apply to the HUD, it can also remove these from console output, which may cause problems, especially since this also would include critical error messages.

I scoured through all messages that have only PRINT_NONOTIFY set, and also assigned a proper print level, with PRINT_BOLD for error messages, and PRINT_HIGH for anything else.

The fact that the aforementioned setting affects console messages is a separate bug and it's out of the scope of this pull request.