### PR TITLE
Remove linked list from particles

### DIFF
--- a/src/g_cvars.cpp
+++ b/src/g_cvars.cpp
@@ -126,10 +126,10 @@ CUSTOM_CVAR(Int, r_maxparticles, 4000, CVAR_ARCHIVE | CVAR_NOINITCALL)
 {
 	if (self == 0)
 		self = 4000;
-	else if (self > 65535)
-		self = 65535;
-	else if (self < 100)
-		self = 100;
+	else if (self > ABSOLUTE_MAX_PARTICLES)
+		self = ABSOLUTE_MAX_PARTICLES;
+	else if (self < ABSOLUTE_MIN_PARTICLES)
+		self = ABSOLUTE_MIN_PARTICLES;
 
 	if (gamestate != GS_STARTUP)
 	{

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include <deque>
+
 #include "doomdata.h"
 #include "g_level.h"
 #include "r_defs.h"
@@ -654,11 +656,10 @@ public:
 	DSeqNode *SequenceListHead;
 
 	// [RH] particle globals
-	uint32_t			OldestParticle; // [MC] Oldest particle for replacing with PS_REPLACE
-	uint32_t			ActiveParticles;
-	uint32_t			InactiveParticles;
+
 	TArray<particle_t>	Particles;
-	TArray<uint16_t>	ParticlesInSubsec;
+	std::deque<particle_t>	ReplaceableParticles;
+
 	FThinkerCollection Thinkers;
 
 	TArray<DVector2>	Scrolls;		// NULL if no DScrollers in this level

--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -1644,6 +1644,8 @@ struct subsector_t
 	FPortalCoverage	portalcoverage[2];
 
 	LightmapSurface *lightmap[2];
+
+	TArray<struct particle_t *> particles;
 };
 
 

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -299,7 +299,7 @@ void P_ThinkParticles (FLevelLocals *Level)
 	}
 	Level->Particles.Resize(last_alive + 1);
 
-	last_alive = Level->ReplaceableParticles.size() - 1;
+	last_alive = ((int)Level->ReplaceableParticles.size()) - 1;
 	for(int i = last_alive; i > 0; i--)
 	{
 		particle_t * p = &Level->ReplaceableParticles[i];
@@ -312,7 +312,7 @@ void P_ThinkParticles (FLevelLocals *Level)
 
 	Level->ReplaceableParticles.resize(last_alive + 1);
 
-	ParticleCount = Level->Particles.Size() + Level->ReplaceableParticles.size();
+	ParticleCount = Level->Particles.Size() + (int)Level->ReplaceableParticles.size();
 }
 
 enum PSFlag

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -33,6 +33,9 @@
 
 #pragma once
 
+#define ABSOLUTE_MAX_PARTICLES 65535
+#define ABSOLUTE_MIN_PARTICLES 100
+
 #include "vectors.h"
 #include "doomdef.h"
 #include "renderstyle.h"
@@ -69,13 +72,12 @@ struct particle_t
     int        color;
     FTextureID texture;
     ERenderStyle style;
-    double Roll, RollVel, RollAcc;
-    uint16_t    tnext, snext, tprev;
+    float Roll, RollVel, RollAcc;
     uint8_t    bright;
 	uint8_t flags;
 };
 
-const uint16_t NO_PARTICLE = 0xffff;
+const uint32_t NO_PARTICLE = 0xffffffff;
 
 void P_InitParticles(FLevelLocals *);
 void P_ClearParticles (FLevelLocals *Level);

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -594,16 +594,17 @@ void HWDrawInfo::RenderThings(subsector_t * sub, sector_t * sector)
 void HWDrawInfo::RenderParticles(subsector_t *sub, sector_t *front)
 {
 	SetupSprite.Clock();
-	for (int i = Level->ParticlesInSubsec[sub->Index()]; i != NO_PARTICLE; i = Level->Particles[i].snext)
+	for (uint32_t i = 0; i < sub->particles.Size(); i++)
 	{
+		particle_t * p = sub->particles[i];
 		if (mClipPortal)
 		{
-			int clipres = mClipPortal->ClipPoint(Level->Particles[i].Pos);
+			int clipres = mClipPortal->ClipPoint(p->Pos);
 			if (clipres == PClip_InFront) continue;
 		}
 
 		HWSprite sprite;
-		sprite.ProcessParticle(this, &Level->Particles[i], front);
+		sprite.ProcessParticle(this, p, front);
 	}
 	SetupSprite.Unclock();
 }
@@ -666,7 +667,7 @@ void HWDrawInfo::DoSubsector(subsector_t * sub)
 	}
 
 	// [RH] Add particles
-	if (gl_render_things && Level->ParticlesInSubsec[sub->Index()] != NO_PARTICLE)
+	if (gl_render_things && sub->particles.Size() > 0)
 	{
 		if (multithread)
 		{

--- a/src/rendering/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.cpp
@@ -612,9 +612,9 @@ namespace swrenderer
 		if ((unsigned int)(sub->Index()) < Level->subsectors.Size())
 		{ // Only do it for the main BSP.
 			int lightlevel = (floorlightlevel + ceilinglightlevel) / 2;
-			for (int i = frontsector->Level->ParticlesInSubsec[sub->Index()]; i != NO_PARTICLE; i = frontsector->Level->Particles[i].snext)
+			for (uint32_t i = 0; i < sub->particles.Size(); i++)
 			{
-				RenderParticle::Project(Thread, &frontsector->Level->Particles[i], sub->sector, lightlevel, FakeSide, foggy);
+				RenderParticle::Project(Thread, sub->particles[i], sub->sector, lightlevel, FakeSide, foggy);
 			}
 		}
 


### PR DESCRIPTION
Refactors out the linked lists from the particle system, uses an array for normal particles and a deque for replaceable particles.

(This also adds a `stat particles` command to show the current number of particles)