### PR TITLE
GLES: Fix first wipe

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_viewpointbuffer.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_viewpointbuffer.cpp
@@ -126,6 +126,8 @@ void HWViewpointBuffer::Clear()
 
 	if (needNewPipeline)
 	{
+		mLastMappedIndex = UINT_MAX;
+
 		mPipelinePos++;
 		mPipelinePos %= mPipelineNbr;
 	}


### PR DESCRIPTION
On GLES renderer the _first_ (and only) screen-wipe on a new game after launch of the engine will be corrupt if sky is not visible (Eg Doom 2 first level).