### PR TITLE
Add ClearScreenToColor to clear canvas textures to transparent colors

### DIFF
--- a/src/common/2d/v_draw.cpp
+++ b/src/common/2d/v_draw.cpp
@@ -456,6 +456,15 @@ DEFINE_ACTION_FUNCTION(FCanvas, ClearScreen)
 	return 0;
 }
 
+DEFINE_ACTION_FUNCTION(FCanvas, ClearScreenToColor)
+{
+	PARAM_SELF_PROLOGUE(FCanvas);
+	PARAM_COLOR(color);
+	self->Drawer.AddColorOnlyQuad(0, 0, self->Drawer.GetWidth(), self->Drawer.GetHeight(), color, &LegacyRenderStyles[STYLE_Source]);
+	self->Tex->NeedUpdate();
+	return 0;
+}
+
 DEFINE_ACTION_FUNCTION(_Screen, SetScreenFade)
 {
 	PARAM_PROLOGUE;

--- a/wadsrc/static/zscript.txt
+++ b/wadsrc/static/zscript.txt
@@ -1,4 +1,4 @@
-version "4.10"
+version "4.11"
 
 // Generic engine code
 #include "zscript/engine/base.zs"

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -523,7 +523,8 @@ class Canvas : Object native abstract
 	native int, int, int, int GetClipRect();
 	native double, double, double, double GetFullscreenRect(double vwidth, double vheight, int fsmode);
 	native Vector2 SetOffset(double x, double y);
-	native void ClearScreen(color col = 0);
+	deprecated("4.11", "use ClearScreenToColor() instead") native void ClearScreen(color col = 0);
+	native void ClearScreenToColor(color col = 0);
 	native void SetScreenFade(double factor);
 
 	native void EnableStencil(bool on);


### PR DESCRIPTION
This PR deprecates `ClearScreen()` in Canvas class and adds `ClearScreenToColor()` as a replacement that fully respects color values passed, including alpha.

It works exactly like OpenGL's `glClear` function.