### PR TITLE
Add an option to display the path travalled by the local player

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -1846,9 +1846,10 @@ void DAutomap::collectPath ()
 		constexpr int MIN_DISTANCE_BETWEEN_POINTS = 32;
 		if (abs(last_line.b.x - pos.X) >= MIN_DISTANCE_BETWEEN_POINTS || abs(last_line.b.y - pos.Y) >= MIN_DISTANCE_BETWEEN_POINTS)
 		{
-			// If the distance between two points is very high, the player has likely teleported so no path should be drawn between the points.
-			constexpr int MAX_DISTANCE_BETWEEN_TICKS = 100;
-			if (abs(last_line.b.x - pos.X) >= MAX_DISTANCE_BETWEEN_TICKS || abs(last_line.b.y - pos.Y) >= MAX_DISTANCE_BETWEEN_TICKS)
+			// If the player's velocity is lower than the distance between the last two ticks (with some tolerance),
+			// the player has likely teleported so no path should be drawn between the points.
+			constexpr float EPSILON = 10.0;
+			if ((pos - last_tick_pos).Length() > (players[consoleplayer].camera->VelXYToSpeed() + EPSILON))
 			{
 				ml.a.x = pos.X;
 				ml.a.y = pos.Y;
@@ -1862,7 +1863,7 @@ void DAutomap::collectPath ()
 			ml.b.x = pos.X;
 			ml.b.y = pos.Y;
 
-			if (path_history.Size() > am_pathlength)
+			if (path_history.Size() > uint32_t(am_pathlength))
 			{
 				// Path is too long; remove the oldest lines.
 				path_history.Delete(0);
@@ -1879,6 +1880,8 @@ void DAutomap::collectPath ()
 		ml.b.y = pos.Y;
 		path_history.Push(ml);
 	}
+
+	last_tick_pos = players[consoleplayer].camera->InterpolatedPosition(r_viewpoint.TicFrac);
 }
 
 //=============================================================================

--- a/src/am_map.h
+++ b/src/am_map.h
@@ -44,6 +44,9 @@ public:
 	// called instead of view drawer if automap active.
 	virtual void Drawer(int bottom) = 0;
 
+	// Used for am_path drawing to calculate distance between ticks.
+	DVector2 last_tick_pos;
+
 	virtual void NewResolution() = 0;
 	virtual void LevelInit() = 0;
 	virtual void UpdateShowAllLines() = 0;

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1336,6 +1336,8 @@ OptionMenu AutomapOptions protected
 	StaticText ""
 	Option "$AUTOMAPMNU_ROTATE",				"am_rotate", "RotateTypes"
 	Option "$AUTOMAPMNU_FOLLOW",				"am_followplayer", "OnOff"
+	Option "$AUTOMAPMNU_PATH",					"am_path", "OnOff"
+	Slider "$AUTOMAPMNU_PATHLENGTH",			"am_pathlength", 100, 10000, 100, 0
 	Option "$AUTOMAPMNU_OVERLAY",				"am_overlay", "OverlayTypes"
 	Option "$AUTOMAPMNU_TEXTURED",				"am_textured", "OnOff"
 	Slider "$AUTOMAPMNU_LINEALPHA",				"am_linealpha", 0.1, 1.0, 0.1, 1
@@ -1395,6 +1397,7 @@ OptionMenu MapControlsMenu protected
 	MapControl "$MAPCNTRLMNU_TOGGLEZOOM",		"am_gobig"
 	MapControl "$MAPCNTRLMNU_TOGGLEFOLLOW",		"am_togglefollow"
 	MapControl "$MAPCNTRLMNU_ROTATE",			"toggle am_rotate"
+	MapControl "$MAPCNTRLMNU_PATH",			    "toggle am_path"
 	MapControl "$MAPCNTRLMNU_TOGGLEGRID",		"am_togglegrid"
 	MapControl "$MAPCNTRLMNU_TOGGLETEXTURE",	"am_toggletexture"
 
@@ -1434,6 +1437,7 @@ OptionMenu MapColorMenu protected
 	ColorPicker "$MAPCOLORMNU_UNEXPLOREDSECRETCOLOR",	"am_unexploredsecretcolor"
 	ColorPicker "$MAPCOLORMNU_SPECIALWALLCOLOR",		"am_specialwallcolor"
 	ColorPicker "$MAPCOLORMNU_PORTAL",					"am_portalcolor"
+	ColorPicker "$MAPCOLORMNU_PATH",					"am_pathcolor"
 }
 
 OptionMenu MapColorMenuCheats protected
@@ -1465,6 +1469,7 @@ OptionMenu MapColorMenuOverlay protected
 	ColorPicker "$MAPCOLORMNU_UNEXPLOREDSECRETCOLOR",	"am_ovunexploredsecretcolor"
 	ColorPicker "$MAPCOLORMNU_SPECIALWALLCOLOR",		"am_ovspecialwallcolor"
 	ColorPicker "$MAPCOLORMNU_PORTAL",					"am_ovportalcolor"
+	ColorPicker "$MAPCOLORMNU_PATH",					"am_ovpathcolor"
 }
 
 OptionMenu MapColorMenuCheatsOverlay protected


### PR DESCRIPTION
This is useful to avoid getting lost on larger maps. This is inspired by [a feature from Doom Retro](https://github.com/bradharding/doomretro/wiki/THE-AUTOMAP#PLAYER-PATH).

The following situations have been tested:

- Playing and finishing a map (path is cleared on map change as expected).
- Dying and respawning (path is cleared as expected).
- Non-rotated and rotated automaps.
- Teleporting intentionally doesn't create a path between the start and end point to prevent long streaking lines from appearing on the automap.

Future ideas:

- Tint path depending on progression in map (such as `kill count / number of monsters in map`), so you know how recent a certain portion of the path is. This could also be based on game time, but I think it'd be preferable for existing path points to keep their color.
  - Maybe tint path depending on owned keys?
- Change detail level based on the default map zoom (which is relative to the map size), so that larger maps can show a longer path before hitting the path length limit (and smaller maps can show a more detailed path).
- Always create a point if the player has stopped (regardless of the distance from last point), so that the line doesn't appear disconnected from the player if the player stops moving.

## Preview

### Normal mode

![Screenshot_Doom_20230428_002329 webp](https://user-images.githubusercontent.com/180032/235007923-468e6272-704f-404d-8a2c-4481c40563d0.png)

### Overlay mode

![Screenshot_Doom_20230428_002406 webp](https://user-images.githubusercontent.com/180032/235007957-bfa5cb24-6c8d-4218-90a2-4d253c09f977.png)