### PR TITLE
[Bugfix] Fix Software Slope Rendering for non-1.2 pixel ratios

### DIFF
--- a/src/rendering/swrenderer/viewport/r_viewport.cpp
+++ b/src/rendering/swrenderer/viewport/r_viewport.cpp
@@ -172,6 +172,9 @@ namespace swrenderer
 
 		WallTMapScale2 = IYaspectMul / CenterX * 1.2 / ypixelstretch;
 
+		// [RicardoLuis0] adjust IYaspectMul for map stretch -- fixes slope rendering on maps that define pixelratio
+		IYaspectMul *= 1.2 / ypixelstretch;
+
 		// thing clipping
 		fillshort(screenheightarray, viewwidth, (short)viewheight);
 


### PR DESCRIPTION
[PixelRatio-1.5.wad.zip](https://github.com/ZDoom/gzdoom/files/10770654/PixelRatio-1.5.wad.zip)
HW Renderer:
![image](https://user-images.githubusercontent.com/15188209/219765598-d11ad301-e4e0-4cbd-9617-e089344e6a29.png)

SW Renderer Before:
![image](https://user-images.githubusercontent.com/15188209/219765775-ae2f8d4c-0219-447f-b5a7-025c190df442.png)

SW Renderer After:
![image](https://user-images.githubusercontent.com/15188209/219765843-98b21807-5660-4c26-81a2-edeb7bc654c6.png)

