### PR TITLE
Added QF_DAMAGEFALLOFF and damagemultiplier, thrustmultiplier, and damage properties to earthquakes.

### DIFF
--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -136,7 +136,7 @@ public:
 	static const int DEFAULT_STAT = STAT_EARTHQUAKE;
 	void Construct(AActor *center, double intensityX, double intensityY, double intensityZ, int duration,
 		int damrad, int tremrad, FSoundID quakesfx, int flags, 
-		double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, double rollIntensity, double rollWave, double damageMultiplier, double thrustMultiplier);
+		double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, double rollIntensity, double rollWave, double damageMultiplier, double thrustMultiplier, int damage);
 
 	void Serialize(FSerializer &arc);
 	void Tick ();
@@ -152,6 +152,7 @@ public:
 	int m_Highpoint, m_MiniCount;
 	double m_RollIntensity, m_RollWave;
 	double m_DamageMultiplier, m_ThrustMultiplier;
+	int m_Damage;
 
 	double GetModIntensity(double intensity, bool fake = false) const;
 	double GetModWave(double ticFrac, double waveMultiplier) const;

--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -135,8 +135,8 @@ class DEarthquake : public DThinker
 public:
 	static const int DEFAULT_STAT = STAT_EARTHQUAKE;
 	void Construct(AActor *center, double intensityX, double intensityY, double intensityZ, int duration,
-		int damrad, int tremrad, FSoundID quakesfx, int flags,
-		double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, double rollIntensity, double rollWave);
+		int damrad, int tremrad, FSoundID quakesfx, int flags, 
+		double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, double rollIntensity, double rollWave, double damageMultiplier, double thrustMultiplier);
 
 	void Serialize(FSerializer &arc);
 	void Tick ();
@@ -151,6 +151,7 @@ public:
 	double m_Falloff;
 	int m_Highpoint, m_MiniCount;
 	double m_RollIntensity, m_RollWave;
+	double m_DamageMultiplier, m_ThrustMultiplier;
 
 	double GetModIntensity(double intensity, bool fake = false) const;
 	double GetModWave(double ticFrac, double waveMultiplier) const;

--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -116,6 +116,7 @@ enum
 	QF_GROUNDONLY =		1 << 7,
 	QF_AFFECTACTORS =	1 << 8,
 	QF_SHAKEONLY =		1 << 9,
+	QF_DAMAGEFALLOFF =	1 << 10,
 };
 
 struct FQuakeJiggers
@@ -153,8 +154,8 @@ public:
 
 	double GetModIntensity(double intensity, bool fake = false) const;
 	double GetModWave(double ticFrac, double waveMultiplier) const;
-	double GetFalloff(double dist) const;
-	void DoQuakeDamage(DEarthquake *quake, AActor *victim) const;
+	double GetFalloff(double dist, double radius) const;
+	void DoQuakeDamage(DEarthquake *quake, AActor *victim, bool falloff) const;
 
 	static int StaticGetQuakeIntensities(double ticFrac, AActor *viewer, FQuakeJiggers &jiggers);
 };

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -6243,7 +6243,9 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				argCount > 12 ? args[12] : 0,
 				argCount > 13 ? args[13] : 0,
 				argCount > 14 ? ACSToDouble(args[14]) : 0,
-				argCount > 15 ? ACSToDouble(args[15]) : 0);
+				argCount > 15 ? ACSToDouble(args[15]) : 0,
+				argCount > 16 ? ACSToDouble(args[16]) : 0,
+				argCount > 17 ? ACSToDouble(args[17]) : 0);
 		}
 
 		case ACSF_SetLineActivation:

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -6244,8 +6244,9 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				argCount > 13 ? args[13] : 0,
 				argCount > 14 ? ACSToDouble(args[14]) : 0,
 				argCount > 15 ? ACSToDouble(args[15]) : 0,
-				argCount > 16 ? ACSToDouble(args[16]) : 0,
-				argCount > 17 ? ACSToDouble(args[17]) : 0);
+				argCount > 16 ? ACSToDouble(args[16]) : 1.0,
+				argCount > 17 ? ACSToDouble(args[17]) : 0.5,
+				argCount > 18 ? args[18] : 0);
 		}
 
 		case ACSF_SetLineActivation:

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -3369,8 +3369,10 @@ DEFINE_ACTION_FUNCTION(AActor, A_QuakeEx)
 	PARAM_INT(highpoint);
 	PARAM_FLOAT(rollIntensity);
 	PARAM_FLOAT(rollWave);
+	PARAM_FLOAT(damageMultiplier);
+	PARAM_FLOAT(thrustMultiplier);
 	P_StartQuakeXYZ(self->Level, self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags, mulWaveX, mulWaveY, mulWaveZ, falloff, highpoint, 
-		rollIntensity, rollWave);
+		rollIntensity, rollWave, damageMultiplier, thrustMultiplier);
 	return 0;
 }
 

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -3371,8 +3371,9 @@ DEFINE_ACTION_FUNCTION(AActor, A_QuakeEx)
 	PARAM_FLOAT(rollWave);
 	PARAM_FLOAT(damageMultiplier);
 	PARAM_FLOAT(thrustMultiplier);
+	PARAM_INT(damage);
 	P_StartQuakeXYZ(self->Level, self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags, mulWaveX, mulWaveY, mulWaveZ, falloff, highpoint, 
-		rollIntensity, rollWave, damageMultiplier, thrustMultiplier);
+		rollIntensity, rollWave, damageMultiplier, thrustMultiplier, damage);
 	return 0;
 }
 

--- a/src/playsim/p_spec.h
+++ b/src/playsim/p_spec.h
@@ -164,7 +164,7 @@ void P_TerminateScript (FLevelLocals *Level, int script, const char *map);
 //
 // [RH] p_quake.c
 //
-bool P_StartQuakeXYZ(FLevelLocals *Level, AActor *activator, int tid, double intensityX, double intensityY, double intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, double rollIntensity, double rollWave);
+bool P_StartQuakeXYZ(FLevelLocals *Level, AActor *activator, int tid, double intensityX, double intensityY, double intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, double rollIntensity, double rollWave, double damageMultiplier, double thrustMultiplier);
 bool P_StartQuake(FLevelLocals *Level, AActor *activator, int tid, double intensity, int duration, int damrad, int tremrad, FSoundID quakesfx);
 
 #endif

--- a/src/playsim/p_spec.h
+++ b/src/playsim/p_spec.h
@@ -164,7 +164,7 @@ void P_TerminateScript (FLevelLocals *Level, int script, const char *map);
 //
 // [RH] p_quake.c
 //
-bool P_StartQuakeXYZ(FLevelLocals *Level, AActor *activator, int tid, double intensityX, double intensityY, double intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, double rollIntensity, double rollWave, double damageMultiplier, double thrustMultiplier);
+bool P_StartQuakeXYZ(FLevelLocals *Level, AActor *activator, int tid, double intensityX, double intensityY, double intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, double rollIntensity, double rollWave, double damageMultiplier, double thrustMultiplier, int damage);
 bool P_StartQuake(FLevelLocals *Level, AActor *activator, int tid, double intensity, int duration, int damrad, int tremrad, FSoundID quakesfx);
 
 #endif

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1209,7 +1209,7 @@ class Actor : Thinker native
 	deprecated("2.3", "User variables are deprecated in ZScript. Actor variables are directly accessible") native void A_SetUserVarFloat(name varname, double value);
 	deprecated("2.3", "User variables are deprecated in ZScript. Actor variables are directly accessible") native void A_SetUserArrayFloat(name varname, int index, double value);
 	native void A_Quake(double intensity, int duration, int damrad, int tremrad, sound sfx = "world/quake");
-	native void A_QuakeEx(double intensityX, double intensityY, double intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, double mulWaveX = 1, double mulWaveY = 1, double mulWaveZ = 1, int falloff = 0, int highpoint = 0, double rollIntensity = 0, double rollWave = 0, double damageMultiplier = 1, double thrustMultiplier = 0.5);
+	native void A_QuakeEx(double intensityX, double intensityY, double intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, double mulWaveX = 1, double mulWaveY = 1, double mulWaveZ = 1, int falloff = 0, int highpoint = 0, double rollIntensity = 0, double rollWave = 0, double damageMultiplier = 1, double thrustMultiplier = 0.5, int damage = 0);
 	action native void A_SetTics(int tics);
 	native void A_DamageSelf(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = null, name species = "None", int src = AAPTR_DEFAULT, int inflict = AAPTR_DEFAULT);
 	native void A_DamageTarget(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = null, name species = "None", int src = AAPTR_DEFAULT, int inflict = AAPTR_DEFAULT);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1209,7 +1209,7 @@ class Actor : Thinker native
 	deprecated("2.3", "User variables are deprecated in ZScript. Actor variables are directly accessible") native void A_SetUserVarFloat(name varname, double value);
 	deprecated("2.3", "User variables are deprecated in ZScript. Actor variables are directly accessible") native void A_SetUserArrayFloat(name varname, int index, double value);
 	native void A_Quake(double intensity, int duration, int damrad, int tremrad, sound sfx = "world/quake");
-	native void A_QuakeEx(double intensityX, double intensityY, double intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, double mulWaveX = 1, double mulWaveY = 1, double mulWaveZ = 1, int falloff = 0, int highpoint = 0, double rollIntensity = 0, double rollWave = 0);
+	native void A_QuakeEx(double intensityX, double intensityY, double intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, double mulWaveX = 1, double mulWaveY = 1, double mulWaveZ = 1, int falloff = 0, int highpoint = 0, double rollIntensity = 0, double rollWave = 0, double damageMultiplier = 1, double thrustMultiplier = 0.5);
 	action native void A_SetTics(int tics);
 	native void A_DamageSelf(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = null, name species = "None", int src = AAPTR_DEFAULT, int inflict = AAPTR_DEFAULT);
 	native void A_DamageTarget(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = null, name species = "None", int src = AAPTR_DEFAULT, int inflict = AAPTR_DEFAULT);

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -653,6 +653,7 @@ enum EQuakeFlags
 	QF_GROUNDONLY =		1 << 7,
 	QF_AFFECTACTORS =	1 << 8,
 	QF_SHAKEONLY =		1 << 9,
+	QF_DAMAGEFALLOFF =	1 << 10,
 };
 
 // A_CheckProximity flags


### PR DESCRIPTION
This PR adds 4 new features to earthquakes:

- QF_DAMAGEFALLOFF: This flag makes the damage and actor thrusting earthquakes produce fall off with distance. It works exactly like how the distance falloff for the actual screenshake effect works*. So the _falloff_ property also needs to be given a value besides 0 for the falloff to work.
- damageMultiplier: This is a new property for earthquakes that acts as a multiplier for the damage they perform to players and actors. It can be used to make earthquakes more or less harmful, such as making a very strong earthquake do more damage. Default is 1.0 (Normal damage)
- thrustMultiplier: Like _damageMultiplier_, this property allows you to increase or decrease how much earthquakes push actors around. It can also be set to 0 to disable actor pushing entirely. Default is 0.5.
- damage: When this property is set to anything above 0, the earthquake will do the exact amount of damage specified, instead of the default randomized damage. This will also account for damage falloff and the damage multiplier.

In addition, since earthquake damage can now go to 0 or below, the damage is clamped to be at least one hit point when the victim is in the damage radius. So that damage falloff or a damage multiplier of 0 won't produce quakes that do no damage despite being within their damage radius. For the latter you can simply use the QF_SHAKEONLY flag.

Also, the code includes a fix that makes QF_AFFECTACTORS use an FMultiBlockThingsIterator instead of a ThinkerIterator, which stops the earthquake from trying to shake objects it shouldn't like items that are in actors' inventories.

[This PR also comes with this update to ACCs' definitions.](https://github.com/ZDoom/acc/pull/95)

An example map is also included, this map produces an earthquake with damage and thrust falloff, the earthquake also does exactly 3 damage, which is then multiplied by 2. And also produces very little pushing.

[Earthquake falloff example.zip](https://github.com/ZDoom/gzdoom/files/10368144/Earthquake.falloff.example.zip)

*Except that for damage and thrusting falloff, it uses the damage radius instead of the tremor radius.