### PR TITLE
Exposed P_GetMidTexturePosition() to ZScript.

### DIFF
--- a/src/playsim/p_3dmidtex.cpp
+++ b/src/playsim/p_3dmidtex.cpp
@@ -44,6 +44,7 @@
 #include "g_levellocals.h"
 #include "actor.h"
 #include "texturemanager.h"
+#include "vm.h"
 
 
 //============================================================================
@@ -256,6 +257,20 @@ bool P_GetMidTexturePosition(const line_t *line, int sideno, double *ptextop, do
 		*ptexbot = *ptextop - textureheight;
 	}
 	return true;
+}
+
+DEFINE_ACTION_FUNCTION(_Line, GetMidTexturePosition)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(line_t);
+	PARAM_INT(side);
+	double top = 0.0;
+	double bottom = 0.0;
+
+	bool res = P_GetMidTexturePosition(self,side,&top,&bottom);
+	if (numret > 2) ret[2].SetFloat(bottom);
+	if (numret > 1) ret[1].SetFloat(top);
+	if (numret > 0) ret[0].SetInt(int(res));
+	return numret;
 }
 
 //============================================================================

--- a/wadsrc/static/zscript/mapdata.zs
+++ b/wadsrc/static/zscript/mapdata.zs
@@ -238,6 +238,7 @@ struct Line native play
 	native clearscope int Index() const;
 	native bool Activate(Actor activator, int side, int type);
 	native bool RemoteActivate(Actor activator, int side, int type, Vector3 pos);
+	native bool, double, double GetMidTexturePosition (int side);
 	
 	clearscope int GetUDMFInt(Name nm) const
 	{


### PR DESCRIPTION
Exactly what it says on the tin. Exposes P_GetMidTexturePosition() to ZScript, to allow for mods to get the boundaries of middle textures for checking collisions with them.