### PR TITLE
Switch to `vcpkg` for library dependencies

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,19 +13,19 @@ jobs:
         - {
             name: "Visual Studio 2022",
             os: windows-2022,
-            extra_options: "-A x64",
+            extra_options: "-A x64 -DCMAKE_TOOLCHAIN_FILE=build/vcpkg/scripts/buildsystems/vcpkg.cmake",
             build_type: "Release"
           }
         - {
             name: "Visual Studio 2019",
             os: windows-2019,
-            extra_options: "-A x64",
+            extra_options: "-A x64 -DCMAKE_TOOLCHAIN_FILE=build/vcpkg/scripts/buildsystems/vcpkg.cmake",
             build_type: "Release"
           }
         - {
             name: "Visual Studio 2019",
             os: windows-2019,
-            extra_options: "-A x64",
+            extra_options: "-A x64 -DCMAKE_TOOLCHAIN_FILE=build/vcpkg/scripts/buildsystems/vcpkg.cmake",
             build_type: "Debug"
           }
         - {
@@ -90,6 +90,13 @@ jobs:
           wget -q "https://github.com/coelckers/gzdoom/releases/download/ci_deps/${ZMUSIC_PACKAGE}"
           tar -xf "${ZMUSIC_PACKAGE}"
         fi
+    
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+      if: runner.os == 'Windows'
+      with:
+        vcpkgDirectory: '${{ github.workspace }}/build/vcpkg'
+        vcpkgGitCommitId: '65c013b9667ff1f58fb8724209227e5a2e761043'
 
     - name: Configure
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,32 @@ if( COMMAND cmake_policy )
 	endif()
 endif()
 
+if (LIBVPX_VCPKG)
+	list(APPEND VCPKG_MANIFEST_FEATURES "vcpkg-libvpx")
+endif()
+
+if (OPENAL_SOFT_VCPKG)
+	list(APPEND VCPKG_MANIFEST_FEATURES "vcpkg-openal-soft")
+endif()
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows" OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows"))
+	# Force static triplet on Windows
+	set(VCPKG_TARGET_TRIPLET "x64-windows-static")
+endif()
+
 project(GZDoom)
+
+if (WIN32 AND VCPKG_TOOLCHAIN)
+	option(LIBVPX_VCPKG "Use libvpx from vcpkg" OFF)
+endif()
+
+if (VCPKG_TOOLCHAIN)
+	option(OPENAL_SOFT_VCPKG "Use OpenAL from vcpkg" OFF)
+endif()
+
+if (NOT VCPKG_TOOLCHAIN)
+	set(VCPKG_MANIFEST_FEATURES)
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,7 +139,11 @@ else()
 endif()
 
 if( NOT NO_OPENAL )
-	if ( NOT DYN_OPENAL )	# DYN_OPENAL uses local copies of the headers.
+	if ( "vcpkg-openal-soft" IN_LIST VCPKG_MANIFEST_FEATURES )
+		# Statically link to OpenAL from vcpkg
+		find_package( OpenAL CONFIG REQUIRED )
+		list( APPEND PROJECT_LIBRARIES OpenAL::OpenAL )
+	elseif ( NOT DYN_OPENAL )	# DYN_OPENAL uses local copies of the headers.
 		find_package( OpenAL )
 		mark_as_advanced(CLEAR OPENAL_INCLUDE_DIR)
 		if( OPENAL_INCLUDE_DIR )
@@ -300,7 +304,7 @@ if( UNIX )
 			add_definitions( -DNO_CLOCK_GETTIME )
 		endif()
 	else()
-		set( PROJECT_LIBRARIES ${PROJECT_LIBRARIES} rt )
+		list( APPEND PROJECT_LIBRARIES rt )
 	endif()
 endif()
 
@@ -317,7 +321,7 @@ add_custom_target( revision_check ALL
 
 set( PROJECT_LIBRARIES ${PROJECT_LIBRARIES} "${ZLIB_LIBRARIES}" "${JPEG_LIBRARIES}" "${BZIP2_LIBRARIES}" "${CMAKE_DL_LIBS}" "${DRPC_LIBRARIES}")
 if (HAVE_VULKAN)
-	set( PROJECT_LIBRARIES ${PROJECT_LIBRARIES} "zvulkan")
+	list( APPEND PROJECT_LIBRARIES "zvulkan" )
 endif()
 
 # ZMUSIC
@@ -1359,6 +1363,10 @@ add_custom_command(TARGET zdoom POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different
 	${CMAKE_SOURCE_DIR}/fm_banks/gs-by-papiezak-and-sneakernets.wopn $<TARGET_FILE_DIR:zdoom>/fm_banks/gs-by-papiezak-and-sneakernets.wopn
 )
+
+if (VCPKG_TOOLCHAIN)
+	x_vcpkg_install_local_dependencies(TARGETS zdoom DESTINATION ".")
+endif()
 
 if( WIN32 )
 	set( INSTALL_SOUNDFONT_PATH . CACHE STRING "Directory where soundfonts and WOPL/WOPN banks will be placed during install." )

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "builtin-baseline": "9d47b24eacbd1cd94f139457ef6cd35e5d92cc84",
+    "features":
+    {
+        "vcpkg-libvpx":
+        {
+            "description": "Use libvpx provided by vcpkg on Windows",
+            "dependencies": [
+                {
+                    "name": "libvpx",
+                    "default-features": false,
+                    "platform": "windows & static & staticcrt"
+                }
+            ]
+        },
+        "vcpkg-openal-soft":
+        {
+            "description": "Use openal-soft provided by vcpkg.",
+            "dependencies": [
+                {
+                    "name": "openal-soft",
+                    "default-features": false,
+                    "platform": "!windows | (windows & static & staticcrt)"
+                }
+            ]
+        }
+    },
+    "dependencies": [
+        {
+            "name": "zlib",
+            "platform": "!windows | (windows & static & staticcrt)"
+        },
+        {
+            "name": "libjpeg-turbo",
+            "platform": "!windows | (windows & static & staticcrt)"
+        },
+        {
+            "name": "bzip2",
+            "platform": "!windows | (windows & static & staticcrt)"
+        },
+        {
+            "name": "sdl2",
+            "platform": "!windows & !osx"
+        },
+        {
+            "name": "libvpx",
+            "platform": "!windows"
+        }
+    ]
+}


### PR DESCRIPTION
This PR switches to Microsoft's `vcpkg` for library dependencies.