### PR TITLE
Added OnEngineInitialize() for static event handlers

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3512,6 +3512,8 @@ static int D_InitGame(const FIWADInfo* iwad_info, TArray<FString>& allwads, TArr
 		D_StartTitle ();				// start up intro loop
 		setmodeneeded = false;			// This may be set to true here, but isn't needed for a restart
 	}
+
+	staticEventManager.OnEngineInitialize();
 	return 0;
 }
 //==========================================================================

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -280,6 +280,14 @@ void EventManager::Shutdown()
 		handler->name(); \
 }
 
+void EventManager::OnEngineInitialize()
+{
+	for (DStaticEventHandler* handler = FirstEventHandler; handler; handler = handler->next)
+	{
+		if (handler->IsStatic())
+			handler->OnEngineInitialize();
+	}
+}
 
 // note for the functions below.
 // *Unsafe is executed on EVERY map load/close, including savegame loading, etc.
@@ -772,6 +780,18 @@ FWorldEvent EventManager::SetupWorldEvent()
 	e.DamageAngle = nullAngle;
 	return e;
 }
+
+void DStaticEventHandler::OnEngineInitialize()
+{
+	IFVIRTUAL(DStaticEventHandler, OnEngineInitialize)
+	{
+		// don't create excessive DObjects if not going to be processed anyway
+		if (isEmpty(func)) return;
+		VMValue params[1] = { (DStaticEventHandler*)this };
+		VMCall(func, params, 1, nullptr, 0);
+	}
+}
+
 
 void DStaticEventHandler::WorldLoaded()
 {

--- a/src/events.h
+++ b/src/events.h
@@ -77,6 +77,7 @@ public:
 	void OnUnregister();
 
 	//
+	void OnEngineInitialize();
 	void WorldLoaded();
 	void WorldUnloaded(const FString& nextmap);
 	void WorldThingSpawned(AActor* actor);
@@ -230,6 +231,8 @@ struct EventManager
 	// shutdown handlers
 	void Shutdown();
 
+	// after the engine is done creating data
+	void OnEngineInitialize();
 	// called right after the map has loaded (approximately same time as OPEN ACS scripts)
 	void WorldLoaded();
 	// called when the map is about to unload (approximately same time as UNLOADING ACS scripts)

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -89,6 +89,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual void OnUnregister() {}
 
     // actual handlers are here
+    virtual void OnEngineInitialize() {}
 	virtual void WorldLoaded(WorldEvent e) {}
     virtual void WorldUnloaded(WorldEvent e) {}
     virtual void WorldThingSpawned(WorldEvent e) {}


### PR DESCRIPTION
Static event handlers are a great way to parse and generate global data from lumps, but it's clear OnRegister() is not the place to do this. Unfortunately there's no real alternative as most of the time info only needs to be parsed once and then never again, something other functions aren't good for. This new virtual solves that by being called after everything else has been created but only once similar to OnRegister().

Only StaticEventHandlers are ever allowed to have this called. I'm not 100% sure if the call is in the right spot as there's a lot going on in the InitGame function, but it works as advertised from testing.