### PR TITLE
Clear* functions now respect color alpha value

### DIFF
--- a/src/common/2d/v_draw.cpp
+++ b/src/common/2d/v_draw.cpp
@@ -451,7 +451,8 @@ DEFINE_ACTION_FUNCTION(_Screen, ClearScreen)
 DEFINE_ACTION_FUNCTION(FCanvas, ClearScreen)
 {
 	PARAM_SELF_PROLOGUE(FCanvas);
-	self->Drawer.ClearScreen();
+	PARAM_COLOR(color);
+	self->Drawer.AddColorOnlyQuad(0, 0, self->Drawer.GetWidth(), self->Drawer.GetHeight(), color, &LegacyRenderStyles[STYLE_Source]);
 	self->Tex->NeedUpdate();
 	return 0;
 }
@@ -1635,7 +1636,7 @@ DEFINE_ACTION_FUNCTION(FCanvas, DrawThickLine)
 //
 //==========================================================================
 
-void ClearRect(F2DDrawer *drawer, int left, int top, int right, int bottom, int palcolor, uint32_t color)
+void ClearRect(F2DDrawer *drawer, int left, int top, int right, int bottom, int palcolor, uint32_t color, bool alpha)
 {
 	auto clipleft = drawer->clipleft;
 	auto cliptop = drawer->cliptop;
@@ -1667,9 +1668,9 @@ void ClearRect(F2DDrawer *drawer, int left, int top, int right, int bottom, int 
 
 	if (palcolor >= 0 && color == 0)
 	{
-		color = GPalette.BaseColors[palcolor] | 0xff000000;
+		color = GPalette.BaseColors[palcolor];
 	}
-	drawer->AddColorOnlyQuad(left, top, right - left, bottom - top, color | 0xFF000000, nullptr);
+	drawer->AddColorOnlyQuad(left, top, right - left, bottom - top, alpha ? color : (color | 0xFF000000), nullptr);
 }
 
 DEFINE_ACTION_FUNCTION(_Screen, Clear)
@@ -1681,8 +1682,9 @@ DEFINE_ACTION_FUNCTION(_Screen, Clear)
 	PARAM_INT(y2);
 	PARAM_INT(color);
 	PARAM_INT(palcol);
+	PARAM_BOOL(alpha);
 	if (!twod->HasBegun2D()) ThrowAbortException(X_OTHER, "Attempt to draw to screen outside a draw function");
-	ClearRect(twod, x1, y1, x2, y2, palcol, color);
+	ClearRect(twod, x1, y1, x2, y2, palcol, color, alpha);
 	return 0;
 }
 
@@ -1695,7 +1697,8 @@ DEFINE_ACTION_FUNCTION(FCanvas, Clear)
 	PARAM_INT(y2);
 	PARAM_INT(color);
 	PARAM_INT(palcol);
-	ClearRect(&self->Drawer, x1, y1, x2, y2, palcol, color);
+	PARAM_BOOL(alpha);
+	ClearRect(&self->Drawer, x1, y1, x2, y2, palcol, color, alpha);
 	self->Tex->NeedUpdate();
 	return 0;
 }

--- a/src/common/2d/v_draw.h
+++ b/src/common/2d/v_draw.h
@@ -288,7 +288,7 @@ void DrawBorder(F2DDrawer* drawer, FTextureID, int x1, int y1, int x2, int y2);
 void DrawFrame(F2DDrawer* twod, PalEntry color, int left, int top, int width, int height, int thickness);
 
 // Set an area to a specified color
-void ClearRect(F2DDrawer* drawer, int left, int top, int right, int bottom, int palcolor, uint32_t color);
+void ClearRect(F2DDrawer* drawer, int left, int top, int right, int bottom, int palcolor, uint32_t color, bool alpha = false);
 
 void VirtualToRealCoords(F2DDrawer* drawer, double& x, double& y, double& w, double& h, double vwidth, double vheight, bool vbottom = false, bool handleaspect = true);
 

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -506,7 +506,7 @@ class Shape2D : Object native
 
 class Canvas : Object native abstract
 {
-	native void Clear(int left, int top, int right, int bottom, Color color, int palcolor = -1);
+	native void Clear(int left, int top, int right, int bottom, Color color, int palcolor = -1, bool alpha = false);
 	native void Dim(Color col, double amount, int x, int y, int w, int h, ERenderStyle style = STYLE_Translucent);
 
 	native vararg void DrawTexture(TextureID tex, bool animate, double x, double y, ...);
@@ -523,7 +523,7 @@ class Canvas : Object native abstract
 	native int, int, int, int GetClipRect();
 	native double, double, double, double GetFullscreenRect(double vwidth, double vheight, int fsmode);
 	native Vector2 SetOffset(double x, double y);
-	native void ClearScreen(color col = 0);
+	native void ClearScreen(color col = color(255, 0, 0, 0));
 	native void SetScreenFade(double factor);
 
 	native void EnableStencil(bool on);
@@ -539,7 +539,7 @@ struct Screen native
 	native static int GetWidth();
 	native static int GetHeight();
 	native static Vector2 GetTextScreenSize();
-	native static void Clear(int left, int top, int right, int bottom, Color color, int palcolor = -1);
+	native static void Clear(int left, int top, int right, int bottom, Color color, int palcolor = -1, bool alpha = false);
 	native static void Dim(Color col, double amount, int x, int y, int w, int h, ERenderStyle style = STYLE_Translucent);
 
 	native static vararg void DrawTexture(TextureID tex, bool animate, double x, double y, ...);


### PR DESCRIPTION
https://forum.zdoom.org/viewtopic.php?t=77592

This PR makes the following changes to `Clear*` functions:
- Clear* functions now respect color alpha value.
- ClearScreen function for canvas textures are now able to clear them to transparent colors, and work exactly like OpenGL's `glClear` function.