### PR TITLE
[bugfix] Fix possible memory corruption in `TArray::Delete(index, count)`

### DIFF
--- a/src/common/utility/tarray.h
+++ b/src/common/utility/tarray.h
@@ -453,6 +453,8 @@ public:
 
 	void Delete (unsigned int index, int deletecount)
 	{
+        if(index >= Count) return;
+        
 		if (index + deletecount > Count)
 		{
 			deletecount = Count - index;


### PR DESCRIPTION
Simpler version of #1957, with no extra checks for zscript's `Array::Delete`