### PR TITLE
When compat_floormove is enabled, prevent sector floor from lowering if a thing is stuck in the ceiling (vanilla behavior)

### DIFF
--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -6652,6 +6652,12 @@ int P_PushDown(AActor *thing, FChangePosition *cpos)
 
 void PIT_FloorDrop(AActor *thing, FChangePosition *cpos)
 {
+	if ((thing->Level->i_compatflags2 & COMPATF2_FLOORMOVE) && (thing->Top() > thing->ceilingz))
+	{
+		cpos->nofit = true;
+		return;
+	}
+
 	double oldfloorz = thing->floorz;
 	double oldz = thing->Z();
 
@@ -7027,7 +7033,6 @@ bool P_ChangeSector(sector_t *sector, int crunch, double amt, int floorOrCeil, b
 		}
 
 	}
-
 	return cpos.nofit;
 }
 


### PR DESCRIPTION
In vanilla, sector floors won't start lowering if the sector contains a thing that's stuck in the ceiling. This PR adds this behavior to the `compat_floormove` compatibility flag.