### PR TITLE
- fixed M_GetSavegamesPath for Linux.

### DIFF
--- a/src/common/platform/posix/unix/i_specialpaths.cpp
+++ b/src/common/platform/posix/unix/i_specialpaths.cpp
@@ -191,7 +191,7 @@ FString M_GetScreenshotsPath()
 
 FString M_GetSavegamesPath()
 {
-	return NicePath("$HOME/" GAME_DIR "/");
+	return NicePath("$HOME/" GAME_DIR "/savegames/");
 }
 
 //===========================================================================


### PR DESCRIPTION
This just used the main appdata folder, unlike Windows and macOS.
Note that this will make old savegames inaccessible because they are in a different folder now!
