### PR TITLE
Change `CheckValue` to multi-return, due to unsupported out int/bool

### DIFF
--- a/src/common/scripting/core/maps.cpp
+++ b/src/common/scripting/core/maps.cpp
@@ -108,7 +108,7 @@ template<typename T>
 using expand_types_vm = 
 std::conditional_t<std::is_same_v<T, uint8_t> || std::is_same_v<T, uint16_t>, uint32_t , /* expand 8/16-bit to 32-bit */
     std::conditional_t<std::is_same_v<T, float> , double , /* expand float to double */
-        std::conditional_t<std::is_same_v<T, FString> , const FString & , T>>>; /* change String to String ref */
+        std::conditional_t<std::is_same_v<T, FString> , const FString & , T>>>; /* change String to String ref */   
 
 template<typename M> unsigned int MapCountUsed(M * self)
 {
@@ -188,10 +188,10 @@ template<typename M> int MapCheckKey(M * self, expand_types_vm<typename M::KeyTy
     return self->CheckKey(key) != nullptr;
 }
 
-template<typename M> expand_types_vm<typename M::ValueType> MapCheckValue(M * self,expand_types_vm<typename M::KeyType> key, int * exists)
+template<typename M> expand_types_vm<typename M::ValueType> MapCheckValue(M * self,expand_types_vm<typename M::KeyType> key, int &exists)
 {
     typename M::ValueType * v = self->CheckKey(key);
-    if ((*exists = !!v)) {
+    if ((exists = !!v)) {
         if constexpr(std::is_same_v<typename M::ValueType, DObject*>)
         {
             return GC::ReadBarrier(*v);
@@ -207,10 +207,10 @@ template<typename M> expand_types_vm<typename M::ValueType> MapCheckValue(M * se
     }
 }
 
-template<typename M> void MapCheckValueString(M * self,expand_types_vm<typename M::KeyType> key, int * exists, FString &out)
+template<typename M> void MapCheckValueString(M * self,expand_types_vm<typename M::KeyType> key, FString &out, int &exists)
 {
     FString * v = self->CheckKey(key);
-    if ((*exists = !!v)) {
+    if ((exists = !!v)) {
         out = *v;
     }
     else
@@ -351,6 +351,25 @@ template<typename I> void MapIteratorSetValue(I * self, expand_types_vm<typename
 //
 //==========================================================================
 
+template<int N, typename T, typename U> void SetValType(T & ret,U & val){
+    if constexpr(std::is_same_v<U, DObject*>)
+    {
+        ret[N].SetObject(val);
+    }
+    else if constexpr(std::is_same_v<U, void*>)
+    {
+        ret[N].SetPointer(val);
+    }
+    else if constexpr(std::is_same_v<U, uint32_t>)
+    {
+        ret[N].SetInt(val);
+    }
+    else if constexpr(std::is_same_v<U, double>)
+    {
+        ret[N].SetFloat(val);
+    }
+}
+
 #define PARAM_VOIDPOINTER(X) PARAM_POINTER( X , void )
 #define PARAM_OBJPOINTER(X) PARAM_OBJECT( X , DObject )
 
@@ -435,8 +454,12 @@ template<typename I> void MapIteratorSetValue(I * self, expand_types_vm<typename
     { \
         PARAM_SELF_STRUCT_PROLOGUE( name ); \
         PARAM_KEY( key ); \
-        PARAM_OUTPOINTER( exists, int); \
-        ACTION_RETURN_VALUE( MapCheckValue(self, key, exists) ); \
+        int exists; \
+        expand_types_vm<value_type> out; \
+        out = MapCheckValue(self, key, exists); \
+	    if (numret > 1) ret[1].SetInt(exists); \
+        if (numret > 0) SetValType<0>(ret, out); \
+        return numret; \
     }
 
 #define DEF_MAP_X_S( name, key_type, PARAM_KEY ) \
@@ -461,10 +484,12 @@ template<typename I> void MapIteratorSetValue(I * self, expand_types_vm<typename
     { \
         PARAM_SELF_STRUCT_PROLOGUE( name ); \
         PARAM_KEY( key ); \
-        PARAM_OUTPOINTER( exists, int); \
+        int exists; \
         FString out; \
-        MapCheckValueString(self, key, exists, out); \
-        ACTION_RETURN_STRING( out ); \
+        MapCheckValueString(self, key, out, exists); \
+	    if (numret > 1) ret[1].SetInt(exists); \
+        if (numret > 0) ret[0].SetString(out); \
+        return numret; \
     }
 
 #define COMMA ,

--- a/src/common/scripting/core/types.cpp
+++ b/src/common/scripting/core/types.cpp
@@ -2231,13 +2231,13 @@ enum OverrideFunctionRetType {
 	OFN_RET_VAL,
 	OFN_RET_KEY,
 	OFN_RET_BOOL,
+	OFN_RET_VAL_BOOL,
 };
 enum OverrideFunctionArgType {
 	OFN_ARG_VOID,
 	OFN_ARG_KEY,
 	OFN_ARG_VAL,
 	OFN_ARG_KEY_VAL,
-	OFN_ARG_KEY_OUT_BOOL,
 };
 
 template<class MT, OverrideFunctionRetType RetType, OverrideFunctionArgType ArgType >
@@ -2264,6 +2264,11 @@ void CreateOverrideFunction(MT *self, FName name)
 	}
 	else if constexpr(RetType == OFN_RET_BOOL)
 	{
+		ret.Push(TypeBool);
+	}
+	else if constexpr(RetType == OFN_RET_VAL_BOOL)
+	{
+		ret.Push(self->ValueType);
 		ret.Push(TypeBool);
 	}
 
@@ -2293,15 +2298,6 @@ void CreateOverrideFunction(MT *self, FName name)
 		argnames.Push(NAME_Key);
 		argnames.Push(NAME_Value);
 	}
-	else if constexpr(ArgType == OFN_ARG_KEY_OUT_BOOL)
-	{
-		args.Push(self->KeyType);
-		args.Push(TypeBool);
-		argflags.Push(0);
-		argflags.Push(VARF_Out);
-		argnames.Push(NAME_Key);
-		argnames.Push(NAME_Exists);
-	}
 
 	Fn->AddVariant(NewPrototype(ret, args), argflags, argnames, *NativeFn->VMPointer, VARF_Method | VARF_Native,SUF_ACTOR | SUF_OVERLAY | SUF_WEAPON | SUF_ITEM);
 	self->FnOverrides.Insert(name, Fn);
@@ -2313,13 +2309,13 @@ PMap::PMap(PType *keytype, PType *valtype, PStruct *backing, int backing_class)
 	mDescriptiveName.Format("Map<%s, %s>", keytype->DescriptiveName(), valtype->DescriptiveName());
 	Size = sizeof(ZSFMap);
 	Align = alignof(ZSFMap);
-	CreateOverrideFunction<PMap, OFN_RET_VAL,  OFN_ARG_KEY>(this, NAME_Get);
-	CreateOverrideFunction<PMap, OFN_RET_VAL,  OFN_ARG_KEY>(this, NAME_GetIfExists);
-	CreateOverrideFunction<PMap, OFN_RET_BOOL, OFN_ARG_KEY>(this, NAME_CheckKey);
-	CreateOverrideFunction<PMap, OFN_RET_VAL,  OFN_ARG_KEY_OUT_BOOL>(this, NAME_CheckValue);
-	CreateOverrideFunction<PMap, OFN_RET_VOID, OFN_ARG_KEY_VAL>(this, NAME_Insert);
-	CreateOverrideFunction<PMap, OFN_RET_VOID, OFN_ARG_KEY>(this, NAME_InsertNew);
-	CreateOverrideFunction<PMap, OFN_RET_VOID, OFN_ARG_KEY>(this, NAME_Remove);
+	CreateOverrideFunction<PMap, OFN_RET_VAL	  , OFN_ARG_KEY		> (this, NAME_Get);
+	CreateOverrideFunction<PMap, OFN_RET_VAL	  , OFN_ARG_KEY		> (this, NAME_GetIfExists);
+	CreateOverrideFunction<PMap, OFN_RET_BOOL	  , OFN_ARG_KEY		> (this, NAME_CheckKey);
+	CreateOverrideFunction<PMap, OFN_RET_VAL_BOOL , OFN_ARG_KEY		> (this, NAME_CheckValue);
+	CreateOverrideFunction<PMap, OFN_RET_VOID	  , OFN_ARG_KEY_VAL	> (this, NAME_Insert);
+	CreateOverrideFunction<PMap, OFN_RET_VOID	  , OFN_ARG_KEY		> (this, NAME_InsertNew);
+	CreateOverrideFunction<PMap, OFN_RET_VOID	  , OFN_ARG_KEY		> (this, NAME_Remove);
 }
 
 //==========================================================================

--- a/wadsrc/static/zscript/engine/maps.zs
+++ b/wadsrc/static/zscript/engine/maps.zs
@@ -11,7 +11,7 @@ struct Map_I32_I8 native
     native bool CheckKey(int key) const;
     
     native version("4.11") int GetIfExists(int key) const;
-    native version("4.11") int CheckValue(int key, out bool exists) const;
+    native version("4.11") int, bool CheckValue(int key) const;
     
     native void Insert(int key, int value);
     native void InsertNew(int key);
@@ -43,7 +43,7 @@ struct Map_I32_I16 native
     native bool CheckKey(int key) const;
     
     native version("4.11") int GetIfExists(int key) const;
-    native version("4.11") int CheckValue(int key, out bool exists) const;
+    native version("4.11") int, bool CheckValue(int key) const;
     
     native void Insert(int key, int value);
     native void InsertNew(int key);
@@ -75,7 +75,7 @@ struct Map_I32_I32 native
     native bool CheckKey(int key) const;
     
     native version("4.11") int GetIfExists(int key) const;
-    native version("4.11") int CheckValue(int key, out bool exists) const;
+    native version("4.11") int, bool CheckValue(int key) const;
     
     native void Insert(int key, int value);
     native void InsertNew(int key);
@@ -107,7 +107,7 @@ struct Map_I32_F32 native
     native bool CheckKey(int key) const;
     
     native version("4.11") double GetIfExists(int key) const;
-    native version("4.11") double CheckValue(int key, out bool exists) const;
+    native version("4.11") double, bool CheckValue(int key) const;
     
     native void Insert(int key, double value);
     native void InsertNew(int key);
@@ -139,7 +139,7 @@ struct Map_I32_F64 native
     native bool CheckKey(int key) const;
     
     native version("4.11") double GetIfExists(int key) const;
-    native version("4.11") double CheckValue(int key, out bool exists) const;
+    native version("4.11") double, bool CheckValue(int key) const;
     
     native void Insert(int key, double value);
     native void InsertNew(int key);
@@ -171,7 +171,7 @@ struct Map_I32_Obj native
     native bool CheckKey(int key) const;
     
     native version("4.11") Object GetIfExists(int key) const;
-    native version("4.11") Object CheckValue(int key, out bool exists) const;
+    native version("4.11") Object, bool CheckValue(int key) const;
     
     native void Insert(int key, Object value);
     native void InsertNew(int key);
@@ -203,7 +203,7 @@ struct Map_I32_Ptr native
     native bool CheckKey(int key) const;
     
     native version("4.11") voidptr GetIfExists(int key) const;
-    native version("4.11") voidptr CheckValue(int key, out bool exists) const;
+    native version("4.11") voidptr, bool CheckValue(int key) const;
     
     native void Insert(int key, voidptr value);
     native void InsertNew(int key);
@@ -232,7 +232,7 @@ struct Map_I32_Str native
     native bool CheckKey(int key) const;
     
     native version("4.11") String GetIfExists(int key) const;
-    native version("4.11") String CheckValue(int key, out bool exists) const;
+    native version("4.11") String, bool CheckValue(int key) const;
     
     native void Insert(int key, String value);
     native void InsertNew(int key);
@@ -266,7 +266,7 @@ struct Map_Str_I8 native
     native bool CheckKey(String key) const;
     
     native version("4.11") int GetIfExists(String key) const;
-    native version("4.11") int CheckValue(String key, out bool exists) const;
+    native version("4.11") int, bool CheckValue(String key) const;
     
     native void Insert(String key, int value);
     native void InsertNew(String key);
@@ -298,7 +298,7 @@ struct Map_Str_I16 native
     native bool CheckKey(String key) const;
     
     native version("4.11") int GetIfExists(String key) const;
-    native version("4.11") int CheckValue(String key, out bool exists) const;
+    native version("4.11") int, bool CheckValue(String key) const;
     
     native void Insert(String key, int value);
     native void InsertNew(String key);
@@ -330,7 +330,7 @@ struct Map_Str_I32 native
     native bool CheckKey(String key) const;
     
     native version("4.11") int GetIfExists(String key) const;
-    native version("4.11") int CheckValue(String key, out bool exists) const;
+    native version("4.11") int, bool CheckValue(String key) const;
     
     native void Insert(String key, int value);
     native void InsertNew(String key);
@@ -362,7 +362,7 @@ struct Map_Str_F32 native
     native bool CheckKey(String key) const;
     
     native version("4.11") double GetIfExists(String key) const;
-    native version("4.11") double CheckValue(String key, out bool exists) const;
+    native version("4.11") double, bool CheckValue(String key) const;
     
     native void Insert(String key, double value);
     native void InsertNew(String key);
@@ -394,7 +394,7 @@ struct Map_Str_F64 native
     native bool CheckKey(String key) const;
     
     native version("4.11") double GetIfExists(String key) const;
-    native version("4.11") double CheckValue(String key, out bool exists) const;
+    native version("4.11") double, bool CheckValue(String key) const;
     
     native void Insert(String key, double value);
     native void InsertNew(String key);
@@ -426,7 +426,7 @@ struct Map_Str_Obj native
     native bool CheckKey(String key) const;
     
     native version("4.11") Object GetIfExists(String key) const;
-    native version("4.11") Object CheckValue(String key, out bool exists) const;
+    native version("4.11") Object, bool CheckValue(String key) const;
     
     native void Insert(String key, Object value);
     native void InsertNew(String key);
@@ -458,7 +458,7 @@ struct Map_Str_Ptr native
     native bool CheckKey(String key) const;
     
     native version("4.11") voidptr GetIfExists(String key) const;
-    native version("4.11") voidptr CheckValue(String key, out bool exists) const;
+    native version("4.11") voidptr, bool CheckValue(String key) const;
     
     native void Insert(String key, voidptr value);
     native void InsertNew(String key);
@@ -490,7 +490,7 @@ struct Map_Str_Str native
     native bool CheckKey(String key) const;
     
     native version("4.11") String GetIfExists(String key) const;
-    native version("4.11") String CheckValue(String key, out bool exists) const;
+    native version("4.11") String, bool CheckValue(String key) const;
     
     native void Insert(String key, String value);
     native void InsertNew(String key);


### PR DESCRIPTION
The VM doesn't support out int/bool parameters for native functions