### PR TITLE
Ignore ZDRay keywords in UDMF

### DIFF
--- a/src/maploader/udmf.cpp
+++ b/src/maploader/udmf.cpp
@@ -1481,6 +1481,16 @@ public:
 					sd->Flags |= WALLF_EXTCOLOR;
 				break;
 
+			case NAME_lm_lightcolorline:
+			case NAME_lm_lightintensityline:
+			case NAME_lm_lightdistanceline:
+			case NAME_lm_sampledist_line:
+			case NAME_lm_sampledist_top:
+			case NAME_lm_sampledist_mid:
+			case NAME_lm_sampledist_bot:
+				CHECK_N(Zd | Zdt)
+					break;
+
 			default:
 				if (strnicmp("user_", key.GetChars(), 5))
 					DPrintf(DMSG_WARNING, "Unknown UDMF sidedef key %s\n", key.GetChars());


### PR DESCRIPTION
With https://github.com/ZDoom/ZDRay/pull/53 both linedefs and sidedefs can have `lm_sampledist_` properties...

Funny thing is that ZDRay previously only had sidedef variants, while GZDoom and UDB both expected this to be in the linedef. 