### PR TITLE
[bugfix] Fix value of `X = Y` when Y is an int constant

### DIFF
--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -2576,7 +2576,15 @@ ExpEmit FxAssign::Emit(VMFunctionBuilder *build)
 	}
 
 	pointer.Free(build);
-	return result;
+
+	if(intconst)
+	{	//fix int constant return for assignment
+		return Right->Emit(build);
+	}
+	else
+	{
+		return result;
+	}
 }
 
 //==========================================================================


### PR DESCRIPTION
[Test.zip](https://github.com/ZDoom/gzdoom/files/10714007/Test.zip)

![image](https://user-images.githubusercontent.com/15188209/218267702-c059eda9-e8a6-4ee8-8214-8ab910fdf847.png)

before fix:
![image](https://user-images.githubusercontent.com/15188209/218267713-7c1df78c-176e-4a41-b69f-22d613ad080f.png)
after fix:
![image](https://user-images.githubusercontent.com/15188209/218267736-492958c5-8669-490f-95b9-8d2a84b1dfbc.png)
