### PR TITLE
Use a slider to allow specifying max FPS with more precision

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2295,7 +2295,7 @@ OptionMenu VideoModeMenu protected
 
 	StaticText " "
 	Option "$DSPLYMNU_VSYNC",					"vid_vsync", "OnOff"
-	Option "$VIDMNU_MAXFPS",					"vid_maxfps", "MaxFps"
+	Slider "$VIDMNU_MAXFPS",					"vid_maxfps", 35, 500, 1
 	Option "$DSPLYMNU_CAPFPS",					"cl_capfps", "OffOn"
 	
 	StaticText ""

--- a/wadsrc/static/menudef.zsimple
+++ b/wadsrc/static/menudef.zsimple
@@ -66,7 +66,7 @@ OptionMenu VideoOptionsSimple protected
 	Option "$GLPREFMNU_SECLIGHTMODE",			gl_lightmode,					"LightingModes"
 	StaticText " "
 	Option "$DSPLYMNU_VSYNC",					"vid_vsync", "OnOff"
-	Option "$VIDMNU_MAXFPS",					"vid_maxfps", "MaxFps"
+	Slider "$VIDMNU_MAXFPS",					"vid_maxfps", 35, 500, 1
 	StaticText " "
 	Slider "$DSPLYMNU_GAMMA",					"vid_gamma",					0.75, 3.0, 0.05, 2
 	Slider "$DSPLYMNU_BRIGHTNESS",				"vid_brightness",				-0.8,0.8, 0.05,2


### PR DESCRIPTION
The minimum value was increased from 30 to 35 to reflect the lowest value you can actually use in `vid_maxfps`. Values lower than 35 are silently clamped to 35.

The maximum value is chosen to cater to the fastest commercially available display as of writing (500 Hz).

Being able to specify maximum FPS with a more precise slider has several benefits:

- This adds support for monitors with less common refresh rates (138 Hz, 165 Hz, ...).
- This adds support for monitors with very high refresh rates (240 Hz or more).
- This allows catering to variable refresh rate setups with a FPS cap chosen to avoid V-Sync input lag, while also avoiding tearing. For example, choosing a FPS cap of 117 on a 120 Hz display will prevent the display from reaching its maximum refresh rate. More information: https://blurbusters.com/howto-low-lag-vsync-on/
  - I've personally tried this setup with GZDoom and it works quite well :slightly_smiling_face:
- The value no longer displays a "Unknown" if customized in the console using the `vid_maxfps` cvar.
