### PR TITLE
- fix bad stringpool setup in filesystem.

### DIFF
--- a/src/common/filesystem/include/fs_filesystem.h
+++ b/src/common/filesystem/include/fs_filesystem.h
@@ -202,7 +202,7 @@ protected:
 	int IwadIndex = -1;
 	int MaxIwadIndex = -1;
 
-	StringPool* stringpool;
+	StringPool* stringpool = nullptr;
 
 private:
 	void DeleteAll();

--- a/src/common/filesystem/source/file_directory.cpp
+++ b/src/common/filesystem/source/file_directory.cpp
@@ -96,7 +96,7 @@ FDirectory::FDirectory(const char * directory, StringPool* sp, bool nosubdirflag
 {
 	auto fn = FS_FullPath(directory);
 	if (fn.back() != '/') fn += '/';
-	FileName = sp->Strdup(fn.c_str());
+	FileName = stringpool->Strdup(fn.c_str());
 }
 
 //==========================================================================

--- a/src/common/filesystem/source/filesystem.cpp
+++ b/src/common/filesystem/source/filesystem.cpp
@@ -194,8 +194,6 @@ static void PrintLastError (FileSystemMessageFunc Printf);
 
 FileSystem::FileSystem()
 {
-	stringpool = new StringPool(true);
-	stringpool->shared = true;	// will be used by all owned resource files.
 }
 
 FileSystem::~FileSystem ()
@@ -219,7 +217,7 @@ void FileSystem::DeleteAll ()
 		delete Files[i];
 	}
 	Files.clear();
-	delete stringpool;
+	if (stringpool != nullptr) delete stringpool;
 	stringpool = nullptr;
 }
 
@@ -247,6 +245,9 @@ bool FileSystem::InitMultipleFiles (std::vector<std::string>& filenames, LumpFil
 	// open all the files, load headers, and count lumps
 	DeleteAll();
 	numfiles = 0;
+
+	stringpool = new StringPool(true);
+	stringpool->shared = true;	// will be used by all owned resource files.
 
 	// first, check for duplicates
 	if (allowduplicates)


### PR DESCRIPTION
Doing it in the constructor does not work because InitMultipleFiles will clear everything again before building up the directory so it would always be null. This triggered another bug in file_directory.cpp which used the constructor's unvalidated parameter.

Fixes #2155