### PR TITLE
[WIP] ZSprites Part 1

### DIFF
--- a/src/common/engine/namedef.h
+++ b/src/common/engine/namedef.h
@@ -10,6 +10,7 @@ xx(Object)
 xx(Actor)
 xx(Class)
 xx(Thinker)
+xx(ZSprite)
 xx(Crosshairs)
 
 xx(Untranslated)

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -510,7 +510,7 @@ public:
 	int ib_compatflags = 0;
 	int i_compatflags = 0;
 	int i_compatflags2 = 0;
-
+	int TotalZSprites = 0;
 	DSectorMarker *SectorMarker;
 
 	uint8_t		md5[16];			// for savegame validation. If the MD5 does not match the savegame won't be loaded.

--- a/src/playsim/dthinker.cpp
+++ b/src/playsim/dthinker.cpp
@@ -807,7 +807,12 @@ DEFINE_ACTION_FUNCTION_NATIVE(DThinker, ChangeStatNum, ChangeStatNum)
 {
 	PARAM_SELF_PROLOGUE(DThinker);
 	PARAM_INT(stat);
-	ChangeStatNum(self, stat);
+
+	// do not allow ZScript to reposition thinkers in or out of particle ticking.
+	if (stat != STAT_SPRITE && !dynamic_cast<DZSprite*>(self))
+	{
+		ChangeStatNum(self, stat);
+	}
 	return 0;
 }
 

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -1607,18 +1607,6 @@ DEFINE_ACTION_FUNCTION(AActor, A_SpawnDebris)
 // A_SpawnParticle
 //
 //===========================================================================
-enum SPFflag
-{
-	SPF_FULLBRIGHT =		1,
-	SPF_RELPOS =			1 << 1,
-	SPF_RELVEL =			1 << 2,
-	SPF_RELACCEL =			1 << 3,
-	SPF_RELANG =			1 << 4,
-	SPF_NOTIMEFREEZE =		1 << 5,
-	SPF_ROLL =				1 << 6,
-	SPF_REPLACE =           1 << 7,
-	SPF_NO_XY_BILLBOARD =	1 << 8,
-};
 
 DEFINE_ACTION_FUNCTION(AActor, A_SpawnParticle)
 {

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -974,7 +974,8 @@ DZSprite::DZSprite()
 {
 	PT = {};
 	Pos = Vel = Prev = { 0,0,0 };
-	Scale = Offset = { 0,0 };
+	Offset = { 0, 0 };
+	Scale = { 1, 1 };
 	Roll = 0;
 	Alpha = 1.0;
 	Style = 0;
@@ -983,9 +984,16 @@ DZSprite::DZSprite()
 	sub = nullptr;
 }
 
+void DZSprite::CallPostBeginPlay()
+{
+	if (Level) Level->TotalZSprites++; // Must happen no matter what.
+	Super::CallPostBeginPlay();
+}
+
 void DZSprite::OnDestroy()
 {
-	Printf("Poof\n");
+	if (Level) Level->TotalZSprites--; // Same here.
+	Printf("Poof - %d\n", Level->TotalZSprites);
 	Super::OnDestroy();
 }
 
@@ -1089,6 +1097,7 @@ void DZSprite::Tick()
 	PT.flags = Flags;
 	PT.bright = !!(Flags & SPF_FULLBRIGHT);
 	PT.subsector = sub;
+	//Printf("%d %d %d\n", int(PT.Pos.X), int(PT.Pos.Y), int(PT.Pos.Z));
 }
 
 void DZSprite::Serialize(FSerializer& arc)

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -972,26 +972,23 @@ void P_DisconnectEffect (AActor *actor)
 
 DZSprite::DZSprite()
 {
-//	particle_t par = {};
-//	PT = &par;
-//	memset(&PT, 0, sizeof(PT));
 	PT = {};
 	Pos = Vel = Prev = { 0,0,0 };
 	Scale = Offset = { 0,0 };
-	Roll = Alpha = 0;
+	Roll = 0;
+	Alpha = 1.0;
 	Style = 0;
 	Texture = FTextureID();
 	Translation = Flags = 0;
 	sub = nullptr;
 }
-/*
+
 void DZSprite::OnDestroy()
 {
-	assert(PT != nullptr || PT == nullptr);
-	M_Free(&PT);
+	Printf("Poof\n");
 	Super::OnDestroy();
 }
-*/
+
 DZSprite* DZSprite::NewZSprite(FLevelLocals* Level, PClass* type, FSpawnZSpriteParams* params)
 {
 	if (type == nullptr)
@@ -1012,7 +1009,7 @@ DZSprite* DZSprite::NewZSprite(FLevelLocals* Level, PClass* type, FSpawnZSpriteP
 		return nullptr;
 	}
 
-	DZSprite *zs = static_cast<DZSprite*>(Level->CreateThinker(type));
+	DZSprite *zs = static_cast<DZSprite*>(Level->CreateThinker(type, STAT_SPRITE));
 
 	if (zs)
 	{
@@ -1024,6 +1021,14 @@ DZSprite* DZSprite::NewZSprite(FLevelLocals* Level, PClass* type, FSpawnZSpriteP
 		zs->Texture = params->Texture;
 		zs->Style = params->Style;
 		zs->Flags = params->Flags;
+		zs->PT.Pos = zs->Pos;
+		zs->PT.Roll = zs->Roll;
+		zs->PT.size = zs->Scale.X; // short term
+		zs->PT.alpha = zs->Alpha;
+		zs->PT.texture = zs->Texture;
+		zs->PT.style = ERenderStyle(zs->Style);
+		zs->PT.flags = zs->Flags;
+		zs->PT.bright = !!(zs->Flags & SPF_FULLBRIGHT);
 	}
 	return zs;
 }
@@ -1038,6 +1043,7 @@ void DZSprite::Tick()
 	// There won't be a standard particle for this, it's only for graphics.
 	if (!Texture.isValid()) 
 	{	
+		Printf("No valid texture, destroyed");
 		Destroy();
 		return;
 	}
@@ -1077,7 +1083,7 @@ void DZSprite::Tick()
 	PT.Pos = Pos;
 	PT.Roll = Roll;
 	PT.size = Scale.X; // short term
-	PT.alpha = Alpha;
+	PT.alpha = float(Alpha);
 	PT.texture = Texture;
 	PT.style = ERenderStyle(Style);
 	PT.flags = Flags;

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -165,8 +165,8 @@ class DZSprite : public DThinker
 
 public:
 	DZSprite();
-	/*
 	void OnDestroy() override;
+	/*
 	~DZSprite() override;
 	*/
 	// TO DO: Enable states for this class

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -165,6 +165,7 @@ class DZSprite : public DThinker
 
 public:
 	DZSprite();
+	void CallPostBeginPlay() override;
 	void OnDestroy() override;
 	/*
 	~DZSprite() override;

--- a/src/playsim/statnums.h
+++ b/src/playsim/statnums.h
@@ -69,6 +69,7 @@ enum
 	STAT_ACTORMOVER,						// actor movers
 	STAT_SCRIPTS,							// The ACS thinker. This is to ensure that it can't tick before all actors called PostBeginPlay
 	STAT_BOT,								// Bot thinker
+	STAT_SPRITE,						// Particle Ex Thinker
 };
 
 #endif

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -594,31 +594,34 @@ void HWDrawInfo::RenderThings(subsector_t * sub, sector_t * sector)
 void HWDrawInfo::RenderParticles(subsector_t *sub, sector_t *front)
 {
 	SetupSprite.Clock();
+	if (Level->TotalZSprites > 0)
 	{
 		auto it = Level->GetThinkerIterator<DZSprite>(NAME_None, STAT_SPRITE);
 		DZSprite *par = nullptr;
-		while (par = it.Next())
+		while ((par = it.Next()) != nullptr)
 		{
 			if (mClipPortal)
 			{
 				int clipres = mClipPortal->ClipPoint(par->PT.Pos);
 				if (clipres == PClip_InFront) continue;
 			}
-
 			HWSprite sprite;
 			sprite.ProcessParticle(this, &par->PT, front);
 		}
 	}
-	for (int i = Level->ParticlesInSubsec[sub->Index()]; i != NO_PARTICLE; i = Level->Particles[i].snext)
+	if (Level->ParticlesInSubsec[sub->Index()] != NO_PARTICLE)
 	{
-		if (mClipPortal)
+		for (int i = Level->ParticlesInSubsec[sub->Index()]; i != NO_PARTICLE; i = Level->Particles[i].snext)
 		{
-			int clipres = mClipPortal->ClipPoint(Level->Particles[i].Pos);
-			if (clipres == PClip_InFront) continue;
-		}
+			if (mClipPortal)
+			{
+				int clipres = mClipPortal->ClipPoint(Level->Particles[i].Pos);
+				if (clipres == PClip_InFront) continue;
+			}
 
-		HWSprite sprite;
-		sprite.ProcessParticle(this, &Level->Particles[i], front);
+			HWSprite sprite;
+			sprite.ProcessParticle(this, &Level->Particles[i], front);
+		}
 	}
 	SetupSprite.Unclock();
 }
@@ -681,7 +684,7 @@ void HWDrawInfo::DoSubsector(subsector_t * sub)
 	}
 
 	// [RH] Add particles
-	if (gl_render_things && Level->ParticlesInSubsec[sub->Index()] != NO_PARTICLE)
+	if (gl_render_things && (Level->TotalZSprites > 0 || Level->ParticlesInSubsec[sub->Index()] != NO_PARTICLE))
 	{
 		if (multithread)
 		{

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -594,6 +594,21 @@ void HWDrawInfo::RenderThings(subsector_t * sub, sector_t * sector)
 void HWDrawInfo::RenderParticles(subsector_t *sub, sector_t *front)
 {
 	SetupSprite.Clock();
+	{
+		auto it = Level->GetThinkerIterator<DZSprite>(NAME_None, STAT_SPRITE);
+		DZSprite *par = nullptr;
+		while (par = it.Next())
+		{
+			if (mClipPortal)
+			{
+				int clipres = mClipPortal->ClipPoint(par->PT.Pos);
+				if (clipres == PClip_InFront) continue;
+			}
+
+			HWSprite sprite;
+			sprite.ProcessParticle(this, &par->PT, front);
+		}
+	}
 	for (int i = Level->ParticlesInSubsec[sub->Index()]; i != NO_PARTICLE; i = Level->Particles[i].snext)
 	{
 		if (mClipPortal)

--- a/src/scripting/backend/codegen_doom.cpp
+++ b/src/scripting/backend/codegen_doom.cpp
@@ -925,6 +925,11 @@ static DObject *BuiltinNewDoom(PClass *cls, int outerside, int backwardscompatib
 		ThrowAbortException(X_OTHER, "Cannot create actors with 'new'");
 		return nullptr;
 	}
+	if (cls->IsDescendantOf(NAME_ZSprite)) // Same for ZSprites.
+	{
+		ThrowAbortException(X_OTHER, "Cannot create ZSprite or inheriting classes with 'new'. Use 'ZSprite.Spawn' instead.");
+		return nullptr;
+	}
 	if ((vm_warnthinkercreation || !backwardscompatible) && cls->IsDescendantOf(NAME_Thinker))
 	{
 		// This must output a diagnostic warning

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -802,6 +802,10 @@ void InitThingdef()
 	auto fspp = NewStruct("FSpawnParticleParams", nullptr);
 	fspp->Size = sizeof(FSpawnParticleParams);
 	fspp->Align = alignof(FSpawnParticleParams);
+
+	auto fzs = NewStruct("FSpawnZSpriteParams", nullptr);
+	fzs->Size = sizeof(FSpawnZSpriteParams);
+	fzs->Align = alignof(FSpawnZSpriteParams);
 }
 
 void SynthesizeFlagFields()

--- a/wadsrc/static/zscript.txt
+++ b/wadsrc/static/zscript.txt
@@ -42,6 +42,7 @@ version "4.10"
 #include "zscript/destructible.zs"
 #include "zscript/level_postprocessor.zs"
 #include "zscript/level_compatibility.zs"
+#include "zscript/zsprite.zs"
 
 #include "zscript/actors/actor.zs"
 #include "zscript/actors/checks.zs"

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -546,6 +546,7 @@ struct LevelLocals native
 	native String GetEpisodeName();
 
 	native void SpawnParticle(FSpawnParticleParams p);
+	native ZSprite SpawnZSprite(Class<ZSprite> type, FSpawnZSpriteParams p);
 }
 
 // a few values of this need to be readable by the play code.

--- a/wadsrc/static/zscript/zsprite.zs
+++ b/wadsrc/static/zscript/zsprite.zs
@@ -1,0 +1,44 @@
+struct FSpawnZSpriteParams native
+{
+	native Vector3		Pos, Vel;
+	native Vector2		Scale, Offset;
+	native double		Roll, Alpha;
+	native TextureID	Texture;
+	native int			Style;
+	native uint			Translation;
+	native uint			Flags;
+};
+
+Class ZSprite : Thinker native
+{
+	native Vector3		Pos, Vel, Prev;
+	native Vector2		Scale, Offset;
+	native double		Roll, Alpha;
+	native TextureID	Texture;
+	native int			Style;
+	native uint			Translation;
+	native uint			Flags;
+
+	native void SetTranslation(Name trans);
+	native bool IsFrozen();
+
+	static ZSprite Spawn(Class<ZSprite> type, TextureID tex, Vector3 pos, Vector3 vel, double alpha = 1.0, double roll = 0.0, 
+						 Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal, int trans = 0, int flags = 0)
+	{
+		if (!Level)	return null;
+
+		FSpawnZSpriteParams p;
+		p.Texture = tex;
+		p.Pos = pos;
+		p.Vel = vel;
+		p.Alpha = alpha;
+		p.Roll = roll;
+		p.Scale = scale;
+		p.Offset = offset;
+		p.Style = style;
+		p.Translation = trans;
+		p.Flags = flags;
+
+		return level.SpawnZSprite(type, p);
+	}
+}


### PR DESCRIPTION
Added ZSprites, a lighter variant of Actor meant for rendering only that's far lighter on memory. 

Current goal is just to get sprites rendering with only thinkers - for testing purposes this is hooking up to `particle_t` just to see if it can work. Don't mind the mess. It will be cleaned up before the end.

Part 2 will add states.

Part 3 will attempt to add a customized method to render all ZSprites in mass without requiring HWSprite for each. The method for doing this is yet to be determined.

Current issues:
- Does not render in `HWSprite::ProcessParticle`. 