### PR TITLE
Properly fix default mouse x sensitivity

### DIFF
--- a/src/common/engine/d_event.cpp
+++ b/src/common/engine/d_event.cpp
@@ -48,7 +48,7 @@ int eventhead;
 int eventtail;
 event_t events[MAXEVENTS];
 
-CVAR(Float, m_sensitivity_x, 4.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(Float, m_sensitivity_x, 2.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Float, m_sensitivity_y, 2.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2678,7 +2678,7 @@ static bool System_DispatchEvent(event_t* ev)
 		}
 		if (!buttonMap.ButtonDown(Button_Strafe) && !lookstrafe)
 		{
-			int turn = int(ev->x * m_yaw * 8.0);
+			int turn = int(ev->x * m_yaw * 16.0);
 			if (invertmousex)
 				turn = -turn;
 			G_AddViewAngle(turn, true);

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -598,6 +598,15 @@ void FGameConfigFile::DoGlobalSetup ()
 				// ooooh boy did i open a can of worms with this one.
 				i_pauseinbackground = !(i_soundinbackground);
 			}
+			if (last < 224)
+			{
+				if (const auto var = FindCVar("m_sensitivity_x", NULL))
+				{
+					UCVarValue v = var->GetGenericRep(CVAR_Float);
+					v.Float *= 0.5f;
+					var->SetGenericRep(v, CVAR_Float);
+				}
+			}
 		}
 	}
 }

--- a/src/version.h
+++ b/src/version.h
@@ -65,7 +65,7 @@ const char *GetVersionString();
 // Version stored in the ini's [LastRun] section.
 // Bump it if you made some configuration change that you want to
 // be able to migrate in FGameConfigFile::DoGlobalSetup().
-#define LASTRUNVERSION "223"
+#define LASTRUNVERSION "224"
 
 // Protocol version used in demos.
 // Bump it if you change existing DEM_ commands or add new ones.


### PR DESCRIPTION
Current setup doubles the default out-of-box mouse x sensitivty from 2 to 4 to compensate for the fact `System_DispatchEvent()` sends the yaw through to the game with only half the amplification that pitch receives.

Since this CVAR is in common code between Raze and GZDoom, this presents a situation where the mouse x sensitivity in Raze is twice what it should be.

All of this is hangover from changes in late 2020 when all the backends had different pre-scaling and amplifications, etc.