### PR TITLE
removed several bad casts to 'long'.

### DIFF
--- a/src/common/filesystem/source/file_7z.cpp
+++ b/src/common/filesystem/source/file_7z.cpp
@@ -65,7 +65,7 @@ struct CZDFileInStream
 	static SRes Read(const ISeekInStream *pp, void *buf, size_t *size)
 	{
 		CZDFileInStream *p = (CZDFileInStream *)pp;
-		auto numread = p->File.Read(buf, (long)*size);
+		auto numread = p->File.Read(buf, (ptrdiff_t)*size);
 		if (numread < 0)
 		{
 			*size = 0;
@@ -96,7 +96,7 @@ struct CZDFileInStream
 		{
 			return 1;
 		}
-		res = (int)p->File.Seek((long)*pos, move_method);
+		res = (int)p->File.Seek((ptrdiff_t)*pos, move_method);
 		*pos = p->File.Tell();
 		return res;
 	}

--- a/src/common/filesystem/source/file_zip.cpp
+++ b/src/common/filesystem/source/file_zip.cpp
@@ -537,7 +537,7 @@ FResourceFile *CheckZip(const char *filename, FileReader &file, LumpFilterInfo* 
 {
 	char head[4];
 
-	if (file.GetLength() >= (long)sizeof(FZipLocalFileHeader))
+	if (file.GetLength() >= (ptrdiff_t)sizeof(FZipLocalFileHeader))
 	{
 		file.Seek(0, FileReader::SeekSet);
 		file.Read(&head, 4);

--- a/src/common/filesystem/source/files_decompress.cpp
+++ b/src/common/filesystem/source/files_decompress.cpp
@@ -402,7 +402,7 @@ public:
 		OutProcessed = 0;
 
 		// Read zip LZMA properties header
-		if (File->Read(header, sizeof(header)) < (long)sizeof(header))
+		if (File->Read(header, sizeof(header)) < (ptrdiff_t)sizeof(header))
 		{
 			DecompressionError("DecompressorLZMA: File too short\n");
 			return false;
@@ -488,7 +488,7 @@ public:
 			return 0;
 		}
 
-		return (long)(next_out - (Byte *)buffer);
+		return (ptrdiff_t)(next_out - (Byte *)buffer);
 	}
 
 	void FillBuffer ()
@@ -698,7 +698,7 @@ public:
 		while(AvailOut && Stream.State != STREAM_FINAL);
 
 		assert(AvailOut == 0);
-		return (long)(Out - (uint8_t*)buffer);
+		return (ptrdiff_t)(Out - (uint8_t*)buffer);
 	}
 };
 

--- a/src/common/rendering/hwrenderer/data/hw_shaderpatcher.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_shaderpatcher.cpp
@@ -246,7 +246,7 @@ FString RemoveLayoutLocationDecl(FString code, const char *inoutkeyword)
 
 		// keyword following the declaration?
 		bool keywordFound = true;
-		long i;
+		ptrdiff_t i;
 		for (i = 0; inoutkeyword[i] != 0; i++)
 		{
 			if (chars[endIndex + i] != inoutkeyword[i])

--- a/src/common/textures/formats/ddstexture.cpp
+++ b/src/common/textures/formats/ddstexture.cpp
@@ -665,7 +665,7 @@ void FDDSTexture::DecompressDXT3 (FileReader &lump, bool premultiplied, uint8_t 
 
 void FDDSTexture::DecompressDXT5 (FileReader &lump, bool premultiplied, uint8_t *buffer, int pixelmode)
 {
-	const long blocklinelen = ((Width + 3) >> 2) << 4;
+	const size_t blocklinelen = ((Width + 3) >> 2) << 4;
 	uint8_t *blockbuff = new uint8_t[blocklinelen];
 	uint8_t *block;
 	PalEntry color[4];

--- a/src/common/textures/formats/tgatexture.cpp
+++ b/src/common/textures/formats/tgatexture.cpp
@@ -97,7 +97,7 @@ FImageSource *TGAImage_TryCreate(FileReader & file, int lumpnum)
 {
 	TGAHeader hdr;
 
-	if (file.GetLength() < (long)sizeof(hdr)) return NULL;
+	if (file.GetLength() < (ptrdiff_t)sizeof(hdr)) return NULL;
 
 	file.Seek(0, FileReader::SeekSet);
 	file.Read(&hdr, sizeof(hdr));

--- a/src/common/utility/cmdlib.cpp
+++ b/src/common/utility/cmdlib.cpp
@@ -986,7 +986,7 @@ void md5Update(FileReader& file, MD5Context& md5, unsigned len)
 	{
 		t = std::min<unsigned>(len, sizeof(readbuf));
 		len -= t;
-		t = (long)file.Read(readbuf, t);
+		t = (unsigned)file.Read(readbuf, t);
 		md5.Update(readbuf, t);
 	}
 }

--- a/src/common/utility/zstring.cpp
+++ b/src/common/utility/zstring.cpp
@@ -603,7 +603,7 @@ ptrdiff_t FString::LastIndexOfAny (const FString &charset) const
 
 ptrdiff_t FString::LastIndexOfAny (const char *charset) const
 {
-	return LastIndexOfAny (charset, long(Len()));
+	return LastIndexOfAny (charset, ptrdiff_t(Len()));
 }
 
 ptrdiff_t FString::LastIndexOfAny (const FString &charset, ptrdiff_t endIndex) const

--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -1049,7 +1049,7 @@ static void PrintSecretString(const char *string, bool thislevel)
 			}
 			else if (string[1] == 'T' || string[1] == 't')
 			{
-				long tid = (long)strtoll(string+2, (char**)&string, 10);
+				int tid = (int)strtoll(string+2, (char**)&string, 10);
 				if (*string == ';') string++;
 				auto it = primaryLevel->GetActorIterator(tid);
 				AActor *actor;

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2413,7 +2413,7 @@ void RenameNerve(FileSystem& fileSystem)
 			continue;
 		}
 		for (int icheck = 0; icheck < numnerveversions; icheck++)
-			if (fr->GetLength() == (long)nervesize[icheck])
+			if (fr->GetLength() == (ptrdiff_t)nervesize[icheck])
 				isizecheck = icheck;
 		if (isizecheck == -1)
 		{
@@ -2474,9 +2474,9 @@ void FixMacHexen(FileSystem& fileSystem)
 	FileReader* reader = fileSystem.GetFileReader(fileSystem.GetIwadNum());
 	auto iwadSize = reader->GetLength();
 
-	static const long DEMO_SIZE = 13596228;
-	static const long BETA_SIZE = 13749984;
-	static const long FULL_SIZE = 21078584;
+	static const ptrdiff_t DEMO_SIZE = 13596228;
+	static const ptrdiff_t BETA_SIZE = 13749984;
+	static const ptrdiff_t FULL_SIZE = 21078584;
 
 	if (DEMO_SIZE != iwadSize
 		&& BETA_SIZE != iwadSize

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -1400,7 +1400,7 @@ static int PatchThing (int thingy)
 			{
 				if (IsNum(strval))
 				{
-					value |= (unsigned long)strtoll(strval, NULL, 10);
+					value |= (uint32_t)strtoll(strval, NULL, 10);
 					vchanged = true;
 				}
 				else
@@ -1526,7 +1526,7 @@ static int PatchThing (int thingy)
 				{
 					if (IsNum (strval))
 					{
-						value[0] |= (unsigned long)strtoll(strval, NULL, 10);
+						value[0] |= (uint32_t)strtoll(strval, NULL, 10);
 						vchanged[0] = true;
 					}
 					else
@@ -1918,7 +1918,7 @@ static int PatchFrame (int frameNum)
 			{
 				if (IsNum(strval))
 				{
-					value |= (unsigned long)strtoll(strval, NULL, 10);
+					value |= (uint32_t)strtoll(strval, NULL, 10);
 					vchanged = true;
 				}
 				else
@@ -2223,7 +2223,7 @@ static int PatchWeapon (int weapNum)
 			{
 				if (IsNum(strval))
 				{
-					value |= (unsigned long)strtoll(strval, NULL, 10);
+					value |= (uint32_t)strtoll(strval, NULL, 10);
 					vchanged = true;
 				}
 				else
@@ -3713,8 +3713,10 @@ void FinishDehPatch ()
 
 		type->ActorInfo()->Replacement = subclass;
 		subclass->ActorInfo()->Replacee = type;
+		subclass->ActorInfo()->LightAssociations = type->ActorInfo()->LightAssociations;
 		// If this actor was already replaced by another actor, copy that
 		// replacement over to this item.
+
 		if (old_replacement != NULL)
 		{
 			subclass->ActorInfo()->Replacement = old_replacement;

--- a/src/gamedata/decallib.cpp
+++ b/src/gamedata/decallib.cpp
@@ -342,7 +342,7 @@ uint16_t FDecalLib::GetDecalID (FScanner &sc)
 	}
 	else
 	{
-		unsigned long num = strtoul (sc.String, NULL, 10);
+		uint64_t num = strtoull (sc.String, NULL, 10);
 		if (num < 1 || num > 65535)
 		{
 			sc.ScriptError ("Decal ID must be between 1 and 65535");

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -10741,7 +10741,7 @@ static int sort_by_runs(const void *a_, const void *b_)
 	return b->ProfileData->NumRuns - a->ProfileData->NumRuns;
 }
 
-static void ShowProfileData(TArray<ProfileCollector> &profiles, long ilimit,
+static void ShowProfileData(TArray<ProfileCollector> &profiles, int ilimit,
 	int (*sorter)(const void *, const void *), bool functions)
 {
 	static const char *const typelabels[2] = { "script", "function" };
@@ -10759,7 +10759,7 @@ static void ShowProfileData(TArray<ProfileCollector> &profiles, long ilimit,
 
 	if (ilimit > 0)
 	{
-		Printf(TEXTCOLOR_ORANGE "Top %ld %ss:\n", ilimit, typelabels[functions]);
+		Printf(TEXTCOLOR_ORANGE "Top %lld %ss:\n", ilimit, typelabels[functions]);
 		limit = (unsigned int)ilimit;
 	}
 	else
@@ -10825,7 +10825,7 @@ void ACSProfile(FLevelLocals *Level, FCommandLine &argv)
 	static const uint8_t sort_match_len[] = {   1,     2,     2,     1,      1 };
 
 		TArray<ProfileCollector> ScriptProfiles, FuncProfiles;
-		long limit = 10;
+		int limit = 10;
 	int (*sorter)(const void *, const void *) = sort_by_total_instr;
 
 	assert(countof(sort_names) == countof(sort_match_len));
@@ -10847,7 +10847,7 @@ void ACSProfile(FLevelLocals *Level, FCommandLine &argv)
 		{
 			// If it's a number, set the display limit.
 			char *endptr;
-			long num = strtol(argv[i], &endptr, 0);
+			int num = (int)strtoll(argv[i], &endptr, 0);
 			if (endptr != argv[i])
 			{
 				limit = num;

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -107,7 +107,7 @@ void FPortalSceneState::EndFrame(HWDrawInfo *di, FRenderState &state)
 
 	if (gl_portalinfo)
 	{
-		indent.Truncate(long(indent.Len()-2));
+		indent.Truncate(indent.Len()-2);
 		Printf("%s}\n", indent.GetChars());
 		if (indent.Len() == 0) gl_portalinfo = false;
 	}

--- a/src/utility/nodebuilder/nodebuild_utility.cpp
+++ b/src/utility/nodebuilder/nodebuild_utility.cpp
@@ -460,7 +460,7 @@ void FNodeBuilder::FindPolyContainers (TArray<FPolyStart> &spots, TArray<FPolySt
 						if (dist < closestdist && dist >= 0)
 						{
 							closestdist = dist;
-							closestseg = (long)j;
+							closestseg = j;
 						}
 					}
 				}


### PR DESCRIPTION
The 'long' type should generally be avoided because its size differs on Windows and Linux/Mac so it is almost guaranteed to cause undefined behavior.

This was just a quick look over the code, most of these occurences were overlooked when the file system was converted to 64 bit, but a few are also older.
