### PR TITLE
Added some null pointer checks to prevent crashes.

### DIFF
--- a/src/playsim/p_interaction.cpp
+++ b/src/playsim/p_interaction.cpp
@@ -1614,6 +1614,9 @@ DEFINE_ACTION_FUNCTION(AActor, PoisonMobj)
 
 bool AActor::OkayToSwitchTarget(AActor *other)
 {
+	if (other == nullptr)
+		return false;
+
 	if (other == this)
 		return false;		// [RH] Don't hate self (can happen when shooting barrels)
 

--- a/src/playsim/p_maputl.cpp
+++ b/src/playsim/p_maputl.cpp
@@ -1686,7 +1686,7 @@ FPathTraverse::~FPathTraverse()
 //
 int P_CheckFov(AActor* t1, AActor* t2, double fov)
 {
-	return absangle(t1->AngleTo(t2), t1->Angles.Yaw) <= DAngle::fromDeg(fov);
+	return absangle(t1->AngleTo(PARAM_NULLCHECK(t2,t2)), t1->Angles.Yaw) <= DAngle::fromDeg(fov);
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, CheckFov, P_CheckFov)


### PR DESCRIPTION
This is a simple bugfix PR that adds null pointer checks to P_CheckFov() and AActor::OkayToSwitchTarget(). The former function just flat out hard crashes when called to a null pointer. (#2072) And the latter rarely causes hard crashes, particularly when on of my mods interacts with Hideous Destructor.