### PR TITLE
Add more information in saved game comments

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2288,7 +2288,25 @@ static void PutSaveComment (FSerializer &arc)
 	// Append elapsed time
 	const char *const time = GStrings("SAVECOMMENT_TIME");
 	levelTime = primaryLevel->time / TICRATE;
-	comment.AppendFormat("%s: %02d:%02d:%02d", time, levelTime/3600, (levelTime%3600)/60, levelTime%60);
+	comment.AppendFormat("%s: %02d:%02d:%02d\n", time, levelTime/3600, (levelTime%3600)/60, levelTime%60);
+
+	// Append kills/items/secrets
+	comment.AppendFormat("K: %d/%d - I: %d/%d - S: %d/%d\n", primaryLevel->killed_monsters, primaryLevel->total_monsters, primaryLevel->found_items, primaryLevel->total_items, primaryLevel->found_secrets, primaryLevel->total_secrets);
+
+	// Append player health and armor
+	const char *const health = GStrings("SAVECOMMENT_HEALTH");
+	const char *const armor = GStrings("SAVECOMMENT_ARMOR");
+	int armorAmount = 0;
+	auto basicArmorItem = primaryLevel->Players[consoleplayer]->mo->FindInventory(NAME_BasicArmor);
+	if (basicArmorItem) {
+		armorAmount += basicArmorItem->IntVar(NAME_Amount);
+	}
+	auto hexenArmorItem = primaryLevel->Players[consoleplayer]->mo->FindInventory(NAME_HexenArmor);
+	if (hexenArmorItem) {
+		double *Slots = (double*)hexenArmorItem->ScriptVar(NAME_Slots, nullptr);
+		armorAmount += Slots[0] + Slots[1] + Slots[2] + Slots[3] + Slots[4];
+	}
+	comment.AppendFormat("%s: %d - %s: %d", health, primaryLevel->Players[consoleplayer]->mo->health, armor, armorAmount);
 
 	// Write out the comment
 	arc.AddString("Comment", comment);


### PR DESCRIPTION
Save games now store kills/items/secrets and player health in the comment string, which is displayed in the save/load game menu. This can help with save game organization when you have many saves on the same level :slightly_smiling_face: 

I didn't find a way to list player armor as well, but I think it would be suitable to list if possible.

This change is not retroactive: old savegames will not display this information until they are overwritten.

## Preview

*Preview is outdated – armor is now saved and displayed as well.*

Displaying a save just after saving it:

![image](https://user-images.githubusercontent.com/180032/216617062-b90f6d6b-87f1-412b-8104-f922a445c100.png)

(Note that `language.0` will have to be updated to contain the new `Health`) localizable string.)
