### PR TITLE
CCMD listmaps: Colorize maps loaded from pwads in blue text

### DIFF
--- a/src/g_dumpinfo.cpp
+++ b/src/g_dumpinfo.cpp
@@ -361,6 +361,8 @@ CCMD(targetinv)
 
 CCMD(listmaps)
 {
+	int iwadNum = fileSystem.GetIwadNum();
+
 	for (unsigned i = 0; i < wadlevelinfos.Size(); i++)
 	{
 		level_info_t *info = &wadlevelinfos[i];
@@ -368,13 +370,20 @@ CCMD(listmaps)
 
 		if (map != NULL)
 		{
+			int mapWadNum = fileSystem.GetFileContainer(map->lumpnum);
+
 			if (argv.argc() == 1 
 			    || CheckWildcards(argv[1], info->MapName.GetChars()) 
 			    || CheckWildcards(argv[1], info->LookupLevelName().GetChars())
-			    || CheckWildcards(argv[1], fileSystem.GetResourceFileName(fileSystem.GetFileContainer(map->lumpnum))))
+			    || CheckWildcards(argv[1], fileSystem.GetResourceFileName(mapWadNum)))
 			{
-				Printf("%s: '%s' (%s)\n", info->MapName.GetChars(), info->LookupLevelName().GetChars(),
-					fileSystem.GetResourceFileName(fileSystem.GetFileContainer(map->lumpnum)));
+				bool isFromPwad = mapWadNum != iwadNum;
+
+				const char* lineColor = isFromPwad ? TEXTCOLOR_LIGHTBLUE : "";
+
+				Printf("%s%s: '%s' (%s)\n", lineColor, info->MapName.GetChars(),
+					info->LookupLevelName().GetChars(),
+					fileSystem.GetResourceFileName(mapWadNum));
 			}
 			delete map;
 		}


### PR DESCRIPTION
Colorize maps that are added or modified by pwads differently so they stand out better

![listmaps-output](https://user-images.githubusercontent.com/20593027/212448264-6ccc453e-bac3-47d1-a179-6da6da807320.png)

Personally, this helps to locate the maps I am most often using the listmaps command to find. Having the maps listed in a different color makes them much easier to spot.

This is kept as simple as possible. All highlighted maps use the same hard-coded TEXTCOLOR_LIGHTBLUE color