### PR TITLE
Fix _portable.ini name confusion

### DIFF
--- a/src/common/platform/win32/i_specialpaths.cpp
+++ b/src/common/platform/win32/i_specialpaths.cpp
@@ -90,7 +90,7 @@ bool IsPortable()
 	}
 
 	// A portable INI means that this storage location should also be portable if the file can be written to.
-	FStringf path("%s" GAMENAME "_portable.ini", progdir.GetChars());
+	FStringf path("%s" GAMENAMELOWERCASE "_portable.ini", progdir.GetChars());
 	if (FileExists(path))
 	{
 		file = CreateFile(path.WideString().c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL,


### PR DESCRIPTION
M_GetConfigPath uses `GAMENAMELOWERCASE_portable.ini`, but IsPortable() used `GAMENAME_portable.ini`. Doesn't have much of an impact on base GZDoom since it's case-insensitive, but can matter for engine forks -- IMO it should just be consistent either way. Picked the lowercase version since it had more uses in the file.