### PR TITLE
added wall texture skewing.

### DIFF
--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -1194,6 +1194,19 @@ struct side_t
 		walltop = 0,
 		wallbottom = 1,
 	};
+	enum ESkew
+	{
+		skew_none = 0,
+		skew_front = 1,
+		skew_back = 2,
+		// for mid textures there's 4 options
+		skew_front_floor = 1,
+		skew_front_ceiling = 2,
+		skew_back_floor = 3,
+		skew_back_ceiling = 4
+
+	};
+
 	struct part
 	{
 		enum EPartFlags
@@ -1209,7 +1222,8 @@ struct side_t
 		double xScale;
 		double yScale;
 		TObjPtr<DInterpolation*> interpolation;
-		int flags;
+		int16_t flags;
+		int8_t skew;
 		FTextureID texture;
 		TextureManipulation TextureFx;
 		PalEntry SpecialColors[2];

--- a/src/maploader/udmf.h
+++ b/src/maploader/udmf.h
@@ -21,6 +21,7 @@ protected:
 	DAngle CheckAngle(FName key);
 	bool CheckBool(FName key);
 	const char *CheckString(FName key);
+	int MatchString(FName key, const char* const* strings, int defval);
 
 	template<typename T>
 	bool Flag(T &value, int mask, FName key)

--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -858,4 +858,8 @@ xx(lm_sampledist_ceiling)
 xx(lm_suncolor)
 xx(lm_sampledistance)
 
+xx(skew_bottom_type)
+xx(skew_middle_type)
+xx(skew_top_type)
+
 xx(Corona)

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -140,6 +140,7 @@ FSerializer &Serialize(FSerializer &arc, const char *key, side_t::part &part, si
 			("texture", part.texture, def->texture)
 			("interpolation", part.interpolation)
 			("flags", part.flags, def->flags)
+			("skew", part.skew, def->skew)
 			("color1", part.SpecialColors[0], def->SpecialColors[0])
 			("color2", part.SpecialColors[1], def->SpecialColors[1])
 			("addcolor", part.AdditiveColor, def->AdditiveColor)

--- a/src/rendering/hwrenderer/scene/hw_drawstructs.h
+++ b/src/rendering/hwrenderer/scene/hw_drawstructs.h
@@ -237,19 +237,19 @@ public:
 	bool DoHorizon(HWWallDispatcher* di, seg_t* seg, sector_t* fs, vertex_t* v1, vertex_t* v2);
 
 	bool SetWallCoordinates(seg_t* seg, FTexCoordInfo* tci, float ceilingrefheight,
-		float topleft, float topright, float bottomleft, float bottomright, float t_ofs);
+		float topleft, float topright, float bottomleft, float bottomright, float t_ofs, float skew);
 
 	void DoTexture(HWWallDispatcher* di, int type, seg_t* seg, int peg,
 		float ceilingrefheight, float floorrefheight,
 		float CeilingHeightstart, float CeilingHeightend,
 		float FloorHeightstart, float FloorHeightend,
-		float v_offset);
+		float v_offset, float skew);
 
 	void DoMidTexture(HWWallDispatcher* di, seg_t* seg, bool drawfogboundary,
 		sector_t* front, sector_t* back,
 		sector_t* realfront, sector_t* realback,
 		float fch1, float fch2, float ffh1, float ffh2,
-		float bch1, float bch2, float bfh1, float bfh2, float zalign);
+		float bch1, float bch2, float bfh1, float bfh2, float zalign, float skew);
 
 	void GetPlanePos(F3DFloor::planeref* planeref, float& left, float& right);
 


### PR DESCRIPTION
This uses the same UDMF properties as Eternity recently introduced for the same feature.

Doing it as a draft for now because there's things to check out and I like feedback on this.

The skewing generally works as I think it is intended but I haven't been able to make a map to compare this with Eternity's implementation to ensure the properties work the same.
Another thing is that the EE properties appear to be sensitive to which side of a linedef they apply to and switch behavior on the backside. I made sure not to propagate this quirk beyond the parsing stage.
While I am confident about handling on one-sided walls and upper and lower textures it is a lot harder to judge on two-sided mid textures because there's so many cases to consider. This part definitely needs testing by someone more experienced with how the Doom engine renders walls.