### PR TITLE
A_SetViewPitch shouldn't call ClampPitch

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3526,11 +3526,6 @@ void AActor::SetRoll(DAngle r, int fflags)
 
 void AActor::SetViewPitch(DAngle p, int fflags)
 {
-	if (player != NULL || (fflags & SPF_FORCECLAMP))
-	{
-		p = ClampPitch(p);
-	}
-
 	if (p != ViewAngles.Pitch)
 	{
 		ViewAngles.Pitch = p;


### PR DESCRIPTION
This will cause erratic behavior if the function is called right after a savegame is loaded, effectively resulting in it copying the player's own pitch, and therefore doubling it.