### PR TITLE
build: resolve missing includes under gcc-13

### DIFF
--- a/libraries/ZVulkan/include/zvulkan/vk_mem_alloc/vk_mem_alloc.h
+++ b/libraries/ZVulkan/include/zvulkan/vk_mem_alloc/vk_mem_alloc.h
@@ -104,6 +104,8 @@ Documentation of all members: vk_mem_alloc.h
 - [Source repository on GitHub](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator)
 */
 
+#include <stdio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libraries/ZVulkan/src/vulkanbuilders.cpp
+++ b/libraries/ZVulkan/src/vulkanbuilders.cpp
@@ -1,4 +1,4 @@
-
+#include <stdexcept>
 #include "vulkanbuilders.h"
 #include "vulkansurface.h"
 #include "vulkancompatibledevice.h"

--- a/libraries/ZVulkan/src/vulkanswapchain.cpp
+++ b/libraries/ZVulkan/src/vulkanswapchain.cpp
@@ -1,4 +1,4 @@
-
+#include <stdexcept>
 #include "vulkanswapchain.h"
 #include "vulkanobjects.h"
 #include "vulkansurface.h"


### PR DESCRIPTION
```
$ make
...
~/gzdoom/libraries/ZVulkan/src/vulkanbuilders.cpp: In member function ‘std::unique_ptr<VulkanShader> ShaderBuilder::Create(const char*, VulkanDevice*)’:
~/gzdoom/libraries/ZVulkan/src/vulkanbuilders.cpp:168:28: error: ‘runtime_error’ is not a member of ‘std’
~/gzdoom/libraries/ZVulkan/include/zvulkan/vk_mem_alloc/vk_mem_alloc.h: In function ‘void VmaUint32ToStr(char*, size_t, uint32_t)’:
~/gzdoom/libraries/ZVulkan/include/zvulkan/vk_mem_alloc/vk_mem_alloc.h:2410:9: error: ‘snprint ’ was not declared in this scope
```

The porting notes make a mention that this is to be expected, https://gcc.gnu.org/gcc-13/porting_to.html .