### PR TITLE
Allows building gzdoom with Vulkan with either X11 or Wayland 

### DIFF
--- a/libraries/ZVulkan/CMakeLists.txt
+++ b/libraries/ZVulkan/CMakeLists.txt
@@ -1,6 +1,17 @@
 cmake_minimum_required(VERSION 3.15)
 project(zvulkan)
 
+option( VULKAN_USE_XLIB "Use Vulkan xlib (X11) WSI integration" ON )
+option( VULKAN_USE_WAYLAND "Use Vulkan Wayland WSI integration" OFF )
+
+if ( VULKAN_USE_XLIB )
+	add_definitions( -DVULKAN_USE_XLIB=1 )
+else()
+	if (VULKAN_USE_WAYLAND)
+		add_definitions( -DVULKAN_USE_WAYLAND=1 )
+	endif()
+endif()
+
 set(ZVULKAN_SOURCES
 	src/vulkanbuilders.cpp
 	src/vulkandevice.cpp

--- a/libraries/ZVulkan/src/volk/volk.c
+++ b/libraries/ZVulkan/src/volk/volk.c
@@ -5,7 +5,11 @@
 #define VK_USE_PLATFORM_MACOS_MVK
 #define VK_USE_PLATFORM_METAL_EXT
 #else
+#if defined(VULKAN_USE_XLIB)
 #define VK_USE_PLATFORM_XLIB_KHR
+#elif defined(VULKAN_USE_WAYLAND)
+#define VK_USE_PLATFORM_WAYLAND_KHR
+#endif
 #endif
 
 /* This file is part of volk library; see volk.h for version/license details */


### PR DESCRIPTION
This PR adds two new exclusive options to ZVulkan library, allowing to switch easily at CMake level between xlib (X11) and wayland.

It defaults to XLIB not to break current behaviour and builds, but it has been tested to build fine with Wayland.