### PR TITLE
Added missing flags to SetPlayerProperty.

### DIFF
--- a/src/playsim/p_lnspec.cpp
+++ b/src/playsim/p_lnspec.cpp
@@ -2914,7 +2914,14 @@ enum
 	PROP_UNUSED1,
 	PROP_UNUSED2,
 	PROP_SPEED,
+
 	PROP_BUDDHA,
+	PROP_BUDDHA2,
+	PROP_FRIGHTENING,
+	PROP_NOCLIP,
+	PROP_NOCLIP2,
+	PROP_GODMODE,
+	PROP_GODMODE2,
 };
 
 FUNC(LS_SetPlayerProperty)
@@ -3035,24 +3042,43 @@ FUNC(LS_SetPlayerProperty)
 	// Set or clear a flag
 	switch (arg2)
 	{
-	case PROP_BUDDHA:
-		mask = CF_BUDDHA;
-		break;
-	case PROP_FROZEN:
-		mask = CF_FROZEN;
-		break;
-	case PROP_NOTARGET:
-		mask = CF_NOTARGET;
-		break;
-	case PROP_INSTANTWEAPONSWITCH:
-		mask = CF_INSTANTWEAPSWITCH;
-		break;
-	case PROP_FLY:
-		//mask = CF_FLY;
-		break;
-	case PROP_TOTALLYFROZEN:
-		mask = CF_TOTALLYFROZEN;
-		break;
+		case PROP_BUDDHA:
+			mask = CF_BUDDHA;
+			break;
+		case PROP_BUDDHA2:
+			mask = CF_BUDDHA2;
+			break;
+		case PROP_FROZEN:
+			mask = CF_FROZEN;
+			break;
+		case PROP_NOTARGET:
+			mask = CF_NOTARGET;
+			break;
+		case PROP_INSTANTWEAPONSWITCH:
+			mask = CF_INSTANTWEAPSWITCH;
+			break;
+		//CF_FLY has special handling
+		case PROP_FLY:
+			//mask = CF_FLY;
+			break;
+		case PROP_TOTALLYFROZEN:
+			mask = CF_TOTALLYFROZEN;
+			break;
+		case PROP_FRIGHTENING:
+			mask = CF_FRIGHTENING;
+			break;
+		case PROP_NOCLIP:
+			mask = CF_NOCLIP;
+			break;
+		case PROP_NOCLIP2:
+			mask = CF_NOCLIP|CF_NOCLIP2; //Both must be on.
+			break;
+		case PROP_GODMODE:
+			mask = CF_GODMODE;
+			break;
+		case PROP_GODMODE2:
+			mask = CF_GODMODE2;
+			break;
 	}
 
 	if (arg0 == 0)

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -435,6 +435,12 @@ enum EPlayerProperties
 	PROP_FLIGHT = 12, // (Deprecated)
 	PROP_SPEED = 15, // (Deprecated)
 	PROP_BUDDHA = 16,
+	PROP_BUDDHA2 = 17,
+	PROP_FRIGHTENING = 18,
+	PROP_NOCLIP = 19,
+	PROP_NOCLIP2 = 20,
+	PROP_GODMODE = 21,
+	PROP_GODMODE2 = 22,
 }
 
 // Line_SetBlocking


### PR DESCRIPTION
This PR completes the SetPlayerProperty line/script special. By adding all of the player cheats that it could not change, such as CF_GODMODE1/2, CF_FRIGHTENING and so on.

[It also comes with a PR for ACC here.](https://github.com/ZDoom/acc/pull/93)

I have also included an example map, which turns on noclip 2 after 5 seconds, then turns it back off 5 seconds later. Since that was the only cheat that requires any special handling of any kind besides turn in a single flag on or off.

[Noclip2 Script.zip](https://github.com/ZDoom/gzdoom/files/10348180/Noclip2.Script.zip)

