### PR TITLE
[bugfix] Fix win32 mouse cursor permanently disappearing

### DIFF
--- a/src/common/platform/win32/i_mouse.cpp
+++ b/src/common/platform/win32/i_mouse.cpp
@@ -189,6 +189,8 @@ CUSTOM_CVAR (Int, in_mouse, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL)
 //
 //==========================================================================
 
+static bool mouse_shown = true;
+
 static void SetCursorState(bool visible)
 {
 	CursorState = visible || !m_hidepointer;
@@ -196,13 +198,19 @@ static void SetCursorState(bool visible)
 	{
 		if (CursorState)
 		{
-			ShowCursor(1);
-			SetCursor((HCURSOR)(intptr_t)GetClassLongPtr(mainwindow.GetHandle(), GCLP_HCURSOR));
+			if(!mouse_shown)
+			{
+				ShowCursor(true);
+				mouse_shown = true;
+			}
 		}
 		else
 		{
-			ShowCursor(0);
-			SetCursor(NULL);
+			if(mouse_shown)
+			{
+				ShowCursor(false);
+				mouse_shown = false;
+			}
 		}
 	}
 }


### PR DESCRIPTION
ShowCursor is a counter, true increases it, false decreases it, and when it's 0 the mouse is hidden.
This fixes it so that gzdoom only increases/decreases said counter if the mouse isn't shown/hidden already, and fixes the hidden mouse bug. (the call to SetCursor isn't necessary anymore either due this fix)