### PR TITLE
widen the special field in FBoomArgs.

### DIFF
--- a/src/gamedata/xlat/xlat.h
+++ b/src/gamedata/xlat/xlat.h
@@ -82,7 +82,7 @@ struct FBoomTranslator
 {
 	uint16_t FirstLinetype = 0;
 	uint16_t LastLinetype = 0;
-	uint8_t NewSpecial = 0;
+	uint16_t NewSpecial = 0;
 	TArray<FBoomArg> Args;
 } ;
 


### PR DESCRIPTION
This code still assumed that all special types fit into 8 bits which is no longer the case.
Fixes #2214