### PR TITLE
Add CenterText MENUDEF flag

### DIFF
--- a/src/common/menu/menu.h
+++ b/src/common/menu/menu.h
@@ -88,6 +88,7 @@ public:
 	EColorRange mFontColor;
 	EColorRange mFontColor2;
 	bool mCenter;
+	bool mCenterText;
 	bool mFromEngine;
 	bool mAnimated;
 	bool mAnimatedTransition;

--- a/src/common/menu/menudef.cpp
+++ b/src/common/menu/menudef.cpp
@@ -431,6 +431,10 @@ static void DoParseListMenuBody(FScanner &sc, DListMenuDescriptor *desc, bool &s
 		{
 			desc->mForceList = true;
 		}
+		else if (sc.Compare("CenterText"))
+		{
+			desc->mCenterText = true;
+		}
 		else
 		{
 			// all item classes from which we know that they support sized scaling.
@@ -768,6 +772,7 @@ static void ParseListMenu(FScanner &sc)
 	desc->mWLeft = 0;
 	desc->mWRight = 0;
 	desc->mCenter = false;
+	desc->mCenterText = false;
 	desc->mFromEngine = fileSystem.GetFileContainer(sc.LumpNum) == 0;	// flags menu if the definition is from the IWAD.
 	desc->mVirtWidth = -2;
 	desc->mCustomSizeSet = false;

--- a/wadsrc/static/zscript/engine/ui/menu/listmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/listmenu.zs
@@ -55,6 +55,7 @@ class ListMenuDescriptor : MenuDescriptor native
 	native int mFontColor;
 	native int mFontColor2;
 	native bool mCenter;
+	native bool mCenterText;
 	native bool mAnimatedTransition;
 	native bool mAnimated;
 	native bool mDontBlur;

--- a/wadsrc/static/zscript/engine/ui/menu/listmenuitems.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/listmenuitems.zs
@@ -161,7 +161,7 @@ class ListMenuItemStaticText : ListMenuItem
 		mText = text;
 		mFont = desc.mFont;
 		mColor = color >= 0? color : desc.mFontColor;
-		mCentered = false;
+		mCentered = desc.mCenterText;
 	}
 
 	void InitDirect(double x, double y, String text, Font font, int color = Font.CR_UNTRANSLATED, bool centered = false)
@@ -294,6 +294,7 @@ class ListMenuItemTextItem : ListMenuItemSelectable
 	override void Draw(bool selected, ListMenuDescriptor desc)
 	{
 		let font = menuDelegate.PickFont(mFont);
+		if (desc.mCenterText) x -= font.StringWidth(mText) / 2;
 		DrawText(desc, font, selected ? mColorSelected : mColor, mXpos, mYpos, mText);
 	}
 


### PR DESCRIPTION
This flag will force text items to be drawn centered, thus offering an easy way to define centered SkillMenu and EpisodeMenu without having to create a custom class for them in ZScript.