### PR TITLE
Fix MBF21_CheckAmmo, closes #2086

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -932,6 +932,7 @@ class Weapon : StateProvider
 		int count1, count2;
 		int enough, enoughmask;
 		int lAmmoUse1;
+        int lAmmoUse2 = AmmoUse2;
 
 		if (sv_infiniteammo || (Owner.FindInventory ('PowerInfiniteAmmo', true) != null))
 		{
@@ -957,20 +958,21 @@ class Weapon : StateProvider
 		count1 = (Ammo1 != null) ? Ammo1.Amount : 0;
 		count2 = (Ammo2 != null) ? Ammo2.Amount : 0;
 
-		if (bDehAmmo && Ammo1 == null)
-		{
-			lAmmoUse1 = 0;
-		}
-		else if (ammocount >= 0 && bDehAmmo)
+		if (ammocount >= 0)
 		{
 			lAmmoUse1 = ammocount;
+			lAmmoUse2 = ammocount;
+		}
+		else if (bDehAmmo && Ammo1 == null)
+		{
+			lAmmoUse1 = 0;
 		}
 		else
 		{
 			lAmmoUse1 = AmmoUse1;
 		}
 
-		enough = (count1 >= lAmmoUse1) | ((count2 >= AmmoUse2) << 1);
+		enough = (count1 >= lAmmoUse1) | ((count2 >= lAmmoUse2) << 1);
 		if (useboth)
 		{
 			enoughmask = 3;


### PR DESCRIPTION
`MBF21_CheckAmmo` uses `Weapon.CheckAmmo`, but that function didn't properly use the ammo amount parameter passed into it, this fixes that.
Fixes bug #2086