### PR TITLE
Add support for not localizing drawn text (try 2)

### DIFF
--- a/src/common/2d/v_draw.cpp
+++ b/src/common/2d/v_draw.cpp
@@ -831,7 +831,7 @@ static inline FSpecialColormap * ListGetSpecialColormap(VMVa_List &tags)
 //==========================================================================
 
 template<class T>
-bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double y, uint32_t tag, T& tags, DrawParms *parms, int type, PalEntry fill, double fillalpha)
+bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double y, uint32_t tag, T& tags, DrawParms *parms, int type, PalEntry fill, double fillalpha, bool scriptDifferences)
 {
 	INTBOOL boolval;
 	int intval;
@@ -886,6 +886,7 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 	parms->scalex = parms->scaley = 1;
 	parms->cellx = parms->celly = 0;
 	parms->maxstrlen = INT_MAX;
+	parms->localize = scriptDifferences;
 	parms->virtBottom = false;
 	parms->srcx = 0.;
 	parms->srcy = 0.;
@@ -1323,6 +1324,10 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 			parms->maxstrlen = ListGetInt(tags);
 			break;
 
+		case DTA_Localize:
+			parms->localize = ListGetInt(tags);
+			break;
+
 		case DTA_CellX:
 			parms->cellx = ListGetInt(tags);
 			break;
@@ -1434,8 +1439,8 @@ bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture *img, double x, double
 }
 // explicitly instantiate both versions for v_text.cpp.
 
-template bool ParseDrawTextureTags<Va_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, Va_List& tags, DrawParms *parms, int type, PalEntry fill, double fillalpha);
-template bool ParseDrawTextureTags<VMVa_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, VMVa_List& tags, DrawParms *parms, int type, PalEntry fill, double fillalpha);
+template bool ParseDrawTextureTags<Va_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, Va_List& tags, DrawParms *parms, int type, PalEntry fill, double fillalpha, bool scriptDifferences);
+template bool ParseDrawTextureTags<VMVa_List>(F2DDrawer* drawer, FGameTexture *img, double x, double y, uint32_t tag, VMVa_List& tags, DrawParms *parms, int type, PalEntry fill, double fillalpha, bool scriptDifferences);
 
 //==========================================================================
 //

--- a/src/common/2d/v_draw.h
+++ b/src/common/2d/v_draw.h
@@ -100,6 +100,7 @@ enum
 
 	// For DrawText calls:
 	DTA_TextLen,		// stop after this many characters, even if \0 not hit
+	DTA_Localize,		// localize text
 	DTA_CellX,			// horizontal size of character cell
 	DTA_CellY,			// vertical size of character cell
 
@@ -194,6 +195,7 @@ struct DrawParms
 	int monospace;
 	int spacing;
 	int maxstrlen;
+	bool localize;
 	bool fortext;
 	bool virtBottom;
 	bool burn;
@@ -266,7 +268,7 @@ enum
 };
 
 template<class T>
-bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture* img, double x, double y, uint32_t tag, T& tags, DrawParms* parms, int type, PalEntry fill = ~0u, double fillalpha = 0.0);
+bool ParseDrawTextureTags(F2DDrawer *drawer, FGameTexture* img, double x, double y, uint32_t tag, T& tags, DrawParms* parms, int type, PalEntry fill = ~0u, double fillalpha = 0.0, bool scriptDifferences = false);
 
 template<class T>
 void DrawTextCommon(F2DDrawer *drawer, FFont* font, int normalcolor, double x, double y, const T* string, DrawParms& parms);

--- a/src/common/2d/v_draw.h
+++ b/src/common/2d/v_draw.h
@@ -100,7 +100,6 @@ enum
 
 	// For DrawText calls:
 	DTA_TextLen,		// stop after this many characters, even if \0 not hit
-	DTA_Localize,		// localize text
 	DTA_CellX,			// horizontal size of character cell
 	DTA_CellY,			// vertical size of character cell
 
@@ -133,6 +132,7 @@ enum
 	DTA_Indexed,			// Use an indexed texture combined with the given translation.
 	DTA_CleanTop,			// Like DTA_Clean but aligns to the top of the screen instead of the center.
 	DTA_NoOffset,			// Ignore 2D drawer's offset.
+	DTA_Localize,		// localize drawn string, for DrawText only
 
 };
 

--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -667,9 +667,9 @@ DEFINE_ACTION_FUNCTION_NATIVE(FFont, GetBottomAlignOffset, GetBottomAlignOffset)
 	ACTION_RETURN_FLOAT(GetBottomAlignOffset(self, code));
 }
 
-static int StringWidth(FFont *font, const FString &str)
+static int StringWidth(FFont *font, const FString &str, bool localize)
 {
-	const char *txt = str[0] == '$' ? GStrings(&str[1]) : str.GetChars();
+	const char *txt = (localize && str[0] == '$') ? GStrings(&str[1]) : str.GetChars();
 	return font->StringWidth(txt);
 }
 
@@ -677,12 +677,13 @@ DEFINE_ACTION_FUNCTION_NATIVE(FFont, StringWidth, StringWidth)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(FFont);
 	PARAM_STRING(str);
-	ACTION_RETURN_INT(StringWidth(self, str));
+	PARAM_BOOL(localize);
+	ACTION_RETURN_INT(StringWidth(self, str, localize));
 }
 
-static int GetMaxAscender(FFont* font, const FString& str)
+static int GetMaxAscender(FFont* font, const FString& str, bool localize)
 {
-	const char* txt = str[0] == '$' ? GStrings(&str[1]) : str.GetChars();
+	const char* txt = (localize && str[0] == '$') ? GStrings(&str[1]) : str.GetChars();
 	return font->GetMaxAscender(txt);
 }
 
@@ -690,12 +691,13 @@ DEFINE_ACTION_FUNCTION_NATIVE(FFont, GetMaxAscender, GetMaxAscender)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(FFont);
 	PARAM_STRING(str);
-	ACTION_RETURN_INT(GetMaxAscender(self, str));
+	PARAM_BOOL(localize);
+	ACTION_RETURN_INT(GetMaxAscender(self, str, localize));
 }
 
-static int CanPrint(FFont *font, const FString &str)
+static int CanPrint(FFont *font, const FString &str, bool localize)
 {
-	const char *txt = str[0] == '$' ? GStrings(&str[1]) : str.GetChars();
+	const char *txt = (localize && str[0] == '$') ? GStrings(&str[1]) : str.GetChars();
 	return font->CanPrint(txt);
 }
 
@@ -703,7 +705,8 @@ DEFINE_ACTION_FUNCTION_NATIVE(FFont, CanPrint, CanPrint)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(FFont);
 	PARAM_STRING(str);
-	ACTION_RETURN_INT(CanPrint(self, str));
+	PARAM_BOOL(localize);
+	ACTION_RETURN_INT(CanPrint(self, str, localize));
 }
 
 static int FindFontColor(int name)

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -430,7 +430,6 @@ enum DrawTextureTags
 
 	// For DrawText calls only:
 	DTA_TextLen,		// stop after this many characters, even if \0 not hit
-	DTA_Localize,		// localize drawn string
 	DTA_CellX,			// horizontal size of character cell
 	DTA_CellY,			// vertical size of character cell
 
@@ -463,6 +462,7 @@ enum DrawTextureTags
 	DTA_Indexed,			// Use an indexed texture combined with the given translation.
 	DTA_CleanTop,			// Like DTA_Clean but aligns to the top of the screen instead of the center.
 	DTA_NoOffset,			// Ignore 2D drawer's offset.
+	DTA_Localize,		// localize drawn string, for DrawText only
 
 };
 

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -430,6 +430,7 @@ enum DrawTextureTags
 
 	// For DrawText calls only:
 	DTA_TextLen,		// stop after this many characters, even if \0 not hit
+	DTA_Localize,		// localize drawn string
 	DTA_CellX,			// horizontal size of character cell
 	DTA_CellY,			// vertical size of character cell
 
@@ -641,9 +642,9 @@ struct Font native
 	// native Font(const Name name);
 
 	native int GetCharWidth(int code);
-	native int StringWidth(String code);
-	native int GetMaxAscender(String code);
-	native bool CanPrint(String code);
+	native int StringWidth(String code, bool localize = true);
+	native int GetMaxAscender(String code, bool localize = true);
+	native bool CanPrint(String code, bool localize = true);
 	native int GetHeight();
 	native int GetDisplacement();
 	native String GetCursor();

--- a/wadsrc/static/zscript/engine/ui/menu/menu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/menu.zs
@@ -349,16 +349,16 @@ class Menu : Object native ui version("2.4")
 		return OptionFont().GetHeight();
 	}
 
-	static int OptionWidth(String s)
+	static int OptionWidth(String s, bool localize = true)
 	{
-		return OptionFont().StringWidth(s);
+		return OptionFont().StringWidth(s, localize);
 	}
 
-	static void DrawOptionText(int x, int y, int color, String text, bool grayed = false)
+	static void DrawOptionText(int x, int y, int color, String text, bool grayed = false, bool localize = true)
 	{
-		String label = Stringtable.Localize(text);
+		String label = localize ? Stringtable.Localize(text) : text;
 		int overlay = grayed? Color(96,48,0,0) : 0;
-		screen.DrawText (OptionFont(), color, x, y, text, DTA_CleanNoMove_1, true, DTA_ColorOverlay, overlay);
+		screen.DrawText (OptionFont(), color, x, y, text, DTA_CleanNoMove_1, true, DTA_ColorOverlay, overlay, DTA_Localize, localize);
 	}
 
 

--- a/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
@@ -61,9 +61,9 @@ class OptionMenuItem : MenuItemBase
 		return x;
 	}
 
-	protected void drawValue(int indent, int y, int color, String text, bool grayed = false)
+	protected void drawValue(int indent, int y, int color, String text, bool grayed = false, bool localize = true)
 	{
-		Menu.DrawOptionText(indent + CursorSpace(), y, color, text, grayed);
+		Menu.DrawOptionText(indent + CursorSpace(), y, color, text, grayed, localize);
 	}
 
 
@@ -999,7 +999,7 @@ class OptionMenuFieldBase : OptionMenuItem
 	{
 		bool grayed = mGrayCheck != null && !mGrayCheck.GetInt();
 		drawLabel(indent, y, selected ? OptionMenuSettings.mFontColorSelection : OptionMenuSettings.mFontColor, grayed);
-		drawValue(indent, y, OptionMenuSettings.mFontColorValue, Represent(), grayed);
+		drawValue(indent, y, OptionMenuSettings.mFontColorValue, Represent(), grayed, false);
 		return indent;
 	}
 
@@ -1068,7 +1068,7 @@ class OptionMenuItemTextField : OptionMenuFieldBase
 		{
 			// reposition the text so that the cursor is visible when in entering mode.
 			String text = Represent();
-			int tlen = Menu.OptionWidth(text) * CleanXfac_1;
+			int tlen = Menu.OptionWidth(text, false) * CleanXfac_1;
 			int newindent = screen.GetWidth() - tlen - CursorSpace();
 			if (newindent < indent) indent = newindent;
 		}


### PR DESCRIPTION
This is a fixed version of https://github.com/ZDoom/gzdoom/pull/1836, which when implemented was broken because I didn't realize that the main menu text in Doom 2 are images rather than drawn text, so it wasn't adequately tested. The problem was really simple but I only now remembered to PR it - I had reversed a boolean condition by accident. The old version was using the for-C++ behavior when called from ZScript and vice-versa.

New behaviour (as expected) in menu text boxes:
![image](https://github.com/ZDoom/gzdoom/assets/9727338/a6671947-25d7-4220-a9c6-de8039277916)

Old behaviour:
![image](https://github.com/ZDoom/gzdoom/assets/9727338/571c533e-c393-4dfb-83ad-fdd54ba500b9)

Also, as can be seen in the screenshots, this version doesn't mess up text that is supposed to be localized.