### PR TITLE
Fix inheritance for bNoSaveGame

### DIFF
--- a/src/gamedata/info.cpp
+++ b/src/gamedata/info.cpp
@@ -487,6 +487,8 @@ void PClassActor::InitializeDefaults()
 			{
 				memset(Defaults + ParentClass->Size, 0, Size - ParentClass->Size);
 			}
+
+			optr->ObjectFlags = ((DObject*)ParentClass->Defaults)->ObjectFlags & OF_Transient;
 		}
 		else
 		{


### PR DESCRIPTION
DObject data was zeroed out during inheritance, and i didn't notice that while implementing bNoSaveGame, this fixes the flag in those cases
[NoSaveGameInheritanceTest.zip](https://github.com/ZDoom/gzdoom/files/12819686/NoSaveGameInheritanceTest.zip)
