### PR TITLE
Misc fixes and zscript stuff

### DIFF
--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -7180,7 +7180,7 @@ bool FxStructMember::RequestAddress(FCompileContext &ctx, bool *writable)
 	if (membervar->Flags & VARF_Meta)
 	{
 		// Meta variables are read only.
-		*writable = false;
+		if(writable != nullptr) *writable = false;
 	}
 	else if (writable != nullptr)
 	{

--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -2489,7 +2489,7 @@ FxExpression *FxAssign::Resolve(FCompileContext &ctx)
 
 			if (btype->isDynArray())
 			{
-				if(ctx.Version >= MakeVersion(4, 11, 0))
+				if(ctx.Version >= MakeVersion(4, 11, 1))
 				{
 					FArgumentList args;
 					args.Push(Right);
@@ -2502,12 +2502,14 @@ FxExpression *FxAssign::Resolve(FCompileContext &ctx)
 				{
 					if(Base->ValueType->isRealPointer() && Right->ValueType->isRealPointer())
 					{
-						ScriptPosition.Message(MSG_WARNING, "Dynamic Array assignments not allowed in ZScript versions below 4.11, use the Copy() or Move() functions instead\n"
-											  TEXTCOLOR_RED "!! Assigning an out array pointer to another out array pointer does not alter either of the underlying arrays' values below ZScript version 4.11 !!");
+						ScriptPosition.Message(MSG_WARNING, "Dynamic Array assignments not allowed in ZScript versions below 4.11.1, use the Copy() or Move() functions instead\n"
+											  TEXTCOLOR_RED "  Assigning an out array pointer to another out array pointer\n"
+															"  does not alter either of the underlying arrays' values\n"
+															"  it only swaps the pointers below ZScript version 4.11.1!!");
 					}
 					else
 					{
-						ScriptPosition.Message(MSG_ERROR, "Dynamic Array assignments not allowed in ZScript versions below 4.11, use the Copy() or Move() functions instead");
+						ScriptPosition.Message(MSG_ERROR, "Dynamic Array assignments not allowed in ZScript versions below 4.11.1, use the Copy() or Move() functions instead");
 						delete this;
 						return nullptr;
 					}
@@ -2515,7 +2517,7 @@ FxExpression *FxAssign::Resolve(FCompileContext &ctx)
 			}
 			else if (btype->isMap())
 			{
-				if(ctx.Version >= MakeVersion(4, 11, 0))
+				if(ctx.Version >= MakeVersion(4, 11, 1))
 				{
 					FArgumentList args;
 					args.Push(Right);
@@ -2528,12 +2530,14 @@ FxExpression *FxAssign::Resolve(FCompileContext &ctx)
 				{
 					if(Base->ValueType->isRealPointer() && Right->ValueType->isRealPointer())
 					{ // don't break existing code, but warn that it's a no-op
-						ScriptPosition.Message(MSG_WARNING, "Map assignments not allowed in ZScript versions below 4.11, use the Copy() or Move() functions instead\n"
-											  TEXTCOLOR_RED "!! Assigning an out map pointer to another out map pointer does not alter either of the underlying maps' values below ZScript version 4.11 !!");
+						ScriptPosition.Message(MSG_WARNING, "Map assignments not allowed in ZScript versions below 4.11.1, use the Copy() or Move() functions instead\n"
+											  TEXTCOLOR_RED "  Assigning an out map pointer to another out map pointer\n"
+															"  does not alter either of the underlying maps' values\n"
+															"  it only swaps the pointers below ZScript version 4.11.1!!");
 					}
 					else
 					{
-						ScriptPosition.Message(MSG_ERROR, "Map assignments not allowed in ZScript versions below 4.11, use the Copy() or Move() functions instead");
+						ScriptPosition.Message(MSG_ERROR, "Map assignments not allowed in ZScript versions below 4.11.1, use the Copy() or Move() functions instead");
 						delete this;
 						return nullptr;
 					}
@@ -2550,7 +2554,9 @@ FxExpression *FxAssign::Resolve(FCompileContext &ctx)
 				if(Base->ValueType->isRealPointer() && Right->ValueType->isRealPointer())
 				{ // don't break existing code, but warn that it's a no-op
 					ScriptPosition.Message(MSG_WARNING, "Struct assignment not implemented yet\n"
-										  TEXTCOLOR_RED "!! Assigning an out struct pointer to another out struct pointer does not alter either of the underlying structs' values !!");
+										  TEXTCOLOR_RED "  Assigning an out struct pointer to another out struct pointer\n"
+														"  does not alter either of the underlying structs' values\n"
+														"  it only swaps the pointers!!");
 				}
 				else
 				{

--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -2454,7 +2454,17 @@ FxExpression *FxAssign::Resolve(FCompileContext &ctx)
 			SAFE_RESOLVE(Right, ctx);
 		}
 	}
-	else if (Base->ValueType == Right->ValueType)
+	else if (Right->IsNativeStruct() && Base->ValueType->isRealPointer() && Base->ValueType->toPointer()->PointedType == Right->ValueType)
+	{
+		// allow conversion of native structs to pointers of the same type. This is necessary to assign elements from global arrays like players, sectors, etc. to local pointers.
+		// For all other types this is not needed. Structs are not assignable and classes can only exist as references.
+		Right->RequestAddress(ctx, nullptr);
+		Right->ValueType = Base->ValueType;
+	}
+	else if (	Base->ValueType == Right->ValueType
+			|| (Base->ValueType->isRealPointer() && Base->ValueType->toPointer()->PointedType == Right->ValueType)
+			|| (Right->ValueType->isRealPointer() && Right->ValueType->toPointer()->PointedType == Base->ValueType)
+			)
 	{
 		if (Base->ValueType->isArray())
 		{
@@ -2462,27 +2472,96 @@ FxExpression *FxAssign::Resolve(FCompileContext &ctx)
 			delete this;
 			return nullptr;
 		}
-		else if (Base->IsDynamicArray())
+		else if(!Base->IsVector() && !Base->IsQuaternion())
 		{
-			ScriptPosition.Message(MSG_ERROR, "Cannot assign dynamic arrays, use Copy() or Move() function instead");
-			delete this;
-			return nullptr;
+			PType * btype = Base->ValueType;
+
+			if(btype->isRealPointer())
+			{
+				PType * p = static_cast<PPointer *>(btype)->PointedType;
+				if(	  p->isDynArray() || p->isMap()
+				  || (p->isStruct() && !static_cast<PStruct*>(p)->isNative)
+				  )
+				{ //un-pointer dynarrays, maps and non-native structs for assignment checking
+					btype = p;
+				}
+			}
+
+			if (btype->isDynArray())
+			{
+				if(ctx.Version >= MakeVersion(4, 11, 0))
+				{
+					FArgumentList args;
+					args.Push(Right);
+					auto call = new FxMemberFunctionCall(Base, NAME_Copy, args, ScriptPosition);
+					Right = Base = nullptr;
+					delete this;
+					return call->Resolve(ctx);
+				}
+				else
+				{
+					if(Base->ValueType->isRealPointer() && Right->ValueType->isRealPointer())
+					{
+						ScriptPosition.Message(MSG_WARNING, "Dynamic Array assignments not allowed in ZScript versions below 4.11, use the Copy() or Move() functions instead\n"
+											  TEXTCOLOR_RED "!! Assigning an out array pointer to another out array pointer does not alter either of the underlying arrays' values below ZScript version 4.11 !!");
+					}
+					else
+					{
+						ScriptPosition.Message(MSG_ERROR, "Dynamic Array assignments not allowed in ZScript versions below 4.11, use the Copy() or Move() functions instead");
+						delete this;
+						return nullptr;
+					}
+				}
+			}
+			else if (btype->isMap())
+			{
+				if(ctx.Version >= MakeVersion(4, 11, 0))
+				{
+					FArgumentList args;
+					args.Push(Right);
+					auto call = new FxMemberFunctionCall(Base, NAME_Copy, args, ScriptPosition);
+					Right = Base = nullptr;
+					delete this;
+					return call->Resolve(ctx);
+				}
+				else
+				{
+					if(Base->ValueType->isRealPointer() && Right->ValueType->isRealPointer())
+					{ // don't break existing code, but warn that it's a no-op
+						ScriptPosition.Message(MSG_WARNING, "Map assignments not allowed in ZScript versions below 4.11, use the Copy() or Move() functions instead\n"
+											  TEXTCOLOR_RED "!! Assigning an out map pointer to another out map pointer does not alter either of the underlying maps' values below ZScript version 4.11 !!");
+					}
+					else
+					{
+						ScriptPosition.Message(MSG_ERROR, "Map assignments not allowed in ZScript versions below 4.11, use the Copy() or Move() functions instead");
+						delete this;
+						return nullptr;
+					}
+				}
+			}
+			else if (btype->isMapIterator())
+			{
+				ScriptPosition.Message(MSG_ERROR, "Cannot assign map iterators");
+				delete this;
+				return nullptr;
+			}
+			else if (btype->isStruct())
+			{
+				if(Base->ValueType->isRealPointer() && Right->ValueType->isRealPointer())
+				{ // don't break existing code, but warn that it's a no-op
+					ScriptPosition.Message(MSG_WARNING, "Struct assignment not implemented yet\n"
+										  TEXTCOLOR_RED "!! Assigning an out struct pointer to another out struct pointer does not alter either of the underlying structs' values !!");
+				}
+				else
+				{
+					ScriptPosition.Message(MSG_ERROR, "Struct assignment not implemented yet");
+					delete this;
+					return nullptr;
+				}
+			}
 		}
-		if (!Base->IsVector() && !Base->IsQuaternion() && Base->ValueType->isStruct())
-		{
-			ScriptPosition.Message(MSG_ERROR, "Struct assignment not implemented yet");
-			delete this;
-			return nullptr;
-		}
+
 		// Both types are the same so this is ok.
-	}
-	else if (Right->IsNativeStruct() && Base->ValueType->isRealPointer() && Base->ValueType->toPointer()->PointedType == Right->ValueType)
-	{
-		// allow conversion of native structs to pointers of the same type. This is necessary to assign elements from global arrays like players, sectors, etc. to local pointers.
-		// For all other types this is not needed. Structs are not assignable and classes can only exist as references.
-		bool writable;
-		Right->RequestAddress(ctx, &writable);
-		Right->ValueType = Base->ValueType;
 	}
 	else
 	{

--- a/src/common/scripting/backend/vmbuilder.cpp
+++ b/src/common/scripting/backend/vmbuilder.cpp
@@ -37,6 +37,7 @@
 #include "m_argv.h"
 #include "c_cvars.h"
 #include "jit.h"
+#include "filesystem.h"
 
 CVAR(Bool, strictdecorate, false, CVAR_GLOBALCONFIG | CVAR_ARCHIVE)
 
@@ -922,13 +923,17 @@ void FFunctionBuildList::Build()
 	VMFunction::CreateRegUseInfo();
 	FScriptPosition::StrictErrors = strictdecorate;
 
-	if (FScriptPosition::ErrorCounter == 0 && Args->CheckParm("-dumpjit")) DumpJit();
+	if (FScriptPosition::ErrorCounter == 0)
+	{
+		if (Args->CheckParm("-dumpjit")) DumpJit(true);
+		else if (Args->CheckParm("-dumpjitmod")) DumpJit(false);
+	}
 	mItems.Clear();
 	mItems.ShrinkToFit();
 	FxAlloc.FreeAllBlocks();
 }
 
-void FFunctionBuildList::DumpJit()
+void FFunctionBuildList::DumpJit(bool include_gzdoom_pk3)
 {
 #ifdef HAVE_VM_JIT
 	FILE *dump = fopen("dumpjit.txt", "w");
@@ -937,7 +942,7 @@ void FFunctionBuildList::DumpJit()
 
 	for (auto &item : mItems)
 	{
-		JitDumpLog(dump, item.Function);
+		if(include_gzdoom_pk3 || fileSystem.GetFileContainer(item.Lump)) JitDumpLog(dump, item.Function);
 	}
 
 	fclose(dump);

--- a/src/common/scripting/backend/vmbuilder.h
+++ b/src/common/scripting/backend/vmbuilder.h
@@ -155,7 +155,7 @@ class FFunctionBuildList
 
 	TArray<Item> mItems;
 
-	void DumpJit();
+	void DumpJit(bool include_gzdoom_pk3);
 
 public:
 	VMFunction *AddFunction(PNamespace *curglobals, const VersionInfo &ver, PFunction *func, FxExpression *code, const FString &name, bool fromdecorate, int currentstate, int statecnt, int lumpnum);

--- a/src/common/scripting/core/types.cpp
+++ b/src/common/scripting/core/types.cpp
@@ -2957,7 +2957,7 @@ bool PStruct::ReadValue(FSerializer &ar, const char *key, void *addr) const
 PField *PStruct::AddField(FName name, PType *type, uint32_t flags)
 {
 	assert(type->Size > 0);
-	return Symbols.AddField(name, type, flags, Size, &Align);
+	return Symbols.AddField(name, type, flags, Size, &Align, mDefFileNo);
 }
 
 //==========================================================================

--- a/src/common/scripting/core/types.cpp
+++ b/src/common/scripting/core/types.cpp
@@ -2377,59 +2377,49 @@ void PMap::GetTypeIDs(intptr_t &id1, intptr_t &id2) const
 //
 //==========================================================================
 
+#define FOR_EACH_MAP_TYPE(FN) \
+		case PMap::MAP_I32_I8: \
+			FN( uint32_t , uint8_t ) \
+		case PMap::MAP_I32_I16: \
+			FN( uint32_t , uint16_t ) \
+		case PMap::MAP_I32_I32: \
+			FN( uint32_t , uint32_t ) \
+		case PMap::MAP_I32_F32: \
+			FN( uint32_t , float ) \
+		case PMap::MAP_I32_F64: \
+			FN( uint32_t , double ) \
+		case PMap::MAP_I32_OBJ: \
+			FN( uint32_t , DObject* ) \
+		case PMap::MAP_I32_PTR: \
+			FN( uint32_t , void* ) \
+		case PMap::MAP_I32_STR: \
+			FN( uint32_t , FString ) \
+		case PMap::MAP_STR_I8: \
+			FN( FString , uint8_t ) \
+		case PMap::MAP_STR_I16: \
+			FN( FString , uint16_t ) \
+		case PMap::MAP_STR_I32: \
+			FN( FString , uint32_t ) \
+		case PMap::MAP_STR_F32: \
+			FN( FString , float ) \
+		case PMap::MAP_STR_F64: \
+			FN( FString , double ) \
+		case PMap::MAP_STR_OBJ: \
+			FN( FString , DObject* ) \
+		case PMap::MAP_STR_PTR: \
+			FN( FString , void* ) \
+		case PMap::MAP_STR_STR: \
+			FN( FString , FString )
+
 void PMap::Construct(void * addr) const {
 	switch(BackingClass)
 	{
-	case MAP_I32_I8:
-		new(addr) ZSMap<uint32_t, uint8_t>();
-		break;
-	case MAP_I32_I16:
-		new(addr) ZSMap<uint32_t, uint16_t>();
-		break;
-	case MAP_I32_I32:
-		new(addr) ZSMap<uint32_t, uint32_t>();
-		break;
-	case MAP_I32_F32:
-		new(addr) ZSMap<uint32_t, float>();
-		break;
-	case MAP_I32_F64:
-		new(addr) ZSMap<uint32_t, double>();
-		break;
-	case MAP_I32_OBJ:
-		new(addr) ZSMap<uint32_t, DObject*>();
-		break;
-	case MAP_I32_PTR:
-		new(addr) ZSMap<uint32_t, void*>();
-		break;
-	case MAP_I32_STR:
-		new(addr) ZSMap<uint32_t, FString>();
-		break;
-	case MAP_STR_I8:
-		new(addr) ZSMap<FString, uint8_t>();
-		break;
-	case MAP_STR_I16:
-		new(addr) ZSMap<FString, uint16_t>();
-		break;
-	case MAP_STR_I32:
-		new(addr) ZSMap<FString, uint32_t>();
-		break;
-	case MAP_STR_F32:
-		new(addr) ZSMap<FString, float>();
-		break;
-	case MAP_STR_F64:
-		new(addr) ZSMap<FString, double>();
-		break;
-	case MAP_STR_OBJ:
-		new(addr) ZSMap<FString, DObject*>();
-		break;
-	case MAP_STR_PTR:
-		new(addr) ZSMap<FString, void*>();
-		break;
-	case MAP_STR_STR:
-		new(addr) ZSMap<FString, FString>();
-		break;
+		#define MAP_CONSTRUCT(KT, VT) new(addr) ZSMap< KT, VT >(); break;
+		FOR_EACH_MAP_TYPE(MAP_CONSTRUCT)
+		#undef MAP_CONSTRUCT
 	};
 }
+
 
 void PMap::InitializeValue(void *addr, const void *def) const
 {
@@ -2446,54 +2436,9 @@ void PMap::DestroyValue(void *addr) const
 {
 	switch(BackingClass)
 	{
-	case MAP_I32_I8:
-		static_cast<ZSMap<uint32_t, uint8_t>*>(addr)->~ZSMap();
-		break;
-	case MAP_I32_I16:
-		static_cast<ZSMap<uint32_t, uint16_t>*>(addr)->~ZSMap();
-		break;
-	case MAP_I32_I32:
-		static_cast<ZSMap<uint32_t, uint32_t>*>(addr)->~ZSMap();
-		break;
-	case MAP_I32_F32:
-		static_cast<ZSMap<uint32_t, float>*>(addr)->~ZSMap();
-		break;
-	case MAP_I32_F64:
-		static_cast<ZSMap<uint32_t, double>*>(addr)->~ZSMap();
-		break;
-	case MAP_I32_OBJ:
-		static_cast<ZSMap<uint32_t, DObject*>*>(addr)->~ZSMap();
-		break;
-	case MAP_I32_PTR:
-		static_cast<ZSMap<uint32_t, void*>*>(addr)->~ZSMap();
-		break;
-	case MAP_I32_STR:
-		static_cast<ZSMap<uint32_t, FString>*>(addr)->~ZSMap();
-		break;
-	case MAP_STR_I8:
-		static_cast<ZSMap<FString, uint8_t>*>(addr)->~ZSMap();
-		break;
-	case MAP_STR_I16:
-		static_cast<ZSMap<FString, uint16_t>*>(addr)->~ZSMap();
-		break;
-	case MAP_STR_I32:
-		static_cast<ZSMap<FString, uint32_t>*>(addr)->~ZSMap();
-		break;
-	case MAP_STR_F32:
-		static_cast<ZSMap<FString, float>*>(addr)->~ZSMap();
-		break;
-	case MAP_STR_F64:
-		static_cast<ZSMap<FString, double>*>(addr)->~ZSMap();
-		break;
-	case MAP_STR_OBJ:
-		static_cast<ZSMap<FString, DObject*>*>(addr)->~ZSMap();
-		break;
-	case MAP_STR_PTR:
-		static_cast<ZSMap<FString, void*>*>(addr)->~ZSMap();
-		break;
-	case MAP_STR_STR:
-		static_cast<ZSMap<FString, FString>*>(addr)->~ZSMap();
-		break;
+		#define MAP_DESTRUCT(KT, VT) static_cast<ZSMap< KT, VT >*>(addr)->~ZSMap(); break;
+		FOR_EACH_MAP_TYPE(MAP_DESTRUCT)
+		#undef MAP_DESTRUCT
 	}
 }
 
@@ -2568,54 +2513,9 @@ void PMap::WriteValue(FSerializer &ar, const char *key, const void *addr) const
 	{
 		switch(BackingClass)
 		{
-		case MAP_I32_I8:
-			PMapValueWriter(ar, static_cast<const ZSMap<uint32_t, uint8_t>*>(addr), this);
-			break;
-		case MAP_I32_I16:
-			PMapValueWriter(ar, static_cast<const ZSMap<uint32_t, uint16_t>*>(addr), this);
-			break;
-		case MAP_I32_I32:
-			PMapValueWriter(ar, static_cast<const ZSMap<uint32_t, uint32_t>*>(addr), this);
-			break;
-		case MAP_I32_F32:
-			PMapValueWriter(ar, static_cast<const ZSMap<uint32_t, float>*>(addr), this);
-			break;
-		case MAP_I32_F64:
-			PMapValueWriter(ar, static_cast<const ZSMap<uint32_t, double>*>(addr), this);
-			break;
-		case MAP_I32_OBJ:
-			PMapValueWriter(ar, static_cast<const ZSMap<uint32_t, DObject*>*>(addr), this);
-			break;
-		case MAP_I32_PTR:
-			PMapValueWriter(ar, static_cast<const ZSMap<uint32_t, void*>*>(addr), this);
-			break;
-		case MAP_I32_STR:
-			PMapValueWriter(ar, static_cast<const ZSMap<uint32_t, FString>*>(addr), this);
-			break;
-		case MAP_STR_I8:
-			PMapValueWriter(ar, static_cast<const ZSMap<FString, uint8_t>*>(addr), this);
-			break;
-		case MAP_STR_I16:
-			PMapValueWriter(ar, static_cast<const ZSMap<FString, uint16_t>*>(addr), this);
-			break;
-		case MAP_STR_I32:
-			PMapValueWriter(ar, static_cast<const ZSMap<FString, uint32_t>*>(addr), this);
-			break;
-		case MAP_STR_F32:
-			PMapValueWriter(ar, static_cast<const ZSMap<FString, float>*>(addr), this);
-			break;
-		case MAP_STR_F64:
-			PMapValueWriter(ar, static_cast<const ZSMap<FString, double>*>(addr), this);
-			break;
-		case MAP_STR_OBJ:
-			PMapValueWriter(ar, static_cast<const ZSMap<FString, DObject*>*>(addr), this);
-			break;
-		case MAP_STR_PTR:
-			PMapValueWriter(ar, static_cast<const ZSMap<FString, void*>*>(addr), this);
-			break;
-		case MAP_STR_STR:
-			PMapValueWriter(ar, static_cast<const ZSMap<FString, FString>*>(addr), this);
-			break;
+			#define MAP_WRITE(KT, VT) PMapValueWriter(ar, static_cast<const ZSMap< KT, VT >*>(addr), this); break;
+			FOR_EACH_MAP_TYPE(MAP_WRITE)
+			#undef MAP_WRITE
 		}
 		ar.EndObject();
 	}
@@ -2668,38 +2568,9 @@ bool PMap::ReadValue(FSerializer &ar, const char *key, void *addr) const
 	{
 		switch(BackingClass)
 		{
-		case MAP_I32_I8:
-			return PMapValueReader(ar, static_cast<ZSMap<uint32_t, uint8_t>*>(addr), this);
-		case MAP_I32_I16:
-			return PMapValueReader(ar, static_cast<ZSMap<uint32_t, uint16_t>*>(addr), this);
-		case MAP_I32_I32:
-			return PMapValueReader(ar, static_cast<ZSMap<uint32_t, uint32_t>*>(addr), this);
-		case MAP_I32_F32:
-			return PMapValueReader(ar, static_cast<ZSMap<uint32_t, float>*>(addr), this);
-		case MAP_I32_F64:
-			return PMapValueReader(ar, static_cast<ZSMap<uint32_t, double>*>(addr), this);
-		case MAP_I32_OBJ:
-			return PMapValueReader(ar, static_cast<ZSMap<uint32_t, DObject*>*>(addr), this);
-		case MAP_I32_PTR:
-			return PMapValueReader(ar, static_cast<ZSMap<uint32_t, void*>*>(addr), this);
-		case MAP_I32_STR:
-			return PMapValueReader(ar, static_cast<ZSMap<uint32_t, FString>*>(addr), this);
-		case MAP_STR_I8:
-			return PMapValueReader(ar, static_cast<ZSMap<FString, uint8_t>*>(addr), this);
-		case MAP_STR_I16:
-			return PMapValueReader(ar, static_cast<ZSMap<FString, uint16_t>*>(addr), this);
-		case MAP_STR_I32:
-			return PMapValueReader(ar, static_cast<ZSMap<FString, uint32_t>*>(addr), this);
-		case MAP_STR_F32:
-			return PMapValueReader(ar, static_cast<ZSMap<FString, float>*>(addr), this);
-		case MAP_STR_F64:
-			return PMapValueReader(ar, static_cast<ZSMap<FString, double>*>(addr), this);
-		case MAP_STR_OBJ:
-			return PMapValueReader(ar, static_cast<ZSMap<FString, DObject*>*>(addr), this);
-		case MAP_STR_PTR:
-			return PMapValueReader(ar, static_cast<ZSMap<FString, void*>*>(addr), this);
-		case MAP_STR_STR:
-			return PMapValueReader(ar, static_cast<ZSMap<FString, FString>*>(addr), this);
+			#define MAP_READ(KT, VT) return PMapValueReader(ar, static_cast<ZSMap< KT, VT >*>(addr), this);
+			FOR_EACH_MAP_TYPE(MAP_READ)
+			#undef MAP_READ
 		}
 	}
 	return false;
@@ -2790,11 +2661,11 @@ PMap *NewMap(PType *keyType, PType *valueType)
 	return (PMap *)mapType;
 }
 
-/* PMap *******************************************************************/
+/* PMapIterator ***********************************************************/
 
 //==========================================================================
 //
-// PMap - Parameterized Constructor
+// PMapIterator - Parameterized Constructor
 //
 //==========================================================================
 
@@ -2844,54 +2715,9 @@ void PMapIterator::GetTypeIDs(intptr_t &id1, intptr_t &id2) const
 void PMapIterator::Construct(void * addr) const {
 	switch(BackingClass)
 	{
-	case PMap::MAP_I32_I8:
-		new(addr) ZSMapIterator<uint32_t, uint8_t>();
-		break;
-	case PMap::MAP_I32_I16:
-		new(addr) ZSMapIterator<uint32_t, uint16_t>();
-		break;
-	case PMap::MAP_I32_I32:
-		new(addr) ZSMapIterator<uint32_t, uint32_t>();
-		break;
-	case PMap::MAP_I32_F32:
-		new(addr) ZSMapIterator<uint32_t, float>();
-		break;
-	case PMap::MAP_I32_F64:
-		new(addr) ZSMapIterator<uint32_t, double>();
-		break;
-	case PMap::MAP_I32_OBJ:
-		new(addr) ZSMapIterator<uint32_t, DObject*>();
-		break;
-	case PMap::MAP_I32_PTR:
-		new(addr) ZSMapIterator<uint32_t, void*>();
-		break;
-	case PMap::MAP_I32_STR:
-		new(addr) ZSMapIterator<uint32_t, FString>();
-		break;
-	case PMap::MAP_STR_I8:
-		new(addr) ZSMapIterator<FString, uint8_t>();
-		break;
-	case PMap::MAP_STR_I16:
-		new(addr) ZSMapIterator<FString, uint16_t>();
-		break;
-	case PMap::MAP_STR_I32:
-		new(addr) ZSMapIterator<FString, uint32_t>();
-		break;
-	case PMap::MAP_STR_F32:
-		new(addr) ZSMapIterator<FString, float>();
-		break;
-	case PMap::MAP_STR_F64:
-		new(addr) ZSMapIterator<FString, double>();
-		break;
-	case PMap::MAP_STR_OBJ:
-		new(addr) ZSMapIterator<FString, DObject*>();
-		break;
-	case PMap::MAP_STR_PTR:
-		new(addr) ZSMapIterator<FString, void*>();
-		break;
-	case PMap::MAP_STR_STR:
-		new(addr) ZSMapIterator<FString, FString>();
-		break;
+		#define MAP_IT_CONSTRUCT(KT, VT) new(addr) ZSMapIterator< KT, VT >(); break;
+		FOR_EACH_MAP_TYPE(MAP_IT_CONSTRUCT)
+		#undef MAP_IT_CONSTRUCT
 	};
 }
 
@@ -2910,54 +2736,9 @@ void PMapIterator::DestroyValue(void *addr) const
 {
 	switch(BackingClass)
 	{
-	case PMap::MAP_I32_I8:
-		static_cast<ZSMapIterator<uint32_t, uint8_t>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_I32_I16:
-		static_cast<ZSMapIterator<uint32_t, uint16_t>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_I32_I32:
-		static_cast<ZSMapIterator<uint32_t, uint32_t>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_I32_F32:
-		static_cast<ZSMapIterator<uint32_t, float>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_I32_F64:
-		static_cast<ZSMapIterator<uint32_t, double>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_I32_OBJ:
-		static_cast<ZSMapIterator<uint32_t, DObject*>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_I32_PTR:
-		static_cast<ZSMapIterator<uint32_t, void*>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_I32_STR:
-		static_cast<ZSMapIterator<uint32_t, FString>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_STR_I8:
-		static_cast<ZSMapIterator<FString, uint8_t>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_STR_I16:
-		static_cast<ZSMapIterator<FString, uint16_t>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_STR_I32:
-		static_cast<ZSMapIterator<FString, uint32_t>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_STR_F32:
-		static_cast<ZSMapIterator<FString, float>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_STR_F64:
-		static_cast<ZSMapIterator<FString, double>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_STR_OBJ:
-		static_cast<ZSMapIterator<FString, DObject*>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_STR_PTR:
-		static_cast<ZSMapIterator<FString, void*>*>(addr)->~ZSMapIterator();
-		break;
-	case PMap::MAP_STR_STR:
-		static_cast<ZSMapIterator<FString, FString>*>(addr)->~ZSMapIterator();
-		break;
+		#define MAP_IT_DESTROY(KT, VT) static_cast<ZSMapIterator< KT, VT >*>(addr)->~ZSMapIterator(); break;
+		FOR_EACH_MAP_TYPE(MAP_IT_DESTROY)
+		#undef MAP_IT_DESTROY
 	}
 }
 

--- a/src/common/scripting/frontend/zcc-parse.lemon
+++ b/src/common/scripting/frontend/zcc-parse.lemon
@@ -1285,6 +1285,26 @@ func_param(X) ::= func_param_flags(A) type(B) IDENTIFIER(C) EQ expr(D).
 	X = parm;
 }
 
+func_param(X) ::= func_param_flags(A) type(B) AND IDENTIFIER(C).
+{
+	NEW_AST_NODE(FuncParamDecl,parm,A.SourceLoc ? A.SourceLoc : B->SourceLoc);
+	parm->Type = B;
+	parm->Name = C.Name();
+	parm->Flags = A.Int | ZCC_Out;
+	parm->Default = nullptr;
+	X = parm;
+}
+
+func_param(X) ::= func_param_flags(A) type(B) AND IDENTIFIER(C) EQ expr(D).
+{
+	NEW_AST_NODE(FuncParamDecl,parm,A.SourceLoc ? A.SourceLoc : B->SourceLoc);
+	parm->Type = B;
+	parm->Name = C.Name();
+	parm->Flags = A.Int | ZCC_Out;
+	parm->Default = D;
+	X = parm;
+}
+
 func_param_flags(X) ::= .									{ X.Int = 0; X.SourceLoc = 0; }
 func_param_flags(X) ::= func_param_flags(A) IN(T).			{ X.Int = A.Int | ZCC_In; X.SourceLoc =  T.SourceLoc; }
 func_param_flags(X) ::= func_param_flags(A) OUT(T).			{ X.Int = A.Int | ZCC_Out; X.SourceLoc =  T.SourceLoc; }

--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -2254,6 +2254,11 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 					Error(f, "The return type of a function cannot be a dynamic array");
 					break;
 				}
+				else if (type->isMap())
+				{
+					Error(f, "The return type of a function cannot be a map");
+					break;
+				}
 				else if (type == TypeFVector2)
 				{
 					type = TypeVector2;

--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -1866,18 +1866,16 @@ PType *ZCCCompiler::DetermineType(PType *outertype, ZCC_TreeNode *field, FName n
 		auto keytype = DetermineType(outertype, field, name, mtype->KeyType, false, false);
 		auto valuetype = DetermineType(outertype, field, name, mtype->ValueType, false, false);
 
-		if (keytype->GetRegType() == REGT_INT)
+		if (keytype->GetRegType() != REGT_STRING && !(keytype->GetRegType() == REGT_INT && keytype->Size == 4))
 		{
-			if (keytype->Size != 4)
+			if(name != NAME_None)
+			{
+				Error(field, "%s : Map<%s , ...> not implemented yet", name.GetChars(), keytype->DescriptiveName());
+			}
+			else
 			{
 				Error(field, "Map<%s , ...> not implemented yet", keytype->DescriptiveName());
-				break;
 			}
-		}
-		else if (keytype->GetRegType() != REGT_STRING)
-		{
-			Error(field, "Map<%s , ...> not implemented yet", keytype->DescriptiveName());
-			break;
 		}
 
 		switch(valuetype->GetRegType())
@@ -1888,14 +1886,20 @@ PType *ZCCCompiler::DetermineType(PType *outertype, ZCC_TreeNode *field, FName n
 		case REGT_POINTER:
 			if (valuetype->GetRegCount() > 1)
 			{
-				Error(field, "%s : Base type for map value types must be integral, but got %s", name.GetChars(), valuetype->DescriptiveName());
+			default:
+				if(name != NAME_None)
+				{
+					Error(field, "%s : Base type for map value types must be integral, but got %s", name.GetChars(), valuetype->DescriptiveName());
+				}
+				else
+				{
+					Error(field, "Base type for map value types must be integral, but got %s", valuetype->DescriptiveName());
+				}
 				break;
 			}
 
 			retval = NewMap(keytype, valuetype);
 			break;
-		default:
-			Error(field, "%s: Base type for map value types must be integral, but got %s", name.GetChars(), valuetype->DescriptiveName());
 		}
 
 		break;
@@ -1913,16 +1917,16 @@ PType *ZCCCompiler::DetermineType(PType *outertype, ZCC_TreeNode *field, FName n
 		auto keytype = DetermineType(outertype, field, name, mtype->KeyType, false, false);
 		auto valuetype = DetermineType(outertype, field, name, mtype->ValueType, false, false);
 
-		if (keytype->GetRegType() == REGT_INT)
+		if (keytype->GetRegType() != REGT_STRING && !(keytype->GetRegType() == REGT_INT && keytype->Size == 4))
 		{
-			if (keytype->Size != 4)
+			if(name != NAME_None)
+			{
+				Error(field, "%s : MapIterator<%s , ...> not implemented yet", name.GetChars(), keytype->DescriptiveName());
+			}
+			else
 			{
 				Error(field, "MapIterator<%s , ...> not implemented yet", keytype->DescriptiveName());
 			}
-		}
-		else if (keytype->GetRegType() != REGT_STRING)
-		{
-			Error(field, "MapIterator<%s , ...> not implemented yet", keytype->DescriptiveName());
 		}
 
 		switch(valuetype->GetRegType())
@@ -1933,13 +1937,19 @@ PType *ZCCCompiler::DetermineType(PType *outertype, ZCC_TreeNode *field, FName n
 		case REGT_POINTER:
 			if (valuetype->GetRegCount() > 1)
 			{
-				Error(field, "%s : Base type for map value types must be integral, but got %s", name.GetChars(), valuetype->DescriptiveName());
+			default:
+				if(name != NAME_None)
+				{
+					Error(field, "%s : Base type for map value types must be integral, but got %s", name.GetChars(), valuetype->DescriptiveName());
+				}
+				else
+				{
+					Error(field, "Base type for map value types must be integral, but got %s", valuetype->DescriptiveName());
+				}
 				break;
 			}
 			retval = NewMapIterator(keytype, valuetype);
 			break;
-		default:
-			Error(field, "%s: Base type for map value types must be integral, but got %s", name.GetChars(), valuetype->DescriptiveName());
 		}
 		break;
 	}

--- a/src/common/scripting/frontend/zcc_parser.cpp
+++ b/src/common/scripting/frontend/zcc_parser.cpp
@@ -52,7 +52,7 @@ static FString ResolveIncludePath(const FString &path,const FString &lumpname){
 
 		auto end = lumpname.LastIndexOf("/"); // find last '/'
 
-		// it's a top-level file, if it's a folder being loaded ( /xxx/yyy/:whatever.zs ) end is before than start, or if it's a zip ( xxx.zip/whatever.zs ) end would be -1
+		// it's a top-level file, if it's a folder being loaded ( /xxx/yyy/:whatever.zs ) end is before than start, or if it's a zip ( xxx.zip:whatever.zs ) end would be -1
 		bool topLevelFile = start > end ;
 
 		FString fullPath = topLevelFile ? FString {} : lumpname.Mid(start + 1, end - start - 1); // get path from lumpname (format 'wad:filepath/filename')

--- a/src/common/scripting/jit/jit.cpp
+++ b/src/common/scripting/jit/jit.cpp
@@ -44,6 +44,13 @@ void JitDumpLog(FILE *file, VMScriptFunction *sfunc)
 {
 	using namespace asmjit;
 	StringLogger logger;
+
+	if(sfunc->VarFlags & VARF_Abstract)
+	{
+		// Printf(TEXTCOLOR_ORANGE "Skipping abstract function during JIT dump: %s\n", sfunc->PrintableName.GetChars());
+		return;
+	}
+
 	try
 	{
 		ThrowingErrorHandler errorHandler;

--- a/src/common/utility/tarray.h
+++ b/src/common/utility/tarray.h
@@ -399,9 +399,16 @@ public:
 		Grow(item.Size());
 		Count += item.Size();
 
-		for (unsigned i = 0; i < item.Size(); i++)
+		if constexpr (std::is_trivially_copyable<T>::value)
 		{
-			new(&Array[start + i]) T(item[i]);
+			memcpy(Array + start,item.Array,item.Size() * sizeof(T));
+		}
+		else
+		{
+			for (unsigned i = 0; i < item.Size(); i++)
+			{
+				new(&Array[start + i]) T(item[i]);
+			}
 		}
 		return start;
 	}
@@ -413,9 +420,16 @@ public:
 		Grow(item.Size());
 		Count += item.Size();
 
-		for (unsigned i = 0; i < item.Size(); i++)
+		if constexpr (std::is_trivially_copyable<T>::value)
 		{
-			new(&Array[start + i]) T(std::move(item[i]));
+			memcpy(Array + start,item.Array,item.Size() * sizeof(T));
+		}
+		else
+		{
+			for (unsigned i = 0; i < item.Size(); i++)
+			{
+				new(&Array[start + i]) T(std::move(item[i]));
+			}
 		}
 		item.Clear();
 		return start;

--- a/src/common/utility/tarray.h
+++ b/src/common/utility/tarray.h
@@ -1128,12 +1128,12 @@ public:
 		Node *n = FindKey(key);
 		if (n != NULL)
 		{
-			n->Pair.Value = value;
+			n->Pair.Value = std::move(value);
 		}
 		else
 		{
 			n = NewKey(key);
-			::new(&n->Pair.Value) VT(value);
+			::new(&n->Pair.Value) VT(std::move(value));
 		}
 		return n->Pair.Value;
 	}


### PR DESCRIPTION
Misc stuff that i've fixed/improved while working on struct returns -- since struct returns themselves will still take a while, thought i should bring this separately as a PR.

Features:
 - Allow assignment of array/map types with `X = Y` (an alias for `X.Copy(Y)`)
 - Add `type &var` as an alternative to `out type var` in function parameters
 - JIT dump without gzdoom.pk3 using `-dumjitmod`

Fixes:
 - improvements to error prints in map/mapiterator
 - minor null dereference fixes
 - fix dumping jit code with abstract functions
 - print warning when trying to assign struct/array/map out references
 - fix move insertion in TMap
 - fix `mDefFileNo` in `PStruct::AddField`
 - minor refactor of `PMap`/`PMapIterator` code
 - performance improvement in debug builds for `TArray::Append` of trivially-copiable types
 - fix typo in a comment