### PR TITLE
Fixed BlockingLine giving erroneous results

### DIFF
--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -285,7 +285,7 @@ void FLevelLocals::ClearLevelData(bool fullgc)
 		auto it = GetThinkerIterator<AActor>(NAME_None, STAT_TRAVELLING);
 		for (AActor *actor = it.Next(); actor != nullptr; actor = it.Next())
 		{
-			actor->BlockingLine = nullptr;
+			actor->BlockingLine = actor->MovementBlockingLine = nullptr;
 			actor->BlockingFloor = actor->BlockingCeiling = actor->Blocking3DFloor = nullptr;
 		}
 	}

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1200,6 +1200,7 @@ public:
 
 	AActor			*BlockingMobj;	// Actor that blocked the last move
 	line_t			*BlockingLine;	// Line that blocked the last move
+	line_t			*MovementBlockingLine; // Line that stopped the Actor's movement in P_XYMovement
 	sector_t		*Blocking3DFloor;	// 3D floor that blocked the last move (if any)
 	sector_t		*BlockingCeiling;	// Sector that blocked the last move (ceiling plane slope)
 	sector_t		*BlockingFloor;		// Sector that blocked the last move (floor plane slope)

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -308,6 +308,7 @@ void AActor::Serialize(FSerializer &arc)
 		A("smokecounter", smokecounter)
 		("blockingmobj", BlockingMobj)
 		A("blockingline", BlockingLine)
+		A("movementblockingline", MovementBlockingLine)
 		A("blocking3dfloor", Blocking3DFloor)
 		A("blockingceiling", BlockingCeiling)
 		A("blockingfloor", BlockingFloor)
@@ -1950,7 +1951,6 @@ static double P_XYMovement (AActor *mo, DVector2 scroll)
 	FCheckPosition tm(!!(mo->flags2 & MF2_RIP));
 
 	DAngle oldangle = mo->Angles.Yaw;
-	line_t* blocker = nullptr;
 	do
 	{
 		if (mo->Level->i_compatflags & COMPATF_WALLRUN) pushtime++;
@@ -1966,7 +1966,7 @@ static double P_XYMovement (AActor *mo, DVector2 scroll)
 		{
 			// blocked move
 			AActor *BlockingMobj = mo->BlockingMobj;
-			line_t *BlockingLine = blocker = mo->BlockingLine;
+			line_t *BlockingLine = mo->MovementBlockingLine = mo->BlockingLine;
 
 			// [ZZ] 
 			if (!BlockingLine && !BlockingMobj) // hit floor or ceiling while XY movement - sector actions
@@ -2213,9 +2213,6 @@ explode:
 			}
 		}
 	} while (++step <= steps);
-
-	// Correctly update whether the Actor was truly blocked by a wall or not
-	mo->BlockingLine = blocker;
 
 	// Friction
 
@@ -4088,7 +4085,7 @@ void AActor::Tick ()
 
 		// Handle X and Y velocities
 		BlockingMobj = nullptr;
-		BlockingLine = nullptr;
+		MovementBlockingLine = nullptr;
 		sector_t* oldBlockingCeiling = BlockingCeiling;
 		sector_t* oldBlockingFloor = BlockingFloor;
 		Blocking3DFloor = nullptr;

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -1950,6 +1950,7 @@ static double P_XYMovement (AActor *mo, DVector2 scroll)
 	FCheckPosition tm(!!(mo->flags2 & MF2_RIP));
 
 	DAngle oldangle = mo->Angles.Yaw;
+	line_t* blocker = nullptr;
 	do
 	{
 		if (mo->Level->i_compatflags & COMPATF_WALLRUN) pushtime++;
@@ -1965,7 +1966,7 @@ static double P_XYMovement (AActor *mo, DVector2 scroll)
 		{
 			// blocked move
 			AActor *BlockingMobj = mo->BlockingMobj;
-			line_t *BlockingLine = mo->BlockingLine;
+			line_t *BlockingLine = blocker = mo->BlockingLine;
 
 			// [ZZ] 
 			if (!BlockingLine && !BlockingMobj) // hit floor or ceiling while XY movement - sector actions
@@ -2212,6 +2213,9 @@ explode:
 			}
 		}
 	} while (++step <= steps);
+
+	// Correctly update whether the Actor was truly blocked by a wall or not
+	mo->BlockingLine = blocker;
 
 	// Friction
 
@@ -4084,6 +4088,7 @@ void AActor::Tick ()
 
 		// Handle X and Y velocities
 		BlockingMobj = nullptr;
+		BlockingLine = nullptr;
 		sector_t* oldBlockingCeiling = BlockingCeiling;
 		sector_t* oldBlockingFloor = BlockingFloor;
 		Blocking3DFloor = nullptr;

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1538,20 +1538,21 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, LookForPlayers, P_LookForPlayers)
 	ACTION_RETURN_BOOL(P_LookForPlayers(self, allaround, params));
 }
 
-static int CheckMonsterUseSpecials(AActor *self)
+static int CheckMonsterUseSpecials(AActor *self, line_t *blocking)
 {
 	spechit_t spec;
 	int good = 0;
 
 	if (!(self->flags6 & MF6_NOTRIGGER))
 	{
+		auto checkLine = blocking ? blocking : self->BlockingLine;
 		while (spechit.Pop (spec))
 		{
 			// [RH] let monsters push lines, as well as use them
 			if (((self->flags4 & MF4_CANUSEWALLS) && P_ActivateLine (spec.line, self, 0, SPAC_Use)) ||
 				((self->flags2 & MF2_PUSHWALL) && P_ActivateLine (spec.line, self, 0, SPAC_Push)))
 			{
-				good |= spec.line == self->BlockingLine ? 1 : 2;
+				good |= spec.line == checkLine ? 1 : 2;
 			}
 		}
 	}
@@ -1563,8 +1564,9 @@ static int CheckMonsterUseSpecials(AActor *self)
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, CheckMonsterUseSpecials, CheckMonsterUseSpecials)
 {
 	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_POINTER(blocking, line_t);
 
-	ACTION_RETURN_INT(CheckMonsterUseSpecials(self));
+	ACTION_RETURN_INT(CheckMonsterUseSpecials(self, blocking));
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, A_Wander, A_Wander)
@@ -2045,6 +2047,7 @@ DEFINE_FIELD(AActor, lastbump)
 DEFINE_FIELD(AActor, DesignatedTeam)
 DEFINE_FIELD(AActor, BlockingMobj)
 DEFINE_FIELD(AActor, BlockingLine)
+DEFINE_FIELD(AActor, MovementBlockingLine)
 DEFINE_FIELD(AActor, Blocking3DFloor)
 DEFINE_FIELD(AActor, BlockingCeiling)
 DEFINE_FIELD(AActor, BlockingFloor)

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -202,6 +202,7 @@ class Actor : Thinker native
 	native int DesignatedTeam;
 	native Actor BlockingMobj;
 	native Line BlockingLine;
+	native Line MovementBlockingLine;
 	native Sector Blocking3DFloor;
 	native Sector BlockingCeiling;
 	native Sector BlockingFloor;
@@ -693,7 +694,7 @@ class Actor : Thinker native
 	native void CheckFakeFloorTriggers (double oldz, bool oldz_has_viewheight = false);
 	native bool CheckFor3DFloorHit(double z, bool trigger);
 	native bool CheckFor3DCeilingHit(double z, bool trigger);
-	native int CheckMonsterUseSpecials();
+	native int CheckMonsterUseSpecials(Line blocking = null);
 	
 	native bool CheckMissileSpawn(double maxdist);
 	native bool CheckPosition(Vector2 pos, bool actorsonly = false, FCheckPosition tm = null);


### PR DESCRIPTION
Also includes a fix where BlockingLine wouldn't get cleared properly when at zero xy velocity. This was an issue mainly caused by the way sliding on walls didn't technically block movement even though the Actor still hit the wall. As a result, this made it impossible to detect if something with +SLIDESONWALLS hit a one-sided line in ZScript without writing extensive manual checks. Another effect of this change is that false positives will no longer trigger i.e. if no line blocked movement this will be accurately reflected in the field.