### PR TITLE
Make feature check for sealed classes functional

### DIFF
--- a/src/common/engine/sc_man_scanner.re
+++ b/src/common/engine/sc_man_scanner.re
@@ -204,7 +204,7 @@ std2:
 		'stop'						{ RET(TK_Stop); }
 		'null'						{ RET(TK_Null); }
 		'nullptr'					{ RET(ParseVersion >= MakeVersion(4, 9, 0)? TK_Null : TK_Identifier); }
-		'sealed'					{ RET(ParseVersion >= MakeVersion(4, 12, 0)? TK_Sealed : TK_Identifier); }
+		'sealed'					{ RET(ParseVersion >= MakeVersion(4, 11, 1)? TK_Sealed : TK_Identifier); }
 
 		'is'						{ RET(ParseVersion >= MakeVersion(1, 0, 0)? TK_Is : TK_Identifier); }
 		'replaces'					{ RET(ParseVersion >= MakeVersion(1, 0, 0)? TK_Replaces : TK_Identifier); }

--- a/src/version.h
+++ b/src/version.h
@@ -50,12 +50,12 @@ const char *GetVersionString();
 // These are for content versioning.
 #define VER_MAJOR 4
 #define VER_MINOR 11
-#define VER_REVISION 0
+#define VER_REVISION 1
 
 // This should always refer to the GZDoom version a derived port is based on and not reflect the derived port's version number!
 #define ENG_MAJOR 4
 #define ENG_MINOR 11
-#define ENG_REVISION 0
+#define ENG_REVISION 1
 
 // Version identifier for network games.
 // Bump it every time you do a release unless you're certain you


### PR DESCRIPTION
sealed classes had a version check for 4.12, since i was expecting a later merge, this changes that to 4.11.1 and changes version.h so that 4.11.1 can actually be set as the zscript version

(putting this as a draft in case next version is 4.12 and not 4.11.1)