### PR TITLE
Store kills/items/secrets in save comment only if visible on HUD

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2275,6 +2275,9 @@ static void PutSaveWads (FSerializer &arc)
 	}
 }
 
+EXTERN_CVAR(Bool, hud_showmonsters)
+EXTERN_CVAR(Bool, hud_showitems)
+EXTERN_CVAR(Bool, hud_showsecrets)
 static void PutSaveComment (FSerializer &arc)
 {
 	int levelTime;
@@ -2291,8 +2294,30 @@ static void PutSaveComment (FSerializer &arc)
 	levelTime = primaryLevel->time / TICRATE;
 	comment.AppendFormat("%s: %02d:%02d:%02d\n", time, levelTime/3600, (levelTime%3600)/60, levelTime%60);
 
-	// Append kills/items/secrets
-	comment.AppendFormat("K: %d/%d - I: %d/%d - S: %d/%d\n", primaryLevel->killed_monsters, primaryLevel->total_monsters, primaryLevel->found_items, primaryLevel->total_items, primaryLevel->found_secrets, primaryLevel->total_secrets);
+	// Append kills/items/secrets (only if visible on HUD to avoid spoiling levels)
+	bool hasStatOnLine = false;
+	if (hud_showmonsters) {
+		comment.AppendFormat("K: %d/%d", primaryLevel->killed_monsters, primaryLevel->total_monsters);
+		hasStatOnLine = true;
+	}
+	if (hud_showitems) {
+		if (hasStatOnLine) {
+			comment.AppendFormat(" - ");
+		}
+		comment.AppendFormat("I: %d/%d", primaryLevel->found_items, primaryLevel->total_items);
+		hasStatOnLine = true;
+	}
+	if (hud_showsecrets) {
+		if (hasStatOnLine) {
+			comment.AppendFormat(" - ");
+		}
+		comment.AppendFormat("S: %d/%d", primaryLevel->found_secrets, primaryLevel->total_secrets);
+		hasStatOnLine = true;
+	}
+
+	if (hasStatOnLine) {
+		comment.AppendFormat("\n");
+	}
 
 	// Append player health and armor
 	const char* const health = "Health";// GStrings("SAVECOMMENT_HEALTH");


### PR DESCRIPTION
- Follow-up to https://github.com/ZDoom/gzdoom/pull/1988.

This prevents spoiling levels when the HUD information is disabled.

This change is not retroactive: it has no effect on existing savegames. You need to save again for this change to have an effect.

- This closes https://github.com/ZDoom/gzdoom/issues/2179.

## Preview

Various combinations of settings being toggled, with the game saved then the load screen being displayed:

![Screenshot_20230921_015547 webp](https://github.com/ZDoom/gzdoom/assets/180032/ee4ad261-2ee0-4111-8f31-bf045ae6d1d0) | ![Screenshot_20230921_015556 webp](https://github.com/ZDoom/gzdoom/assets/180032/205a9a2f-02ee-42c8-b475-a4409bfc24c5)
-|-

![Screenshot_20230921_015606 webp](https://github.com/ZDoom/gzdoom/assets/180032/d67bd916-b424-4a7a-b997-64ebb1f0c5eb) | ![Screenshot_20230921_015633 webp](https://github.com/ZDoom/gzdoom/assets/180032/b77967c7-f7fc-458a-a0a4-8c211b2fd115)
-|-

![Screenshot_20230921_015640 webp](https://github.com/ZDoom/gzdoom/assets/180032/ed432fc5-582c-4da8-ab63-ceb3ed74cad0) | ![Screenshot_20230921_015648 webp](https://github.com/ZDoom/gzdoom/assets/180032/6d875646-68bd-4c2d-bfeb-2ed8194c030b)
-|-

<img width="50%" src="https://github.com/ZDoom/gzdoom/assets/180032/0e130fe5-6e3e-4560-9206-d3aa8d2a2428">
