### PR TITLE
- fix gl_lightmode migration

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -151,7 +151,7 @@ CUSTOM_CVAR(Int, gl_maplightmode, -1, CVAR_NOINITCALL) // this is just for testi
 	if (self > 5 || self < -1) self = -1;
 }
 
-CUSTOM_CVAR(Int, gl_lightmode, 1, CVAR_ARCHIVE | CVAR_NOINITCALL)
+CUSTOM_CVAR(Int, hw_lightmode, 1, CVAR_ARCHIVE | CVAR_NOINITCALL)
 {
 	if (self < 0 || self > 2) self = 2;
 }
@@ -166,8 +166,8 @@ ELightMode getRealLightmode(FLevelLocals* Level, bool for3d)
 	}
 	if (lightmode == ELightMode::Doom && for3d)
 	{
-		if (gl_lightmode == 1) lightmode = ELightMode::ZDoomSoftware;
-		else if (gl_lightmode == 2) lightmode = ELightMode::DoomSoftware;
+		if (hw_lightmode == 1) lightmode = ELightMode::ZDoomSoftware;
+		else if (hw_lightmode == 2) lightmode = ELightMode::DoomSoftware;
 	}
 	return lightmode;
 }

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -613,7 +613,8 @@ void FGameConfigFile::DoGlobalSetup ()
 				{
 					UCVarValue v = var->GetGenericRep(CVAR_Int);
 					v.Int /= 8; // all legacy modes map to 0, ZDoom software to 1 and Vanilla software to 2.
-					var->SetGenericRep(v, CVAR_Int);
+					auto newvar = FindCVar("hw_lightmode", NULL);
+					if (newvar != nullptr) newvar->SetGenericRep(v.Int == 16? 2 : v.Int == 8? 1 : 0, CVAR_Int);
 				}
 			}
 		}

--- a/src/rendering/hwrenderer/scene/hw_lighting.cpp
+++ b/src/rendering/hwrenderer/scene/hw_lighting.cpp
@@ -153,8 +153,7 @@ PalEntry HWDrawInfo::CalcLightColor(int light, PalEntry pe, int blendfactor)
 //
 //	Rules for fog:
 //
-//  1. If bit 4 of gl_lightmode is set always use the level's fog density. 
-//     This is what Legacy's GL render does.
+//  1. If lightmode is DoomLegacy, always use the level's fog density. 
 //	2. black fog means no fog and always uses the distfogtable based on the level's fog density setting
 //	3. If outside fog is defined and the current fog color is the same as the outside fog
 //	   the engine always uses the outside fog density to make the fog uniform across the Level->

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2615,7 +2615,7 @@ OptionMenu "OpenGLOptions" protected
 	Submenu "$GLPREFMNU_VRMODE",				"VR3DMenu"
 	Submenu "$GLMNU_POSTPROCESS",				"PostProcessMenu"
 	StaticText " "
-	Option "$GLPREFMNU_SECLIGHTMODE",			gl_lightmode,					"LightingModes"
+	Option "$GLPREFMNU_SECLIGHTMODE",			hw_lightmode,					"LightingModes"
 	Option "$GLPREFMNU_SWLMBANDED",				gl_bandedswlight,				"OnOff"
 	Option "$GLPREFMNU_FOGMODE",				gl_fogmode,						"FogMode"
 	Option "$GLPREFMNU_FOGFORCEFULLBRIGHT",		gl_brightfog,					"YesNo"

--- a/wadsrc/static/menudef.zsimple
+++ b/wadsrc/static/menudef.zsimple
@@ -63,7 +63,7 @@ OptionMenu VideoOptionsSimple protected
 	StaticText " "
 	Option "$GLTEXMNU_TEXFILTER",		gl_texture_filter,				"FilterModes"
 	Option "$GLTEXMNU_ANISOTROPIC",		gl_texture_filter_anisotropic,	"Anisotropy"
-	Option "$GLPREFMNU_SECLIGHTMODE",			gl_lightmode,					"LightingModes"
+	Option "$GLPREFMNU_SECLIGHTMODE",			hw_lightmode,					"LightingModes"
 	StaticText " "
 	Option "$DSPLYMNU_VSYNC",					"vid_vsync", "OnOff"
 	Slider "$VIDMNU_MAXFPS",					"vid_maxfps", 35, 500, 1


### PR DESCRIPTION
Use a new CVAR to evade the clamp-on-write that destroys the original value and use a more robust method to set the new value.

Fixes #2117