### PR TITLE
Fix gameinfo load from same directory as file containing gameinfo lump

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1794,6 +1794,8 @@ static FString ParseGameInfo(TArray<FString> &pwads, const char *fn, const char 
 	int pos = 0;
 
 	const char *lastSlash = strrchr (fn, '/');
+	if (lastSlash == NULL)
+	    lastSlash = strrchr (fn, ':');
 
 	sc.OpenMem("GAMEINFO", data, size);
 	while(sc.GetToken())
@@ -1818,8 +1820,7 @@ static FString ParseGameInfo(TArray<FString> &pwads, const char *fn, const char 
 				FString checkpath;
 				if (lastSlash != NULL)
 				{
-					checkpath = FString(fn, (lastSlash - fn) + 1);
-					checkpath += sc.String;
+					checkpath = FString(fn, lastSlash - fn) + '/' + sc.String;
 				}
 				else
 				{


### PR DESCRIPTION
Fixes scenario 2 in https://github.com/ZDoom/gzdoom/issues/2011#issuecomment-1440997829