### PR TITLE
fix menu entry for light modes

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2450,14 +2450,9 @@ OptionValue "Colormaps"
 
 OptionValue "LightingModes"
 {
-	0, "$OPTVAL_STANDARD"
-	1, "$OPTVAL_BRIGHT"
-	2, "$OPTVAL_DOOM"
-	3, "$OPTVAL_DARK"
-	4, "$OPTVAL_LEGACY"
-	5, "$OPTVAL_BUILD"
-	8, "$OPTVAL_SOFTWARE"
-	16, "$OPTVAL_VANILLA"
+	0, "$OPTVAL_CLASSIC"
+	1, "$OPTVAL_SOFTWARE"
+	2, "$OPTVAL_VANILLA"
 }
 
 OptionValue "Precision"


### PR DESCRIPTION
This part was missing from the first PR.
I chose "Classic" for the legacy mode because the text already exists and also best describes what it is, i.e. the classic GZDoom light mode from old days.
