### PR TITLE
Added SHADOWAIM, SHADOWBLOCK, SHADOWAIMVERT, ShadowAimFactor, and ShadowPenaltyFactor.

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -428,7 +428,7 @@ enum ActorFlag8
 	MF8_STAYONLIFT		= 0x02000000,	// MBF AI enhancement.
 	MF8_DONTFOLLOWPLAYERS	= 0x04000000,	// [inkoalawetrust] Friendly monster will not follow players.
 	MF8_SEEFRIENDLYMONSTERS	= 0X08000000,	// [inkoalawetrust] Hostile monster can see friendly monsters.
-	MF8_CROSSLINECHECK	= 0x10000000,	// [MC]Enables CanCrossLine virtual
+	MF8_CROSSLINECHECK	= 0x10000000,	// [MC] Enables CanCrossLine virtual
 	MF8_MASTERNOSEE		= 0x20000000,	// Don't show object in first person if their master is the current camera.
 	MF8_ADDLIGHTLEVEL	= 0x40000000,	// [MC] Actor light level is additive with sector.
 	MF8_ONLYSLAMSOLID	= 0x80000000,	// [B] Things with skullfly will ignore non-solid Actors.
@@ -438,6 +438,8 @@ enum ActorFlag8
 enum ActorFlag9
 {
 	MF9_SHADOWAIM		= 0x00000001,	// [inkoalawetrust] Monster still gets aim penalty from aiming at shadow actors even with MF6_SEEINVISIBLE on.
+	MF9_DOSHADOWBLOCK	= 0x00000002,	// [inkoalawetrust] Should the monster look for SHADOWBLOCK actors ?
+	MF9_SHADOWBLOCK		= 0x00000004,	// [inkoalawetrust] Actors in the line of fire with this flag trigger the MF_SHADOW aiming penalty.
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1202,6 +1202,8 @@ public:
 	double			Gravity;		// [GRB] Gravity factor
 	double			Friction;
 	double			pushfactor;
+	double			ShadowAimFactor;	// [inkoalawetrust] How much the actors' aim is affected when attacking shadow actors. 
+	double			ShadowPenaltyFactor;// [inkoalawetrust] How much the shadow actor affects its' shooters' aim.
 	int				bouncecount;	// Strife's grenades only bounce twice before exploding
 	int 			FastChaseStrafeCount;
 	int				lastpush;

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -394,7 +394,7 @@ enum ActorFlag7
 	MF7_SPRITEANGLE		= 0x02000000,	// [MC] Utilize the SpriteAngle property and lock the rotation to the degrees specified.
 	MF7_SMASHABLE		= 0x04000000,	// dies if hitting the floor.
 	MF7_NOSHIELDREFLECT = 0x08000000,	// will not be reflected by shields.
-	MF7_FORCEZERORADIUSDMG = 0x10000000,	// passes zero radius damage on to P_DamageMobj, this is necessary in some cases where DoSpecialDamage gets overrideen.
+	MF7_FORCEZERORADIUSDMG = 0x10000000,// passes zero radius damage on to P_DamageMobj, this is necessary in some cases where DoSpecialDamage gets overrideen.
 	MF7_NOINFIGHTSPECIES = 0x20000000,	// don't start infights with one's own species.
 	MF7_FORCEINFIGHTING	= 0x40000000,	// overrides a map setting of 'no infighting'.
 	MF7_INCHASE			= 0x80000000,	// [RH] used by A_Chase and A_Look to avoid recursion
@@ -437,7 +437,7 @@ enum ActorFlag8
 // --- mobj.flags9 ---
 enum ActorFlag9
 {
-	
+	MF9_SHADOWAIM		= 0x00000001,	// [inkoalawetrust] Monster still gets aim penalty from aiming at shadow actors even with MF6_SEEINVISIBLE on.
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -440,6 +440,7 @@ enum ActorFlag9
 	MF9_SHADOWAIM		= 0x00000001,	// [inkoalawetrust] Monster still gets aim penalty from aiming at shadow actors even with MF6_SEEINVISIBLE on.
 	MF9_DOSHADOWBLOCK	= 0x00000002,	// [inkoalawetrust] Should the monster look for SHADOWBLOCK actors ?
 	MF9_SHADOWBLOCK		= 0x00000004,	// [inkoalawetrust] Actors in the line of fire with this flag trigger the MF_SHADOW aiming penalty.
+	MF9_SHADOWAIMVERT	= 0x00000008,	// [inkoalawetrust] Monster aim is also offset vertically when aiming at shadow actors.
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -399,6 +399,8 @@ enum ActorFlag7
 	MF7_FORCEINFIGHTING	= 0x40000000,	// overrides a map setting of 'no infighting'.
 	MF7_INCHASE			= 0x80000000,	// [RH] used by A_Chase and A_Look to avoid recursion
 };
+
+// --- mobj.flags8 ---
 enum ActorFlag8
 {
 	MF8_FRIGHTENING		= 0x00000001,	// for those moments when halloween just won't do
@@ -430,6 +432,12 @@ enum ActorFlag8
 	MF8_MASTERNOSEE		= 0x20000000,	// Don't show object in first person if their master is the current camera.
 	MF8_ADDLIGHTLEVEL	= 0x40000000,	// [MC] Actor light level is additive with sector.
 	MF8_ONLYSLAMSOLID	= 0x80000000,	// [B] Things with skullfly will ignore non-solid Actors.
+};
+
+// --- mobj.flags9 ---
+enum ActorFlag9
+{
+	
 };
 
 // --- mobj.renderflags ---
@@ -586,6 +594,7 @@ typedef TFlags<ActorFlag5> ActorFlags5;
 typedef TFlags<ActorFlag6> ActorFlags6;
 typedef TFlags<ActorFlag7> ActorFlags7;
 typedef TFlags<ActorFlag8> ActorFlags8;
+typedef TFlags<ActorFlag9> ActorFlags9;
 typedef TFlags<ActorRenderFlag> ActorRenderFlags;
 typedef TFlags<ActorRenderFlag2> ActorRenderFlags2;
 typedef TFlags<ActorBounceFlag> ActorBounceFlags;
@@ -598,6 +607,7 @@ DEFINE_TFLAGS_OPERATORS (ActorFlags5)
 DEFINE_TFLAGS_OPERATORS (ActorFlags6)
 DEFINE_TFLAGS_OPERATORS (ActorFlags7)
 DEFINE_TFLAGS_OPERATORS (ActorFlags8)
+DEFINE_TFLAGS_OPERATORS (ActorFlags9)
 DEFINE_TFLAGS_OPERATORS (ActorRenderFlags)
 DEFINE_TFLAGS_OPERATORS (ActorRenderFlags2)
 DEFINE_TFLAGS_OPERATORS (ActorBounceFlags)
@@ -1072,6 +1082,7 @@ public:
 	ActorFlags6		flags6;			// Shit! Where did all the flags go?
 	ActorFlags7		flags7;			// WHO WANTS TO BET ON 8!?
 	ActorFlags8		flags8;			// I see your 8, and raise you a bet for 9.
+	ActorFlags9		flags9;			// Happy ninth actor flag field GZDoom !
 	double			Floorclip;		// value to use for floor clipping
 	double			radius, Height;		// for movement checking
 

--- a/src/playsim/actorinlines.h
+++ b/src/playsim/actorinlines.h
@@ -269,8 +269,19 @@ inline bool P_CheckForShadowBlock(AActor* t1, AActor* t2, DVector3 pos)
 	FTraceResults result;
 	ShadowCheckData ShadowCheck;
 	ShadowCheck.HitShadow = false;
-	DVector3 dir = t1->Vec3To(t2);
-	double dist = dir.Length();
+	DVector3 dir;
+	double dist;
+	if (t2)
+	{
+		dir = t1->Vec3To(t2);
+		dist = dir.Length();
+	}
+	//No second actor, fall back to shooting at facing direction.
+	else
+	{
+		dir = DRotator(-(t1->Angles.Pitch), t1->Angles.Yaw, t1->Angles.Yaw);
+		dist = 65536.0; //Arbitrary large value.
+	}
 
 	Trace(pos, t1->Sector, dir, dist, ActorFlags::FromInt(0xFFFFFFFF), ML_BLOCKEVERYTHING, t1, result, 0, CheckForShadowBlockers, &ShadowCheck);
 

--- a/src/playsim/actorinlines.h
+++ b/src/playsim/actorinlines.h
@@ -243,7 +243,7 @@ inline bool P_IsBlockedByLine(AActor* actor, line_t* line)
 
 struct ShadowCheckData
 {
-	bool HitShadow;
+	AActor* HitShadow;
 };
 
 static ETraceStatus CheckForShadowBlockers(FTraceResults& res, void* userdata)
@@ -251,7 +251,7 @@ static ETraceStatus CheckForShadowBlockers(FTraceResults& res, void* userdata)
 	ShadowCheckData *output = (ShadowCheckData *) userdata;
 	if (res.HitType == TRACE_HitActor && res.Actor && (res.Actor->flags9 & MF9_SHADOWBLOCK))
 	{
-		output->HitShadow = true;
+		output->HitShadow = res.Actor;
 		return TRACE_Stop;
 	}
 
@@ -263,12 +263,12 @@ static ETraceStatus CheckForShadowBlockers(FTraceResults& res, void* userdata)
 	return TRACE_Continue;
 }
 
-// [inkoalawetrust] Check if an MF9_SHADOWBLOCK actor is standing between t1 and t2.
-inline bool P_CheckForShadowBlock(AActor* t1, AActor* t2, DVector3 pos)
+// [inkoalawetrust] Check if an MF9_SHADOWBLOCK actor is standing between t1 and t2 and return it.
+inline AActor* P_CheckForShadowBlock(AActor* t1, AActor* t2, DVector3 pos)
 {
 	FTraceResults result;
 	ShadowCheckData ShadowCheck;
-	ShadowCheck.HitShadow = false;
+	ShadowCheck.HitShadow = nullptr;
 	DVector3 dir;
 	double dist;
 	if (t2)

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -2092,6 +2092,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_Respawn)
 		self->flags6 = defs->flags6;
 		self->flags7 = defs->flags7;
 		self->flags8 = defs->flags8;
+		self->flags9 = defs->flags9;
 		self->SetState (self->SpawnState);
 		self->renderflags &= ~RF_INVISIBLE;
 

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -1226,7 +1226,17 @@ DEFINE_ACTION_FUNCTION(AActor, A_CustomRailgun)
 			self->Angles.Yaw = self->AngleTo(self->target,- self->target->Vel.X * veleffect, -self->target->Vel.Y * veleffect);
 		}
 
-		if (self->target->flags & MF_SHADOW)
+		// [inkoalawetrust] The exact formula P_RailAttack uses to determine where the railgun trace should spawn from.
+		DVector2 shootXY = (self->Vec2Angle(spawnofs_xy, (self->Angles.Yaw + spread_xy) - DAngle::fromDeg(90.)));
+		double shootZ = self->Center() - self->FloatSpeed + spawnofs_z - self->Floorclip;
+		if (flags & 16) shootZ += self->AttackOffset(); //16 is RGF_CENTERZ 
+		DVector3 checkPos;
+		checkPos.X = shootXY.X;
+		checkPos.Y = shootXY.Y;
+		checkPos.Z = shootZ;
+
+		bool doshadow = !(self->flags6 & MF6_SEEINVISIBLE) || (self->flags9 & MF9_SHADOWAIM);
+		if (doshadow && (self->target->flags & MF_SHADOW || self->flags9 & MF9_DOSHADOWBLOCK && P_CheckForShadowBlock(self, self->target, checkPos)))
 		{
 			DAngle rnd = DAngle::fromDeg(pr_crailgun.Random2() * (45. / 256.));
 			self->Angles.Yaw += rnd;

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -1234,12 +1234,15 @@ DEFINE_ACTION_FUNCTION(AActor, A_CustomRailgun)
 		checkPos.X = shootXY.X;
 		checkPos.Y = shootXY.Y;
 		checkPos.Z = shootZ;
-
+		
 		bool doshadow = !(self->flags6 & MF6_SEEINVISIBLE) || (self->flags9 & MF9_SHADOWAIM);
 		if (doshadow && (self->target->flags & MF_SHADOW || self->flags9 & MF9_DOSHADOWBLOCK && P_CheckForShadowBlock(self, self->target, checkPos)))
 		{
-			DAngle rnd = DAngle::fromDeg(pr_crailgun.Random2() * (45. / 256.));
-			self->Angles.Yaw += rnd;
+			self->Angles.Yaw += DAngle::fromDeg(pr_crailgun.Random2() * (45. / 256.));
+			if (self->flags9 & MF9_SHADOWAIMVERT)
+			{
+				self->Angles.Pitch += DAngle::fromDeg(pr_crailgun.Random2() * (45. / 256.));
+			}
 		}
 	}
 

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -1184,6 +1184,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CustomRailgun)
 	DVector3 savedpos = self->Pos();
 	DAngle saved_angle = self->Angles.Yaw;
 	DAngle saved_pitch = self->Angles.Pitch;
+	AActor* penalizer = nullptr;
 
 	if (aim && self->target == NULL)
 	{
@@ -1236,12 +1237,15 @@ DEFINE_ACTION_FUNCTION(AActor, A_CustomRailgun)
 		checkPos.Z = shootZ;
 		
 		bool doshadow = !(self->flags6 & MF6_SEEINVISIBLE) || (self->flags9 & MF9_SHADOWAIM);
-		if (doshadow && (self->target->flags & MF_SHADOW || self->flags9 & MF9_DOSHADOWBLOCK && P_CheckForShadowBlock(self, self->target, checkPos)))
+		if (doshadow && (self->target->flags & MF_SHADOW || self->flags9 & MF9_DOSHADOWBLOCK && (penalizer = P_CheckForShadowBlock(self, self->target, checkPos))))
 		{
-			self->Angles.Yaw += DAngle::fromDeg(pr_crailgun.Random2() * (45. / 256.));
+			if (penalizer == nullptr)
+				penalizer = self->target;
+
+			self->Angles.Yaw += DAngle::fromDeg(pr_crailgun.Random2() * (45. / 256.)) * self->ShadowAimFactor * penalizer->ShadowPenaltyFactor;
 			if (self->flags9 & MF9_SHADOWAIMVERT)
 			{
-				self->Angles.Pitch += DAngle::fromDeg(pr_crailgun.Random2() * (45. / 256.));
+				self->Angles.Pitch += DAngle::fromDeg(pr_crailgun.Random2() * (45. / 256.)) * self->ShadowAimFactor * penalizer->ShadowPenaltyFactor;
 			}
 		}
 	}

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -3023,7 +3023,7 @@ void A_Face(AActor *self, AActor *other, DAngle max_turn, DAngle max_pitch, DAng
 
 
 	// This will never work well if the turn angle is limited.
-	if (max_turn == nullAngle && (self->Angles.Yaw == other_angle) && other->flags & MF_SHADOW && !(self->flags6 & MF6_SEEINVISIBLE) )
+	if (max_turn == nullAngle && (self->Angles.Yaw == other_angle) && other->flags & MF_SHADOW && (!(self->flags6 & MF6_SEEINVISIBLE) || (self->flags9 & MF9_SHADOWAIM)))
     {
 		self->Angles.Yaw += DAngle::fromDeg(pr_facetarget.Random2() * (45 / 256.));
     }
@@ -3073,7 +3073,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_MonsterRail)
 	// Let the aim trail behind the player
 	self->Angles.Yaw = self->AngleTo(self->target, -self->target->Vel.X * 3, -self->target->Vel.Y * 3);
 
-	if (self->target->flags & MF_SHADOW && !(self->flags6 & MF6_SEEINVISIBLE))
+	if (self->target->flags & MF_SHADOW && (!(self->flags6 & MF6_SEEINVISIBLE) || (self->flags9 & MF9_SHADOWAIM)))
 	{
 		self->Angles.Yaw += DAngle::fromDeg(pr_railface.Random2() * 45./256);
 	}

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -3021,9 +3021,9 @@ void A_Face(AActor *self, AActor *other, DAngle max_turn, DAngle max_pitch, DAng
 	}
 	
 
-
+	bool doshadow = !(self->flags6 & MF6_SEEINVISIBLE) || (self->flags9 & MF9_SHADOWAIM);
 	// This will never work well if the turn angle is limited.
-	if (max_turn == nullAngle && (self->Angles.Yaw == other_angle) && other->flags & MF_SHADOW && (!(self->flags6 & MF6_SEEINVISIBLE) || (self->flags9 & MF9_SHADOWAIM)))
+	if (max_turn == nullAngle && (self->Angles.Yaw == other_angle) && doshadow && (other->flags & MF_SHADOW || self->flags9 & MF9_DOSHADOWBLOCK && P_CheckForShadowBlock(self, other, self->PosAtZ(self->Center()))))
     {
 		self->Angles.Yaw += DAngle::fromDeg(pr_facetarget.Random2() * (45 / 256.));
     }
@@ -3073,7 +3073,8 @@ DEFINE_ACTION_FUNCTION(AActor, A_MonsterRail)
 	// Let the aim trail behind the player
 	self->Angles.Yaw = self->AngleTo(self->target, -self->target->Vel.X * 3, -self->target->Vel.Y * 3);
 
-	if (self->target->flags & MF_SHADOW && (!(self->flags6 & MF6_SEEINVISIBLE) || (self->flags9 & MF9_SHADOWAIM)))
+	double shootZ = self->Center() - self->FloatSpeed - self->Floorclip; // The formula P_RailAttack uses, minus offset_z since this function doesn't use it.
+	if (((!(self->flags6 & MF6_SEEINVISIBLE) || (self->flags9 & MF9_SHADOWAIM)) && (self->target->flags & MF_SHADOW || self->flags9 & MF9_DOSHADOWBLOCK && P_CheckForShadowBlock(self, self->target, self->PosAtZ(shootZ)))))
 	{
 		self->Angles.Yaw += DAngle::fromDeg(pr_railface.Random2() * 45./256);
 	}

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -104,6 +104,7 @@ static void SpawnDeepSplash(AActor *t1, const FTraceResults &trace, AActor *puff
 static FRandom pr_tracebleed("TraceBleed");
 static FRandom pr_checkthing("CheckThing");
 static FRandom pr_lineattack("LineAttack");
+static FRandom pr_shadowaimz("VerticalShadowAim");
 static FRandom pr_crunch("DoCrunch");
 
 // keep track of special lines as they are hit,
@@ -4452,6 +4453,23 @@ DAngle P_AimLineAttack(AActor *t1, DAngle angle, double distance, FTranslatedLin
 	{
 		*pLineTarget = *result;
 	}
+
+	AActor* mo;
+	if (target)
+		mo = target;
+	else
+		mo = result->linetarget;
+	bool shadowPenalty = ((!(t1->flags6 & MF6_SEEINVISIBLE) || (t1->flags9 & MF9_SHADOWAIM)) && ((mo && mo->flags & MF_SHADOW) || (t1->flags9 & MF9_DOSHADOWBLOCK && P_CheckForShadowBlock(t1, mo, t1->PosAtZ(shootz)))));
+
+	// [inkoalawetrust] Randomly offset the vertical aim of monsters. Roughly uses the SSG vertical spread.
+	if (t1->player == NULL && t1->flags9 & MF9_SHADOWAIMVERT && shadowPenalty)
+	{
+		if (result->linetarget)
+			result->pitch = DAngle::fromDeg(pr_shadowaimz.Random2() * (28.388 / 256.));
+		else
+			t1->Angles.Pitch = DAngle::fromDeg(pr_shadowaimz.Random2() * (28.388 / 256.));
+	}
+
 	return result->linetarget ? result->pitch : t1->Angles.Pitch;
 }
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6689,7 +6689,7 @@ AActor *P_SpawnMissileXYZ (DVector3 pos, AActor *source, AActor *dest, PClassAct
 	// invisible target: rotate velocity vector in 2D
 	// [RC] Now monsters can aim at invisible player as if they were fully visible.
 	// [inkoalawetrust] Unless the actor should get the aim penalty anyway.
-	if (dest->flags & MF_SHADOW && (!(source->flags6 & MF6_SEEINVISIBLE) || (source->flags9 & MF9_SHADOWAIM)))
+	if ((!(source->flags6 & MF6_SEEINVISIBLE) || (source->flags9 & MF9_SHADOWAIM)) && (dest->flags & MF_SHADOW || source->flags9 & MF9_DOSHADOWBLOCK && P_CheckForShadowBlock(source, dest, pos)))
 	{
 		DAngle an = DAngle::fromDeg(pr_spawnmissile.Random2() * (22.5 / 256));
 		double c = an.Cos();
@@ -6822,7 +6822,7 @@ AActor *P_SpawnMissileZAimed (AActor *source, double z, AActor *dest, PClassActo
 
 	an = source->Angles.Yaw;
 
-	if (dest->flags & MF_SHADOW && (!(source->flags6 & MF6_SEEINVISIBLE) || (source->flags9 & MF9_SHADOWAIM)))
+	if ((!(source->flags6 & MF6_SEEINVISIBLE) || (source->flags9 & MF9_SHADOWAIM)) && (dest->flags & MF_SHADOW || source->flags9 & MF9_DOSHADOWBLOCK && P_CheckForShadowBlock(source, dest, source->PosAtZ(z))))
 	{
 		an += DAngle::fromDeg(pr_spawnmissile.Random2() * (16. / 360.));
 	}

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6647,7 +6647,7 @@ AActor *P_SpawnMissileXYZ (DVector3 pos, AActor *source, AActor *dest, PClassAct
 
 	if (dest == NULL)
 	{
-		Printf ("P_SpawnMissilyXYZ: Tried to shoot %s from %s with no dest\n",
+		Printf ("P_SpawnMissileXYZ: Tried to shoot %s from %s with no destination\n",
 			type->TypeName.GetChars(), source->GetClass()->TypeName.GetChars());
 		return NULL;
 	}
@@ -6688,7 +6688,8 @@ AActor *P_SpawnMissileXYZ (DVector3 pos, AActor *source, AActor *dest, PClassAct
 
 	// invisible target: rotate velocity vector in 2D
 	// [RC] Now monsters can aim at invisible player as if they were fully visible.
-	if (dest->flags & MF_SHADOW && !(source->flags6 & MF6_SEEINVISIBLE))
+	// [inkoalawetrust] Unless the actor should get the aim penalty anyway.
+	if (dest->flags & MF_SHADOW && (!(source->flags6 & MF6_SEEINVISIBLE) || (source->flags9 & MF9_SHADOWAIM)))
 	{
 		DAngle an = DAngle::fromDeg(pr_spawnmissile.Random2() * (22.5 / 256));
 		double c = an.Cos();
@@ -6821,7 +6822,7 @@ AActor *P_SpawnMissileZAimed (AActor *source, double z, AActor *dest, PClassActo
 
 	an = source->Angles.Yaw;
 
-	if (dest->flags & MF_SHADOW)
+	if (dest->flags & MF_SHADOW && (!(source->flags6 & MF6_SEEINVISIBLE) || (source->flags9 & MF9_SHADOWAIM)))
 	{
 		an += DAngle::fromDeg(pr_spawnmissile.Random2() * (16. / 360.));
 	}

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -233,6 +233,7 @@ void AActor::Serialize(FSerializer &arc)
 		A("flags6", flags6)
 		A("flags7", flags7)
 		A("flags8", flags8)
+		A("flags9", flags9)
 		A("weaponspecial", weaponspecial)
 		A("special1", special1)
 		A("special2", special2)
@@ -7692,6 +7693,9 @@ void PrintMiscActorInfo(AActor *query)
 		Printf("\n   flags8: %x", query->flags8.GetValue());
 		for (flagi = 0; flagi <= 31; flagi++)
 			if (query->flags8 & ActorFlags8::FromInt(1<<flagi)) Printf(" %s", FLAG_NAME(1<<flagi, flags8));
+		Printf("\n   flags9: %x", query->flags9.GetValue());
+		for (flagi = 0; flagi <= 31; flagi++)
+			if (query->flags9 & ActorFlags9::FromInt(1<<flagi)) Printf(" %s", FLAG_NAME(1<<flagi, flags9));
 		Printf("\nBounce flags: %x\nBounce factors: f:%f, w:%f", 
 			query->BounceFlags.GetValue(), query->bouncefactor,
 			query->wallbouncefactor);

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -348,6 +348,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF9, SHADOWAIM, AActor, flags9),
 	DEFINE_FLAG(MF9, DOSHADOWBLOCK, AActor, flags9),
 	DEFINE_FLAG(MF9, SHADOWBLOCK, AActor, flags9),
+	DEFINE_FLAG(MF9, SHADOWAIMVERT, AActor, flags9),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -346,6 +346,8 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, ONLYSLAMSOLID, AActor, flags8),
 
 	DEFINE_FLAG(MF9, SHADOWAIM, AActor, flags9),
+	DEFINE_FLAG(MF9, DOSHADOWBLOCK, AActor, flags9),
+	DEFINE_FLAG(MF9, SHADOWBLOCK, AActor, flags9),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -345,6 +345,8 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, ADDLIGHTLEVEL, AActor, flags8),
 	DEFINE_FLAG(MF8, ONLYSLAMSOLID, AActor, flags8),
 
+	DEFINE_FLAG(MF9, SHADOWAIM, AActor, flags9),
+
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),
 	DEFINE_FLAG2(FX_ROCKET, ROCKETTRAIL, AActor, effects),

--- a/src/scripting/thingdef_properties.cpp
+++ b/src/scripting/thingdef_properties.cpp
@@ -988,6 +988,7 @@ DEFINE_PROPERTY(clearflags, 0, Actor)
 	defaults->flags6 = 0;
 	defaults->flags7 = 0;
 	defaults->flags8 = 0;
+	defaults->flags9 = 0;
 }
 
 //==========================================================================

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -2108,6 +2108,8 @@ DEFINE_FIELD_NAMED(AActor, ViewAngles.Yaw, viewangle)
 DEFINE_FIELD_NAMED(AActor, ViewAngles.Pitch, viewpitch)
 DEFINE_FIELD_NAMED(AActor, ViewAngles.Roll, viewroll)
 DEFINE_FIELD(AActor, LightLevel)
+DEFINE_FIELD(AActor, ShadowAimFactor)
+DEFINE_FIELD(AActor, ShadowPenaltyFactor)
 
 DEFINE_FIELD_X(FCheckPosition, FCheckPosition, thing);
 DEFINE_FIELD_X(FCheckPosition, FCheckPosition, pos);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -248,6 +248,7 @@ class Actor : Thinker native
 	native double ViewAngle, ViewPitch, ViewRoll;
 	native double RadiusDamageFactor;		// Radius damage factor
 	native double SelfDamageFactor;
+	native double ShadowAimFactor, ShadowPenaltyFactor;
 	native double StealthAlpha;
 	native int WoundHealth;		// Health needed to enter wound state
 	native readonly color BloodColor;
@@ -361,6 +362,8 @@ class Actor : Thinker native
 	property FriendlySeeBlocks: FriendlySeeBlocks;
 	property ThruBits: ThruBits;
 	property LightLevel: LightLevel;
+	property ShadowAimFactor: ShadowAimFactor;
+	property ShadowPenaltyFactor: ShadowPenaltyFactor;
 	
 	// need some definition work first
 	//FRenderStyle RenderStyle;
@@ -438,6 +441,8 @@ class Actor : Thinker native
 		FastSpeed -1;
 		RadiusDamageFactor 1;
 		SelfDamageFactor 1;
+		ShadowAimFactor 1;
+		ShadowPenaltyFactor 1;
 		StealthAlpha 0;
 		WoundHealth 6;
 		GibHealth int.min;


### PR DESCRIPTION
This pull request extends the behavior of the aiming penalty that monsters get when they shoot at MF_SHADOW actors.

Here's a list of the new flags:
- SHADOWAIM: This flag can be used in conjunction with SEEINVISIBLE to make a monster able to immediately see cloaked players, but still get an aim penalty when shooting at them or through SHADOWBLOCK actors. Which brings me to:
- SHADOWBLOCK: This flag marks an actor as being able to impose the shadow aim penalty on actors simply by being in their line of fire. Such as for making a cloaking field that is a large hitbox with the flag, or functional smoke grenades.
- DOSHADOWBLOCK: Because the previous flag works by making actors fire a trace from their position to their target*. This flag needs to be on at the shooters' end to actually make their aim degrade by SHADOWBLOCK actors.**
- SHADOWAIMVERT: This flag makes it so actors also have their vertical aim degraded by shadow actors. For example, the Cacodemons' projectiles will also have vertical spread when this flag is on.

Besides these 4 flags, the PR also adds two properties that can be used to fine tune just how much an actors' aim is degraded.

- ShadowAimFactor: This is a multiplier that allows you to control how much the actors' aim is degraded by shadows. It can be used to make monsters more or less accurate when shooting at shadow actors.
- ShadowPenaltyFactor: This works similarly to ShadowAimFactor, but on the shadow actors' end. It can be used to, for example, make super thick SHADOWBLOCK fog that massively degrades the aim of DOSHADOWBLOCK actors that try to shoot through it. Or can be used to make a super blursphere that makes the player twice as hard for all monsters to hit. If a SHADOWBLOCK actor is in the LOF, its' penalty factor will be applied to the monsters' aim, otherwise, the penalty factor of the target is used.


I have also included an example map that demonstrates these new flags and properties. And with certain scenarios like an actor with an aim factor of 0.25 firing at a player with a super blursphere that gives them a penalty factor of 8.

[Sight flags example.zip](https://github.com/ZDoom/gzdoom/files/10416387/Sight.flags.example.zip)


*Or will fall back to firing the trace at the shooters' facing direction if no other actor is passed.
**Even with this flag on, the shooter will only check for shadow blockers at the very end of the shadow checks, and will NOT do so if his target already has MF_SHADOW on. This minimizes the overhead of the trace as much as possible.