### PR TITLE
Fix Y position of characters in monospace fonts

### DIFF
--- a/src/common/fonts/font.cpp
+++ b/src/common/fonts/font.cpp
@@ -422,7 +422,7 @@ void FFont::ReadSheetFont(TArray<FolderEntry> &folderdata, int width, int height
 				{
 					for (int x = 0; x < numtex_x; x++)
 					{
-						auto image = new FSheetTexture(sheetBitmaps.Size() - 1, x * width, y * width, width, height);
+						auto image = new FSheetTexture(sheetBitmaps.Size() - 1, x * width, y * height, width, height);
 						FImageTexture *imgtex = new FImageTexture(image);
 						auto gtex = MakeGameTexture(imgtex, nullptr, ETextureType::FontChar);
 						gtex->SetWorldPanning(true);


### PR DESCRIPTION
The issue was either a typo, or a false assumption that all monospace font characters would be in squares on the sheet. Fixes #1937