### PR TITLE
Fixed incorrect parameter type for ZScript States.

### DIFF
--- a/src/common/scripting/vm/vm.h
+++ b/src/common/scripting/vm/vm.h
@@ -553,7 +553,7 @@ bool AssertObject(void * ob);
 #define PARAM_STRING_VAL_AT(p,x)	assert((p) < numparam); assert(reginfo[p] == REGT_STRING); FString x = param[p].s();
 #define PARAM_STRING_AT(p,x)		assert((p) < numparam); assert(reginfo[p] == REGT_STRING); const FString &x = param[p].s();
 #define PARAM_STATELABEL_AT(p,x)	assert((p) < numparam); assert(reginfo[p] == REGT_INT); int x = param[p].i;
-#define PARAM_STATE_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_POINTER); FState *x = (FState *)StateLabels.GetState(param[p].i, self->GetClass());
+#define PARAM_STATE_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_POINTER || reginfo[p] == REGT_INT); FState *x = (FState *)StateLabels.GetState(param[p].i, self->GetClass());
 #define PARAM_STATE_ACTION_AT(p,x)	assert((p) < numparam); assert(reginfo[p] == REGT_INT); FState *x = (FState *)StateLabels.GetState(param[p].i, stateowner->GetClass());
 #define PARAM_POINTER_AT(p,x,type)	assert((p) < numparam); assert(reginfo[p] == REGT_POINTER); type *x = (type *)param[p].a;
 #define PARAM_OUTPOINTER_AT(p,x,type)	assert((p) < numparam); type *x = (type *)param[p].a;

--- a/src/common/scripting/vm/vm.h
+++ b/src/common/scripting/vm/vm.h
@@ -553,7 +553,7 @@ bool AssertObject(void * ob);
 #define PARAM_STRING_VAL_AT(p,x)	assert((p) < numparam); assert(reginfo[p] == REGT_STRING); FString x = param[p].s();
 #define PARAM_STRING_AT(p,x)		assert((p) < numparam); assert(reginfo[p] == REGT_STRING); const FString &x = param[p].s();
 #define PARAM_STATELABEL_AT(p,x)	assert((p) < numparam); assert(reginfo[p] == REGT_INT); int x = param[p].i;
-#define PARAM_STATE_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); FState *x = (FState *)StateLabels.GetState(param[p].i, self->GetClass());
+#define PARAM_STATE_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_POINTER); FState *x = (FState *)StateLabels.GetState(param[p].i, self->GetClass());
 #define PARAM_STATE_ACTION_AT(p,x)	assert((p) < numparam); assert(reginfo[p] == REGT_INT); FState *x = (FState *)StateLabels.GetState(param[p].i, stateowner->GetClass());
 #define PARAM_POINTER_AT(p,x,type)	assert((p) < numparam); assert(reginfo[p] == REGT_POINTER); type *x = (type *)param[p].a;
 #define PARAM_OUTPOINTER_AT(p,x,type)	assert((p) < numparam); type *x = (type *)param[p].a;


### PR DESCRIPTION
ZScript state types should be pointers to states, but the assertion was requiring an integer.  This PR updates that to require a pointer instead.