### PR TITLE
- block the `centerview` CCMD if the player has TOTALLYFROZEN. This is …

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -317,7 +317,8 @@ CCMD (slot)
 		}
 
 		// [Nash] Option to display the name of the weapon being switched to.
-		if ((paused || pauseext) || players[consoleplayer].playerstate != PST_LIVE) return;
+		if ((paused || pauseext) || players[consoleplayer].playerstate != PST_LIVE)
+			return;
 		if (SendItemUse != players[consoleplayer].ReadyWeapon && (displaynametags & 2) && StatusBar && SmallFont && SendItemUse)
 		{
 			StatusBar->AttachMessage(Create<DHUDMessageFadeOut>(nullptr, SendItemUse->GetTag(),
@@ -328,6 +329,8 @@ CCMD (slot)
 
 CCMD (centerview)
 {
+	if ((players[consoleplayer].cheats & CF_TOTALLYFROZEN))
+		return;
 	Net_WriteByte (DEM_CENTERVIEW);
 }
 


### PR DESCRIPTION
…deliberately done this way, instead of placing the check inside `PlayerPawn::CheckPitch`, because there may be other situations where we don't want to block the centering function (`APowerFlight::EndEffect` being one such case)

- also while I'm in this file, fix code styling for another one of my previous submissions