### PR TITLE
Add changeskill console command

### DIFF
--- a/docs/console.html
+++ b/docs/console.html
@@ -2361,6 +2361,11 @@ alias -creep "joy_speedmultiplier 1.0"</pre>
 					of a music lump or file on disk (which need not have been specified with the 
 					-file parameter).
 				</div>
+				<div class="c" id="changeskill">changeskill <i>skill</i></div>
+				<div class="b">Changes the current skill of the game. The skill change will take 
+					effect at the next map change. The skill must be a number. The default skill 
+					levels range from 0 to 4 inclusive.
+				</div>
 				<div class="c" id="chase">chase</div>
 				<div class="b">Turns the chasecom on and off. This command also works while 
 					watching demos, so you can bind it to a key and watch demos in the third 
@@ -3177,6 +3182,7 @@ alias -creep "joy_speedmultiplier 1.0"</pre>
 				<a href="#centerview">centerview</a><br />
 				<a href="#changemap">changemap</a><br />
 				<a href="#changemus">changemus</a><br />
+				<a href="#changeskill">changeskill</a><br />
 				<a href="#chase">chase</a><br />
 				<a href="#chase_dist">chase_dist</a><br />
 				<a href="#chase_height">chase_height</a><br />

--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -408,6 +408,39 @@ CCMD (changemap)
 	}
 }
 
+CCMD (changeskill)
+{
+	if (!players[consoleplayer].mo || !usergame)
+	{
+		Printf ("Use the skill command when not in a game.\n");
+		return;
+	}
+
+	if (!players[consoleplayer].settings_controller && netgame)
+	{
+		Printf ("Only setting controllers can change the skill.\n");
+		return;
+	}
+
+	if (argv.argc() == 2)
+	{
+		int skill = atoi(argv[1]);
+		if (skill < 0 || skill >= AllSkills.Size())
+		{
+			Printf ("Skill %d is out of range.\n", skill);
+		}
+		else
+		{
+			NextSkill = skill;
+			Printf ("Skill %d will take effect on the next map.\n", skill);
+		}
+	}
+	else
+	{
+		Printf ("Usage: changeskill <skill>\n");
+	}
+}
+
 CCMD (give)
 {
 	if (CheckCheatmode () || argv.argc() < 2)


### PR DESCRIPTION
This PR adds a new "changeskill" console command that's equivalent to the [ChangeSkill](https://zdoom.org/wiki/ChangeSkill) action special, allowing a player to change the difficulty of their game on the next map load without starting a new game. This command fits the analogy of "map : changemap :: skill : changeskill".