### PR TITLE
lightmode refactor

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -2012,6 +2012,9 @@ void DAutomap::drawSubsectors()
 	PalEntry flatcolor;
 	mpoint_t originpt;
 
+	auto lm = getRealLightmode(Level, false);
+	bool softlightramp = !V_IsHardwareRenderer() || lm == ELightMode::Doom || lm == ELightMode::DoomDark;
+
 	auto &subsectors = Level->subsectors;
 	for (unsigned i = 0; i < subsectors.Size(); ++i)
 	{
@@ -2186,15 +2189,14 @@ void DAutomap::drawSubsectors()
 			// Why the +12? I wish I knew, but experimentation indicates it
 			// is necessary in order to best reproduce Doom's original lighting.
 			double fadelevel;
-
-			if (!V_IsHardwareRenderer() || primaryLevel->lightMode == ELightMode::DoomDark || primaryLevel->lightMode == ELightMode::Doom || primaryLevel->lightMode == ELightMode::ZDoomSoftware || primaryLevel->lightMode == ELightMode::DoomSoftware)
+			if (softlightramp)
 			{
 				double map = (NUMCOLORMAPS * 2.) - ((floorlight + 12) * (NUMCOLORMAPS / 128.));
 				fadelevel = clamp((map - 12) / NUMCOLORMAPS, 0.0, 1.0);
 			}
 			else
 			{
-				// The hardware renderer's light modes 0, 1 and 4 use a linear light scale which must be used here as well. Otherwise the automap gets too dark.
+				// for the hardware renderer's light modes that use a linear light scale this must do the same. Otherwise the automap gets too dark.
 				fadelevel = 1. - clamp(floorlight, 0, 255) / 255.f;
 			}
 

--- a/src/common/rendering/hwrenderer/data/hw_cvars.h
+++ b/src/common/rendering/hwrenderer/data/hw_cvars.h
@@ -18,7 +18,6 @@ EXTERN_CVAR (Bool, gl_light_shadowmap);
 EXTERN_CVAR (Int, gl_shadowmap_quality);
 
 EXTERN_CVAR(Int, gl_fogmode)
-EXTERN_CVAR(Int, gl_lightmode)
 EXTERN_CVAR(Bool,gl_mirror_envmap)
 
 EXTERN_CVAR(Bool,gl_mirrors)

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -161,7 +161,7 @@ ELightMode getRealLightmode(FLevelLocals* Level, bool for3d)
 	auto lightmode = Level->info->lightmode;
 	if (lightmode == ELightMode::NotSet)
 	{
-		if (gl_maplightmode != -1) Level->info->lightmode == (ELightMode)*gl_maplightmode;
+		if (gl_maplightmode != -1) Level->info->lightmode = (ELightMode)*gl_maplightmode;
 		else Level->info->lightmode = ELightMode::Doom;
 	}
 	if (lightmode == ELightMode::Doom && for3d)

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -683,7 +683,6 @@ public:
 	float		MusicVolume;
 
 	// Hardware render stuff that can either be set via CVAR or MAPINFO
-	ELightMode	lightMode;
 	bool		brightfog;
 	bool		lightadditivesurfaces;
 	bool		notexturefill;
@@ -883,3 +882,5 @@ inline TArrayView<FLevelLocals *> AllLevels()
 {
 	return TArrayView<FLevelLocals *>(&primaryLevel, 1);
 }
+
+ELightMode getRealLightmode(FLevelLocals* Level, bool for3d);

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -607,6 +607,15 @@ void FGameConfigFile::DoGlobalSetup ()
 					var->SetGenericRep(v, CVAR_Float);
 				}
 			}
+			if (last < 225)
+			{
+				if (const auto var = FindCVar("gl_lightmode", NULL))
+				{
+					UCVarValue v = var->GetGenericRep(CVAR_Int);
+					v.Int /= 8; // all legacy modes map to 0, ZDoom software to 1 and Vanilla software to 2.
+					var->SetGenericRep(v, CVAR_Int);
+				}
+			}
 		}
 	}
 }

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1521,7 +1521,8 @@ DEFINE_MAP_OPTION(lightmode, false)
 	parse.ParseAssign();
 	parse.sc.MustGetNumber();
 
-	if ((parse.sc.Number >= 0 && parse.sc.Number <= 4) || parse.sc.Number == 8 || parse.sc.Number == 16)
+	if (parse.sc.Number == 8 || parse.sc.Number == 16) info->lightmode = ELightMode::NotSet;
+	else if (parse.sc.Number >= 0 && parse.sc.Number <= 5)
 	{
 		info->lightmode = ELightMode(parse.sc.Number);
 	}

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -139,7 +139,8 @@ void HWDrawInfo::StartScene(FRenderViewpoint &parentvp, HWViewpointUniforms *uni
 	mClipper = &staticClipper;
 
 	Viewpoint = parentvp;
-	lightmode = Level->lightMode;
+	lightmode = getRealLightmode(Level, true);
+
 	if (uniforms)
 	{
 		VPUniforms = *uniforms;
@@ -153,7 +154,7 @@ void HWDrawInfo::StartScene(FRenderViewpoint &parentvp, HWViewpointUniforms *uni
 		VPUniforms.mViewMatrix.loadIdentity();
 		VPUniforms.mNormalViewMatrix.loadIdentity();
 		VPUniforms.mViewHeight = viewheight;
-		if (gl_lightmode == 5)
+		if (lightmode == ELightMode::Build)
 		{
 			VPUniforms.mGlobVis = 1 / 64.f;
 			VPUniforms.mPalLightLevels = 32 | (static_cast<int>(gl_fogmode) << 8) | ((int)lightmode << 16);

--- a/src/version.h
+++ b/src/version.h
@@ -65,7 +65,7 @@ const char *GetVersionString();
 // Version stored in the ini's [LastRun] section.
 // Bump it if you made some configuration change that you want to
 // be able to migrate in FGameConfigFile::DoGlobalSetup().
-#define LASTRUNVERSION "224"
+#define LASTRUNVERSION "225"
 
 // Protocol version used in demos.
 // Bump it if you change existing DEM_ commands or add new ones.


### PR DESCRIPTION
This addresses my main issue with the current light mode handling, i.e. that it mixes valid user preferences with map-specific settings. From a user perspective the only relevant modes have been the two software lighting options plus 'doom' as a fallback for low performance systems.

This PR splits the setting in two, one map based setting retaining most of the existing functionality and a user setting that allows switching the default light mode between those 3 modes mentioned above.
MAPINFO can still set all modes, but the software choices are subject to the user option now, so that low end users have the ability to opt out of these more performance demanding modes.
