### PR TITLE
Fixes bones when using OpenGL 3.3 (UBO bone data)

### DIFF
--- a/src/rendering/hwrenderer/hw_models.cpp
+++ b/src/rendering/hwrenderer/hw_models.cpp
@@ -140,7 +140,9 @@ void FHWModelRenderer::DrawElements(int numIndices, size_t offset)
 int FHWModelRenderer::SetupFrame(FModel *model, unsigned int frame1, unsigned int frame2, unsigned int size, const TArray<VSMatrix>& bones, int boneStartIndex)
 {
 	auto mdbuff = static_cast<FModelVertexBuffer*>(model->GetVertexBuffer(GetType()));
+	screen->mBones->Map();
 	boneIndexBase = boneStartIndex >= 0 ? boneStartIndex : screen->mBones->UploadBones(bones);
+	screen->mBones->Unmap();
 	state.SetBoneIndexBase(boneIndexBase);
 	if (mdbuff)
 	{


### PR DESCRIPTION
When not using shader storage the IQM models do not work. The problem is the bone buffer is unmapped after CreateScene and when the model later tries to  upload the data it fails.
This fixes the issue but it may not be the best fix, maybe Map and Unmap of the bone data could be done further up the callstack I'm not sure?