### PR TITLE
Add a cvar to swap health and armor position on alternative HUD

### DIFF
--- a/src/g_statusbar/shared_hud.cpp
+++ b/src/g_statusbar/shared_hud.cpp
@@ -74,6 +74,7 @@ CVAR (Int ,  hud_showlag,		0, CVAR_ARCHIVE);		// Show input latency (maketic - g
 CVAR (Int, hud_ammo_order, 0, CVAR_ARCHIVE);				// ammo image and text order
 CVAR (Int, hud_ammo_red, 25, CVAR_ARCHIVE)					// ammo percent less than which status is red    
 CVAR (Int, hud_ammo_yellow, 50, CVAR_ARCHIVE)				// ammo percent less is yellow more green        
+CVAR (Bool, hud_swaphealtharmor, false, CVAR_ARCHIVE);		// swap health and armor position on HUD
 CVAR (Int, hud_health_red, 25, CVAR_ARCHIVE)				// health amount less than which status is red   
 CVAR (Int, hud_health_yellow, 50, CVAR_ARCHIVE)				// health amount less than which status is yellow
 CVAR (Int, hud_health_green, 100, CVAR_ARCHIVE)				// health amount above is blue, below is green   
@@ -193,4 +194,3 @@ void DBaseStatusBar::DrawAltHUD()
 		VMCall(func, params, countof(params), nullptr, 0);
 	}
 }
-

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1161,6 +1161,7 @@ OptionMenu "AltHUDOptions" protected
 	Option "$ALTHUDMNU_AMMOORDER",				"hud_ammo_order", "AltHUDAmmoOrder"
 	Slider "$ALTHUDMNU_AMMORED",				"hud_ammo_red", 0, 100, 1, 0
 	Slider "$ALTHUDMNU_AMMOYELLOW",				"hud_ammo_yellow", 0, 100, 1, 0
+	Option "$ALTHUDMNU_SWAPHEALTHARMOR",		"hud_swaphealtharmor", "OnOff"
 	Slider "$ALTHUDMNU_HEALTHRED",				"hud_health_red", 0, 100, 1, 0
 	Slider "$ALTHUDMNU_HEALTHYELLOW",			"hud_health_yellow", 0, 100, 1, 0
 	Slider "$ALTHUDMNU_HEALTHGREEN",			"hud_health_green", 0, 100, 1, 0

--- a/wadsrc/static/zscript/ui/statusbar/alt_hud.zs
+++ b/wadsrc/static/zscript/ui/statusbar/alt_hud.zs
@@ -926,8 +926,12 @@ class AltHud ui
 			DrawStatus(CPlayer, 5, hudheight-75);
 			DrawFrags(CPlayer, 5, hudheight-70);
 		}
-		DrawHealth(CPlayer, 5, hudheight-45);
-		DrawArmor(BasicArmor(CPlayer.mo.FindInventory('BasicArmor')), HexenArmor(CPlayer.mo.FindInventory('HexenArmor')), 5, hudheight-20);
+
+		int armory = hud_swaphealtharmor ? hudheight-45 : hudheight-20;
+		int healthy = hud_swaphealtharmor ? hudheight-20 : hudheight-45;
+		DrawHealth(CPlayer, 5, healthy);
+		DrawArmor(BasicArmor(CPlayer.mo.FindInventory('BasicArmor')), HexenArmor(CPlayer.mo.FindInventory('HexenArmor')), 5, armory);
+
 		int y = DrawKeys(CPlayer, hudwidth-4, hudheight-10);
 		y = DrawAmmo(CPlayer, hudwidth-5, y);
 		if (hud_showweapons) DrawWeapons(CPlayer, hudwidth - 5, y);


### PR DESCRIPTION
When enabled, this makes the layout identical to the standard HUD (similar to how most other games lay out health and armor on a HUD).

## Preview

### Disabled (default)

![image](https://user-images.githubusercontent.com/180032/216641149-d85fc6ea-80f3-4f03-a3ed-103ae44d3f9d.png)

### Enabled

![image](https://user-images.githubusercontent.com/180032/216641192-5b7f2eb2-2719-4963-a195-9744df092643.png)