### PR TITLE
Move `invertmouse` CVARs into common code.

### DIFF
--- a/src/common/engine/d_event.cpp
+++ b/src/common/engine/d_event.cpp
@@ -50,6 +50,8 @@ event_t events[MAXEVENTS];
 
 CVAR(Float, m_sensitivity_x, 4.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Float, m_sensitivity_y, 2.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(Bool, invertmouse, false, CVAR_GLOBALCONFIG | CVAR_ARCHIVE);  // Invert mouse look down/up?
+CVAR(Bool, invertmousex, false,	CVAR_GLOBALCONFIG | CVAR_ARCHIVE);  // Invert mouse look left/right?
 
 
 //==========================================================================
@@ -170,6 +172,9 @@ void PostMouseMove(int xx, int yy)
 
 	ev.x = float(xx) * m_sensitivity_x;
 	ev.y = -float(yy) * m_sensitivity_y;
+
+	if (invertmousex) ev.x = -ev.x;
+	if (invertmouse) ev.y = -ev.y;
 
 	if (ev.x || ev.y)
 	{

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -186,8 +186,6 @@ EXTERN_CVAR (Float, turbo)
 EXTERN_CVAR (Bool, freelook)
 EXTERN_CVAR (Float, m_pitch)
 EXTERN_CVAR (Float, m_yaw)
-EXTERN_CVAR (Bool, invertmouse)
-EXTERN_CVAR (Bool, invertmousex)
 EXTERN_CVAR (Bool, lookstrafe)
 EXTERN_CVAR (Int, screenblocks)
 EXTERN_CVAR (Bool, sv_cheats)
@@ -2672,15 +2670,12 @@ static bool System_DispatchEvent(event_t* ev)
 		if (buttonMap.ButtonDown(Button_Mlook) || freelook)
 		{
 			int look = int(ev->y * m_pitch * 16.0);
-			if (invertmouse) look = -look;
 			G_AddViewPitch(look, true);
 			ev->y = 0;
 		}
 		if (!buttonMap.ButtonDown(Button_Strafe) && !lookstrafe)
 		{
 			int turn = int(ev->x * m_yaw * 8.0);
-			if (invertmousex)
-				turn = -turn;
 			G_AddViewAngle(turn, true);
 			ev->x = 0;
 		}

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -202,8 +202,6 @@ int				lookspeed[2] = {450, 512};
 #define SLOWTURNTICS	6 
 
 CVAR (Bool,		cl_run,			false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always run?
-CVAR (Bool,		invertmouse,	false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Invert mouse look down/up?
-CVAR (Bool,		invertmousex,	false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Invert mouse look left/right?
 CVAR (Bool,		freelook,		true,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always mlook?
 CVAR (Bool,		lookstrafe,		false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always strafe with mouse?
 CVAR (Float,	m_forward,		1.f,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)


### PR DESCRIPTION
Removes duplication of CVAR definitions between Raze and GZDoom in differing, but port-specific places.