### PR TITLE
Add PreHandlePickup() for unconditional processing of received items

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/health.zs
+++ b/wadsrc/static/zscript/actors/inventory/health.zs
@@ -76,10 +76,19 @@ class Health : Inventory
 	override bool TryPickup (in out Actor other)
 	{
 		PrevHealth = other.player != NULL ? other.player.health : other.health;
+		
+		// [AA] Allows pre-handling of health pickups similarly to how it's
+		// done in Inventory, except the final success depends on the
+		// GiveBody() call, rather than CallHandlePickup() call:
+        EPreHandlePickupResult preHandled = PRE_HANDLE_PICKUP_PASS;
+        if (other.Inv != NULL)
+        {
+            preHandled = other.Inv.CallPreHandlePickup(self);
+        }
 
 		// P_GiveBody adds one new feature, applied only if it is possible to pick up negative health:
-		// Negative values are treated as positive percentages, ie Amount -100 means 100% health, ignoring max amount.
-		if (other.GiveBody(Amount, MaxAmount))
+		// Negative values are treated as positive percentages, ie Amount -100 means 100% health, ignoring max amount.		
+        if (preHandled != PRE_HANDLE_PICKUP_FALSE && (preHandled == PRE_HANDLE_PICKUP_TRUE || other.GiveBody(Amount, MaxAmount)))
 		{
 			GoAwayAndDie();
 			return true;

--- a/wadsrc/static/zscript/actors/inventory/health.zs
+++ b/wadsrc/static/zscript/actors/inventory/health.zs
@@ -80,15 +80,15 @@ class Health : Inventory
 		// [AA] Allows pre-handling of health pickups similarly to how it's
 		// done in Inventory, except the final success depends on the
 		// GiveBody() call, rather than CallHandlePickup() call:
-        EPreHandlePickupResult preHandled = PRE_HANDLE_PICKUP_PASS;
-        if (other.Inv != NULL)
-        {
-            preHandled = other.Inv.CallPreHandlePickup(self);
-        }
+		EPreHandlePickupResult preHandled = PRE_HANDLE_PICKUP_PASS;
+		if (other.Inv != NULL)
+		{
+			preHandled = other.Inv.CallPreHandlePickup(self);
+		}
 
 		// P_GiveBody adds one new feature, applied only if it is possible to pick up negative health:
 		// Negative values are treated as positive percentages, ie Amount -100 means 100% health, ignoring max amount.		
-        if (preHandled != PRE_HANDLE_PICKUP_FALSE && (preHandled == PRE_HANDLE_PICKUP_TRUE || other.GiveBody(Amount, MaxAmount)))
+		if (preHandled != PRE_HANDLE_PICKUP_FALSE && (preHandled == PRE_HANDLE_PICKUP_TRUE || other.GiveBody(Amount, MaxAmount)))
 		{
 			GoAwayAndDie();
 			return true;

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -418,13 +418,13 @@ class Inventory : Actor
 	virtual EPreHandlePickupResult CallPreHandlePickup(Inventory item)
 	{       
 		let me = self;
-        while (me != null)
-        {
+		while (me != null)
+		{
 			EPreHandlePickupResult result = me.PreHandlePickup(item);
-            if (result != PRE_HANDLE_PICKUP_PASS)
+			if (result != PRE_HANDLE_PICKUP_PASS)
 				return result;
-            me = me.Inv;
-        }
+			me = me.Inv;
+		}
 		return PRE_HANDLE_PICKUP_PASS;
 	}
 
@@ -506,7 +506,7 @@ class Inventory : Actor
 		{
 			preHandled = tInv.CallPreHandlePickup(self);
 		}
-        if (preHandled != PRE_HANDLE_PICKUP_FALSE && (preHandled == PRE_HANDLE_PICKUP_TRUE || (tInv != NULL  && tInv.CallHandlePickup (self))))
+		if (preHandled != PRE_HANDLE_PICKUP_FALSE && (preHandled == PRE_HANDLE_PICKUP_TRUE || (tInv != NULL  && tInv.CallHandlePickup (self))))
 		{
 			// Let something else the player is holding intercept the pickup.
 			if (!bPickupGood)


### PR DESCRIPTION
Added functions: `PreHandlePickup()` and `CallPreHandlePickup()`

These function similarly to `HandlePickup()`/`CallHandlePickup()`, except they're called earlier in the chain and unconditionally. This will allow mod authors to process items universally in cases where the item can't be replaced and its `HandlePickup()` override returns true, blocking further processing. For example, this will allow to process powerups every time they're received.

`CallPreHandlePickup()` is also injected in `TryPickup()` of the Health class to allow processing of health pickups.

The return values (true/false/pass) utilize a new `EPreHandlePickupResult` enum added to Inventory.