### PR TITLE
Fix BUILD_SHARED_LIBS build option on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@ if( WIN32 )
 	add_definitions( -D_WIN32 )
 
 	set( PROJECT_LIBRARIES
+		psapi
 		wsock32
 		winmm
 		dinput8


### PR DESCRIPTION
This PR fixes the build error "unresolved external symbol GetModuleInformation" that happens when the project is built on Windows with the (non-default) BUILD_SHARED_LIBS option enabled.

Gzdoom must be linked against psapi because of its use of GetModuleInformation(). When BUILD_SHARED_LIBS is off (default), it gets linked because the internal discord-rpc library is linked against it and then statically linked into the project. When BUILD_SHARED_LIBS is on, the discord-rpc library is not statically linked into the project and doesn't cause the project to be linked against psapi. The issue is fixed by making Gzdoom itself explicitly link against psapi too.

(I don't have any specific need for BUILD_SHARED_LIBS=on, but I got stuck in a rabbithole for a while today because I happened to turn on the setting while trying to debug a mistake of my own while setting up cmake. This PR would also help anyone such as fork authors who for whatever reason might try removing the discord-rpc library.)