### PR TITLE
Expose LineTracer WallMask and more

### DIFF
--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -1068,9 +1068,13 @@ DEFINE_ACTION_FUNCTION(DLineTracer, Trace)
 	PARAM_FLOAT(direction_y);
 	PARAM_FLOAT(direction_z);
 	PARAM_FLOAT(maxDist);
-	// actor flags and wall flags are not supported due to how flags are implemented on the ZScript side.
+	// actor flags are not supported due to how flags are implemented on the ZScript side.
 	// say thanks to oversimplifying the user API.
 	PARAM_INT(traceFlags);
+
+	PARAM_UINT(wallMask);
+	PARAM_BOOL(ignoreAllActors);
+	PARAM_OBJECT(ignore, AActor);
 
 	// these are internal hacks.
 	traceFlags &= ~(TRACE_PCross | TRACE_Impact);
@@ -1079,7 +1083,7 @@ DEFINE_ACTION_FUNCTION(DLineTracer, Trace)
 
 	// Trace(vector3 start, Sector sector, vector3 direction, double maxDist, ETraceFlags traceFlags)
 	bool res = Trace(DVector3(start_x, start_y, start_z), sector, DVector3(direction_x, direction_y, direction_z), maxDist,
-					 (ActorFlag)0xFFFFFFFF, 0xFFFFFFFF, nullptr, self->Results, traceFlags, &DLineTracer::TraceCallback, self);
+		(ActorFlag)(ignoreAllActors ? 0x0 : 0xFFFFFFFF), wallMask, ignore, self->Results, traceFlags, &DLineTracer::TraceCallback, self);
 	ACTION_RETURN_BOOL(res);
 }
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -299,7 +299,7 @@ struct TraceResults native
 class LineTracer : Object native
 {
 	native @TraceResults Results;
-	native bool Trace(vector3 start, Sector sec, vector3 direction, double maxDist, ETraceFlags traceFlags);
+	native bool Trace(vector3 start, Sector sec, vector3 direction, double maxDist, ETraceFlags traceFlags, /* Line::ELineFlags */ uint wallMask = 0xFFFFFFFF, bool ignoreAllActors = false, Actor ignore = null);
 
 	virtual ETraceStatus TraceCallback()
 	{


### PR DESCRIPTION
expose WallMask and ignore actor, allow disabling Actor Tracing for LineTracer::Trace