### PR TITLE
CMakeLists upgrade to 3.16 and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,4 @@
-cmake_minimum_required( VERSION 3.1.0 )
-project(GZDoom)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF) 
-
+cmake_minimum_required( VERSION 3.16 )
 
 if( COMMAND cmake_policy )
 	if( POLICY CMP0011 )
@@ -13,7 +7,21 @@ if( COMMAND cmake_policy )
 	if( POLICY CMP0054 )
 		cmake_policy( SET CMP0054 NEW )
 	endif()
+	if ( POLICY CMP0067 )
+		cmake_policy( SET CMP0067 NEW )
+	endif()
+	if ( POLICY CMP0091 )
+		cmake_policy( SET CMP0091 NEW )
+		set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+	endif()
 endif()
+
+project(GZDoom)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF) 
+
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
 include( FindPackageHandleStandardArgs )
@@ -146,13 +154,6 @@ endif()
 
 if( DEM_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
 	set( PROFILE 0 CACHE BOOL "Enable profiling with gprof for Debug and RelWithDebInfo build types." )
-
-	if( CMAKE_CXX_STANDARD )
-		# By default, try_compile() invocations ignore CXX_STANDARD value
-		# CMake 3.8 and newer have CMP0067 policy that fixes the issue, but it should be enabled explicitly
-		# Older versions require manual specification of the corresponding command line option
-		set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${CMAKE_CXX_STANDARD}" )
-	endif()
 endif()
 
 # Fast math flags, required by some subprojects
@@ -236,28 +237,19 @@ if( MSVC )
 	# Avoid CRT DLL dependancies in release builds, optionally generate assembly output for checking crash locations.
 	option( ZDOOM_GENERATE_ASM "Generate assembly output." OFF )
 	if( ZDOOM_GENERATE_ASM )
-		set( REL_C_FLAGS "/MT /Oy /Oi /FAcs /GS-" )
+		set( REL_C_FLAGS "/Oy /Oi /FAcs /GS-" )
 	else()
-		set( REL_C_FLAGS "/MT /Oy /Oi /GS-" )
+		set( REL_C_FLAGS "/Oy /Oi /GS-" )
 	endif()
 
 
 	# Debug allocations in debug builds
-	set( DEB_C_FLAGS "/D _CRTDBG_MAP_ALLOC /MTd" )
+	set( DEB_C_FLAGS "/D _CRTDBG_MAP_ALLOC" )
 
 	# Disable warnings for unsecure CRT functions from VC8+
 	set( ALL_C_FLAGS "${ALL_C_FLAGS} /DUNICODE /D_UNICODE /D_WIN32_WINNT=0x0600 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS" )
 
-	# The CMake configurations set /GR and /MD by default, which conflict with our settings.
-	string(REPLACE "/MD " " " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE} )
-	string(REPLACE "/MD " " " CMAKE_CXX_FLAGS_MINSIZEREL ${CMAKE_CXX_FLAGS_MINSIZEREL} )
-	string(REPLACE "/MD " " " CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} )
 	string(REPLACE "/Ob1 " "/Ob2 " CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} )
-	string(REPLACE "/MDd " " " CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG} )
-	string(REPLACE "/MD " " " CMAKE_C_FLAGS_RELEASE ${CMAKE_C_FLAGS_RELEASE} )
-	string(REPLACE "/MD " " " CMAKE_C_FLAGS_MINSIZEREL ${CMAKE_C_FLAGS_MINSIZEREL} )
-	string(REPLACE "/MD " " " CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO} )
-	string(REPLACE "/MDd " " " CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG} )
 else()
 	set( REL_LINKER_FLAGS "" )
 	set( ALL_C_FLAGS "-ffp-contract=off" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.1.0 )
+cmake_minimum_required( VERSION 3.16.0 )
 
 include(precompiled_headers)
 
@@ -409,7 +409,7 @@ set( PLAT_WIN32_SOURCES
 	)
 
 if (HAVE_VULKAN)
-	set (PLAT_WIN32_SOURCES ${PLAT_WIN32_SOURCES} common/platform/win32/win32vulkanvideo.cpp )
+	list (APPEND PLAT_WIN32_SOURCES common/platform/win32/win32vulkanvideo.cpp )
 endif()
 
 # todo: implement an actual crash catcher for ARM
@@ -697,10 +697,6 @@ set( VM_JIT_SOURCES
 	common/scripting/jit/jit_store.cpp
 )
 
-# This is disabled for now because I cannot find a way to give the .pch file a different name.
-# Visual C++ 2015 seems hell-bent on only allowing one .pch file with the same name as the executable.
-#enable_precompiled_headers( g_pch2.h FASTMATH_PCH_SOURCES )
-
 # Enable fast math for some sources
 set( FASTMATH_SOURCES
 	rendering/swrenderer/r_all.cpp
@@ -773,11 +769,11 @@ if (HAVE_GLES2)
 		common/rendering/gles/glad/src/glad.c
 	)
 
-	set (FASTMATH_SOURCES ${FASTMATH_SOURCES} ${GLES_SOURCES})
+	list (APPEND FASTMATH_SOURCES ${GLES_SOURCES})
 endif()
 
 if (HAVE_VULKAN)
-	set (FASTMATH_SOURCES ${FASTMATH_SOURCES} ${VULKAN_SOURCES})
+	list (APPEND FASTMATH_SOURCES ${VULKAN_SOURCES})
 endif()
 
 set (FASTMATH_SOURCES ${FASTMATH_SOURCES})
@@ -1186,14 +1182,7 @@ else()
 	set( NOT_COMPILED_SOURCE_FILES ${NOT_COMPILED_SOURCE_FILES} ${VM_JIT_SOURCES} )
 endif()
 
-if( MSVC )
-	enable_precompiled_headers( g_pch.h PCH_SOURCES )
-else()
-	# Temporary solution for compilers other than MSVC
-	set_source_files_properties( ${PCH_SOURCES} PROPERTIES COMPILE_FLAGS "-include g_pch.h" )
-endif()
-
-add_executable( zdoom WIN32 MACOSX_BUNDLE
+set( ZDOOM_SOURCES
 	${HEADER_FILES}
 	${NOT_COMPILED_SOURCE_FILES}
 	${SYSTEM_SOURCES}
@@ -1224,10 +1213,18 @@ add_executable( zdoom WIN32 MACOSX_BUNDLE
 	common/thirdparty/math/fastsin.cpp
 )
 
+set( ZDOOM_NONPCH_SOURCES ${ZDOOM_SOURCES} )
+list( REMOVE_ITEM ZDOOM_NONPCH_SOURCES ${PCH_SOURCES} )
+
+add_executable( zdoom WIN32 MACOSX_BUNDLE ${ZDOOM_SOURCES} )
+
+target_precompile_headers( zdoom PRIVATE g_pch.h )
+
 set_source_files_properties( ${FASTMATH_SOURCES} PROPERTIES COMPILE_FLAGS ${ZD_FASTMATH_FLAG} )
 set_source_files_properties( xlat/parse_xlat.cpp PROPERTIES OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xlat_parser.c" )
 set_source_files_properties( common/engine/sc_man.cpp PROPERTIES OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/sc_man_scanner.h" )
 set_source_files_properties( ${NOT_COMPILED_SOURCE_FILES} PROPERTIES HEADER_FILE_ONLY TRUE )
+set_source_files_properties( ${ZDOOM_NONPCH_SOURCES} PROPERTIES SKIP_PRECOMPILE_HEADERS TRUE )
 
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")

--- a/src/common/audio/music/music.cpp
+++ b/src/common/audio/music/music.cpp
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdexcept>
+#include <memory>
 
 #include "i_sound.h"
 #include "i_music.h"

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocessshader.h
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocessshader.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "zstring.h"
+#include "tarray.h"
+
 enum class PostProcessUniformType
 {
 	Undefined,

--- a/src/common/thirdparty/richpresence.cpp
+++ b/src/common/thirdparty/richpresence.cpp
@@ -36,6 +36,7 @@
 */
 
 #include <time.h>
+#include <string.h>
 
 #include "common/engine/printf.h"
 #include "discord_rpc.h"

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -30,6 +30,8 @@
 
 struct event_t;
 
+#include <functional>
+
 #include "dobjgc.h"
 #include "name.h"
 #include "gamestate.h"


### PR DESCRIPTION
* Remove precompiled header hack that is no longer needed
* Fixes for compilation on VS2022 Debug configurations
* Set CMAKE_MSVC_RUNTIME_LIBRARY instead of hacking around CMake compiler flags.