### PR TITLE
Fixed the variable type of LineTracers' Crossed3DWater.

### DIFF
--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -292,7 +292,7 @@ struct TraceResults native
 
 	native Sector CrossedWater;		// For Boom-style, Transfer_Heights-based deep water
 	native vector3 CrossedWaterPos;	// remember the position so that we can use it for spawning the splash
-	native Sector Crossed3DWater;		// For 3D floor-based deep water
+	native F3DFloor Crossed3DWater;	// For 3D floor-based deep water
 	native vector3 Crossed3DWaterPos;
 }
 


### PR DESCRIPTION
Seems like there was some kind of oversight. Crossed3DWater is an F3DFloor pointer internally, not sector_t. So that variable was broken until now. Never tried accessing sector_t specific data from it like _ceilingplane_, but I'm sure it probably causes a crash due to wrong data or something worse.

![image](https://github.com/ZDoom/gzdoom/assets/56005600/ca51c39c-b9db-4d9a-9b85-71095df823eb)
