### PR TITLE
Inventory map change fix

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2111,7 +2111,7 @@ class PlayerPawn : Actor
 				let it = toDelete[i];
 				if (!it.bDestroyed)
 				{
-					item.DepleteOrDestroy();
+					it.DepleteOrDestroy();
 				}
 			}
 		}


### PR DESCRIPTION
Fixed wrong pointer being used in PlayerFinishLevel, causing wrong inventory items to be destroyed.