### PR TITLE
Impel people to include demo mods in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -82,7 +82,7 @@ body:
     id: description
     attributes:
       label: A clear and concise description of what the bug is.
-      description: Describe what happens, what software were you running? _Include screenshot if possible_
+      description: Describe what happens, what software were you running? _Include a small mod demonstrating the bug, or a screenshot if possible_
       placeholder: "How & When does this occur?"
     validations:
       required: true


### PR DESCRIPTION
Since small demo mods are the preferred way for GZDoom developers to reproduce bugs