### PR TITLE
Fix diffuse-only material shaders not applying

### DIFF
--- a/src/common/textures/hw_material.cpp
+++ b/src/common/textures/hw_material.cpp
@@ -133,12 +133,15 @@ FMaterial::FMaterial(FGameTexture * tx, int scaleflags)
 			if (index >= FIRST_USER_SHADER)
 			{
 				const UserShaderDesc& usershader = usershaders[index - FIRST_USER_SHADER];
-				if (tx->Layers && usershader.shaderType == mShaderIndex) // Only apply user shader if it matches the expected material
+				if (usershader.shaderType == mShaderIndex) // Only apply user shader if it matches the expected material
 				{
-					for (auto& texture : tx->Layers->CustomShaderTextures)
+					if (tx->Layers)
 					{
-						if (texture == nullptr) continue;
-						mTextureLayers.Push({ texture.get(), 0 });	// scalability should be user-definable.
+						for (auto& texture : tx->Layers->CustomShaderTextures)
+						{
+							if (texture == nullptr) continue;
+							mTextureLayers.Push({ texture.get(), 0 });	// scalability should be user-definable.
+						}
 					}
 					mShaderIndex = index;
 				}


### PR DESCRIPTION
After commit 941c0850ba7c98663c55fa7b3b4a9d2b5657aeb3, any material definitions in GLDEFS that set a shader without any additional textures would have said shader simply be ignored entirely.

After taking a good look at the changes in it, I took notice of a small oversight, and have corrected it. Everything works as expected now, though I'm not 100% sure if my fix is *"appropriate"*, so to speak. The fact it appears to be solved by such a small change bothers me.