### PR TITLE
Fix a very rare crash with complex Polyobjects

### DIFF
--- a/src/utility/nodebuilder/nodebuild.h
+++ b/src/utility/nodebuilder/nodebuild.h
@@ -269,6 +269,7 @@ private:
 	TArray<int> Colinear;	// Loops with edges colinear to a splitter
 	FEventTree Events;		// Vertices intersected by the current splitter
 
+	TArray<uint32_t> UnsetSegs;			// Segs with no definitive side in current splitter
 	TArray<FSplitSharer> SplitSharers;	// Segs colinear with the current splitter
 
 	uint32_t HackSeg;			// Seg to force to back of splitter
@@ -294,7 +295,9 @@ private:
 	void CreateSubsectorsForReal ();
 	bool CheckSubsector (uint32_t set, node_t &node, uint32_t &splitseg);
 	bool CheckSubsectorOverlappingSegs (uint32_t set, node_t &node, uint32_t &splitseg);
-	bool ShoveSegBehind (uint32_t set, node_t &node, uint32_t seg, uint32_t mate);	int SelectSplitter (uint32_t set, node_t &node, uint32_t &splitseg, int step, bool nosplit);
+	bool ShoveSegBehind (uint32_t set, node_t &node, uint32_t seg, uint32_t mate);
+	int SelectSplitter (uint32_t set, node_t &node, uint32_t &splitseg, int step, bool nosplit);
+	void DoGLSegSplit (uint32_t set, node_t &node, uint32_t splitseg, uint32_t &outset0, uint32_t &outset1, int side, int sidev0, int sidev1, bool hack);
 	void SplitSegs (uint32_t set, node_t &node, uint32_t splitseg, uint32_t &outset0, uint32_t &outset1, unsigned int &count0, unsigned int &count1);
 	uint32_t SplitSeg (uint32_t segnum, int splitvert, int v1InFront);
 	int Heuristic (node_t &node, uint32_t set, bool honorNoSplit);


### PR DESCRIPTION
If all of the worst stars align when compiling Polyobject BSP and splitting a seg into two sets:
- The very first seg in the current set fails all of the metrics for determining which side of a split it is on, and doesn't know which side it should go to. Since there are 0 are in front, it goes to front by default.
- Every other seg in the same set don't fail their metrics, and they all decide they are meant to go to the front side.
- Oops! Now there's nothing in the back side!

I've fixed this by collecting all of the undecided segs in a split, and setting the new side after the other segs. Doing it in the normal loop means there's a non-zero chance the crash prevention will fail depending on how the segs are in memory.

This can technically happen with even the most simplistic Polyobjects, but it becomes more common the more complex it is (add tons of lines, have non-orthogonal lines, move and rotate it, so on). Quite an annoying crash since it doesn't always replicate consistently.