### PR TITLE
Allow viewbob speed adjustment through properties

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -48,6 +48,7 @@ class PlayerPawn : Actor
 	color 		DamageFade;				// [CW] Fades for when you are being damaged.
 	double		FlyBob;					// [B] Fly bobbing mulitplier
 	double		ViewBob;				// [SP] ViewBob Multiplier
+	double		ViewBobSpeed;			// [AA] ViewBob speed multiplier
 	double		WaterClimbSpeed;		// [B] Speed when climbing up walls in water
 	double		FullHeight;
 	double		curBob;
@@ -79,6 +80,7 @@ class PlayerPawn : Actor
 	property TeleportFreezeTime: TeleportFreezeTime;
 	property FlyBob: FlyBob;
 	property ViewBob: ViewBob;
+	property ViewBobSpeed: ViewBobSpeed;
 	property WaterClimbSpeed : WaterClimbSpeed;
 	
 	flagdef NoThrustWhenInvul: PlayerFlags, 0;
@@ -128,6 +130,7 @@ class PlayerPawn : Actor
 		Player.AirCapacity 1;
 		Player.FlyBob 1;
 		Player.ViewBob 1;
+		Player.ViewBobSpeed 20;
 		Player.WaterClimbSpeed 3.5;
 		Player.TeleportFreezeTime 18;
 		Obituary "$OB_MPDEFAULT";
@@ -619,7 +622,7 @@ class PlayerPawn : Actor
 		}
 		else
 		{
-			angle = Level.maptime / (20 * TICRATE / 35.) * 360.;
+			angle = Level.maptime / (ViewBobSpeed * TICRATE / 35.) * 360.;
 			bob = player.bob * sin(angle) * (waterlevel > 1 ? 0.25f : 0.5f);
 		}
 


### PR DESCRIPTION
This adds `ViewBobSpeed` to PlayerPawn that is passed in `CalcHeight()` instead of the flat value of 20 and can be adjusted with the `Player.ViewBobSpeed` property (default value 20). This will let modders dynamically adjust how to only how far the camera bobs up and down, but also how _quickly_ it does that, which allows to easily convey a feeling of a heavy, slow-moving character whose view might bob a lot but would do it slowly.