### PR TITLE
Fixed incorrect parameter type in A_CheckForResurrection.

### DIFF
--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1634,7 +1634,7 @@ int CheckForResurrection(AActor *self, FState* state, int sound)
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, A_CheckForResurrection, CheckForResurrection)
 {
 	PARAM_SELF_PROLOGUE(AActor);
-	PARAM_STATE(state);
+	PARAM_POINTER(state, FState);
 	PARAM_INT(sound);
 	ACTION_RETURN_BOOL(CheckForResurrection(self, state, sound));
 }


### PR DESCRIPTION
Prototype in ZScript is `native bool A_CheckForResurrection(State state = null, Sound snd = 0);` which is a State pointer.  However, native code marked it as an int, leading to a crash.  This PR changes the expected type to a State pointer instead of an integer.  This change is limited to A_CheckForResurrection.