### PR TITLE
Added XF_THRUSTLESS, XF_NOALLIES and XF_CIRCULAR.

### DIFF
--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -407,7 +407,8 @@ enum
 	RADF_NODAMAGE = 8,
 	RADF_THRUSTZ = 16,
 	RADF_OLDRADIUSDAMAGE = 32,
-	RADF_THRUSTLESS = 64
+	RADF_THRUSTLESS = 64,
+	RADF_NOALLIES = 128
 };
 int P_GetRadiusDamage(AActor *self, AActor *thing, int damage, int distance, int fulldmgdistance, bool oldradiusdmg);
 int	P_RadiusAttack (AActor *spot, AActor *source, int damage, int distance, 

--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -408,9 +408,10 @@ enum
 	RADF_THRUSTZ = 16,
 	RADF_OLDRADIUSDAMAGE = 32,
 	RADF_THRUSTLESS = 64,
-	RADF_NOALLIES = 128
+	RADF_NOALLIES = 128,
+	RADF_CIRCULAR = 256
 };
-int P_GetRadiusDamage(AActor *self, AActor *thing, int damage, int distance, int fulldmgdistance, bool oldradiusdmg);
+int P_GetRadiusDamage(AActor *self, AActor *thing, int damage, int distance, int fulldmgdistance, bool oldradiusdmg, bool circular);
 int	P_RadiusAttack (AActor *spot, AActor *source, int damage, int distance, 
 						FName damageType, int flags, int fulldamagedistance=0, FName species = NAME_None);
 

--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -406,7 +406,8 @@ enum
 	RADF_SOURCEISSPOT = 4,
 	RADF_NODAMAGE = 8,
 	RADF_THRUSTZ = 16,
-	RADF_OLDRADIUSDAMAGE = 32
+	RADF_OLDRADIUSDAMAGE = 32,
+	RADF_THRUSTLESS = 64
 };
 int P_GetRadiusDamage(AActor *self, AActor *thing, int damage, int distance, int fulldmgdistance, bool oldradiusdmg);
 int	P_RadiusAttack (AActor *spot, AActor *source, int damage, int distance, 

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -6072,10 +6072,12 @@ int P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bom
 			)
 			)	continue;
 
-		if((species != NAME_None) && (thing->Species != species))
-		{
+		if ((species != NAME_None) && (thing->Species != species))
 			continue;
-		}
+
+		//[inkoalawetrust] Don't harm actors friendly to the explosions' source.
+		if ((flags & RADF_NOALLIES) && bombsource->IsFriend(thing))
+			continue;
 
 		if (bombsource && thing != bombsource && bombsource->player && P_ShouldPassThroughPlayer(bombsource, thing))
 			continue;

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1302,7 +1302,8 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, GetRadiusDamage, P_GetRadiusDamage)
 	PARAM_INT(distance);
 	PARAM_INT(fulldmgdistance);
 	PARAM_BOOL(oldradiusdmg);
-	ACTION_RETURN_INT(P_GetRadiusDamage(self, thing, damage, distance, fulldmgdistance, oldradiusdmg));
+	PARAM_BOOL(circular);
+	ACTION_RETURN_INT(P_GetRadiusDamage(self, thing, damage, distance, fulldmgdistance, oldradiusdmg, circular));
 }
 
 static int RadiusAttack(AActor *self, AActor *bombsource, int bombdamage, int bombdistance, int damagetype, int flags, int fulldamagedistance, int species)

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1187,7 +1187,7 @@ class Actor : Thinker native
 	native void A_CustomComboAttack(class<Actor> missiletype, double spawnheight, int damage, sound meleesound = "", name damagetype = "none", bool bleed = true);
 	native void A_Burst(class<Actor> chunktype);
 	native void A_RadiusDamageSelf(int damage = 128, double distance = 128, int flags = 0, class<Actor> flashtype = null);
-	native int GetRadiusDamage(Actor thing, int damage, int distance, int fulldmgdistance = 0, bool oldradiusdmg = false);
+	native int GetRadiusDamage(Actor thing, int damage, int distance, int fulldmgdistance = 0, bool oldradiusdmg = false, bool circular = false);
 	native int RadiusAttack(Actor bombsource, int bombdamage, int bombdistance, Name bombmod = 'none', int flags = RADF_HURTSOURCE, int fulldamagedistance = 0, name species = "None");
 	
 	native void A_Respawn(int flags = 1);

--- a/wadsrc/static/zscript/actors/attacks.zs
+++ b/wadsrc/static/zscript/actors/attacks.zs
@@ -606,6 +606,7 @@ extend class Actor
 		if (flags & XF_HURTSOURCE)	pflags |= RADF_HURTSOURCE;
 		if (flags & XF_NOTMISSILE)	pflags |= RADF_SOURCEISSPOT;
 		if (flags & XF_THRUSTZ)	pflags |= RADF_THRUSTZ;
+		if (flags & XF_THRUSTLESS) pflags |= RADF_THRUSTLESS;
 
 		int count = RadiusAttack (target, damage, distance, damagetype, pflags, fulldamagedistance);
 		if (!(flags & XF_NOSPLASH)) CheckSplash(distance);

--- a/wadsrc/static/zscript/actors/attacks.zs
+++ b/wadsrc/static/zscript/actors/attacks.zs
@@ -607,6 +607,7 @@ extend class Actor
 		if (flags & XF_NOTMISSILE)	pflags |= RADF_SOURCEISSPOT;
 		if (flags & XF_THRUSTZ)	pflags |= RADF_THRUSTZ;
 		if (flags & XF_THRUSTLESS) pflags |= RADF_THRUSTLESS;
+		if (flags & XF_NOALLIES) pflags |= RADF_NOALLIES;
 
 		int count = RadiusAttack (target, damage, distance, damagetype, pflags, fulldamagedistance);
 		if (!(flags & XF_NOSPLASH)) CheckSplash(distance);

--- a/wadsrc/static/zscript/actors/attacks.zs
+++ b/wadsrc/static/zscript/actors/attacks.zs
@@ -608,6 +608,7 @@ extend class Actor
 		if (flags & XF_THRUSTZ)	pflags |= RADF_THRUSTZ;
 		if (flags & XF_THRUSTLESS) pflags |= RADF_THRUSTLESS;
 		if (flags & XF_NOALLIES) pflags |= RADF_NOALLIES;
+		if (flags & XF_CIRCULAR) pflags |= RADF_CIRCULAR;
 
 		int count = RadiusAttack (target, damage, distance, damagetype, pflags, fulldamagedistance);
 		if (!(flags & XF_NOSPLASH)) CheckSplash(distance);

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -262,6 +262,7 @@ enum EExplodeFlags
 	XF_NOSPLASH = 16,
 	XF_THRUSTZ = 32,
 	XF_THRUSTLESS = 64,
+	XF_NOALLIES = 128,
 };
 
 // Flags for A_RadiusThrust
@@ -1222,7 +1223,8 @@ enum RadiusDamageFlags
 	RADF_NODAMAGE = 8,
 	RADF_THRUSTZ = 16,
 	RADF_OLDRADIUSDAMAGE = 32,
-	RADF_THRUSTLESS = 64
+	RADF_THRUSTLESS = 64,
+	RADF_NOALLIES = 128
 };
 
 enum IntermissionSequenceType

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -261,7 +261,7 @@ enum EExplodeFlags
 	XF_EXPLICITDAMAGETYPE = 8,
 	XF_NOSPLASH = 16,
 	XF_THRUSTZ = 32,
-
+	XF_THRUSTLESS = 64,
 };
 
 // Flags for A_RadiusThrust
@@ -1221,7 +1221,8 @@ enum RadiusDamageFlags
 	RADF_SOURCEISSPOT = 4,
 	RADF_NODAMAGE = 8,
 	RADF_THRUSTZ = 16,
-	RADF_OLDRADIUSDAMAGE = 32
+	RADF_OLDRADIUSDAMAGE = 32,
+	RADF_THRUSTLESS = 64
 };
 
 enum IntermissionSequenceType

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -263,6 +263,7 @@ enum EExplodeFlags
 	XF_THRUSTZ = 32,
 	XF_THRUSTLESS = 64,
 	XF_NOALLIES = 128,
+	XF_CIRCULAR = 256,
 };
 
 // Flags for A_RadiusThrust
@@ -1224,7 +1225,8 @@ enum RadiusDamageFlags
 	RADF_THRUSTZ = 16,
 	RADF_OLDRADIUSDAMAGE = 32,
 	RADF_THRUSTLESS = 64,
-	RADF_NOALLIES = 128
+	RADF_NOALLIES = 128,
+	RADF_CIRCULAR = 256
 };
 
 enum IntermissionSequenceType


### PR DESCRIPTION
This PR also adds their RADF_ equivalents for RadiusAttack() too.

- XF_THRUSTLESS: Makes the explosion apply no thrust at all to the actors caught in the blast. Doing purely damage.
- XF_NOALLIES: Makes the explosion not harm any allies caught in the blast. This only works with friendly monsters and players. And also DOES NOT imply that the shooter is safe unless XF/RADF_HURTSOURCE is off.
- XF_CIRCULAR: This is the big one. When turned on, it allows the explosion to hurt actors in an actual spherical radius around the epicenter. Instead of Doom's original cubical radius.

In addition to the XF/RADF_CIRCULAR flag, this PR also adds a _circular_ parameter to GetRadiusDamage(), which allows the function to calculate blastdamage using the spherical blast radius instead of the vanilla cubical one.

I have attached an example map below. Which demonstrates all of the new flags.
[Explosion flags example.zip](https://github.com/ZDoom/gzdoom/files/10365913/Explosion.flags.example.zip)
