### PR TITLE
Allow setting the colormap from mapinfo (dsda-doom)

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1821,6 +1821,12 @@ void FLevelLocals::Init()
 			flags |= LEVEL_HASFADETABLE;
 		}
 	}
+
+	if (strnicmp (info->CustomColorMap.GetChars(), "COLORMAP", 8) != 0)
+	{
+		flags3 |= LEVEL3_HAS_CUSTOM_COLORMAP;
+	}
+
 	airsupply = info->airsupply*TICRATE;
 	outsidefog = info->outsidefog;
 	WallVertLight = info->WallVertLight*2;

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -254,6 +254,7 @@ void level_info_t::Reset()
 	LevelName = "";
 	AuthorName = "";
 	FadeTable = "COLORMAP";
+	CustomColorMap = "COLORMAP";
 	WallHorizLight = -8;
 	WallVertLight = +8;
 	F1Pic = "";
@@ -1152,6 +1153,12 @@ DEFINE_MAP_OPTION(fadetable, true)
 {
 	parse.ParseAssign();
 	parse.ParseLumpOrTextureName(info->FadeTable);
+}
+
+DEFINE_MAP_OPTION(colormap, true)
+{
+	parse.ParseAssign();
+	parse.ParseLumpOrTextureName(info->CustomColorMap);
 }
 
 DEFINE_MAP_OPTION(evenlighting, true)

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -270,6 +270,7 @@ enum ELevelFlags : unsigned int
 	LEVEL3_AVOIDMELEE			= 0x00020000,	// global flag needed for proper MBF support.
 	LEVEL3_NOJUMPDOWN			= 0x00040000,	// only for MBF21. Inverse of MBF's dog_jumping flag.
 	LEVEL3_LIGHTCREATED			= 0x00080000,	// a light had been created in the last frame
+	LEVEL3_HAS_CUSTOM_COLORMAP  = 0x00100000,   // custom colormap property from dsda-doom
 };
 
 
@@ -330,6 +331,7 @@ struct level_info_t
 	FString		SkyPic1;
 	FString		SkyPic2;
 	FString		FadeTable;
+	FString		CustomColorMap;
 	FString		F1Pic;
 	FString		BorderTexture;
 	FString		MapBackground;

--- a/src/rendering/swrenderer/r_swrenderer.cpp
+++ b/src/rendering/swrenderer/r_swrenderer.cpp
@@ -271,7 +271,11 @@ void FSoftwareRenderer::SetColormap(FLevelLocals *Level)
 	NormalLight.Maps = realcolormaps.Maps;
 	NormalLight.ChangeColor(PalEntry(255, 255, 255), 0);
 	NormalLight.ChangeFade(Level->fadeto);
-	if (Level->fadeto == 0)
+	if(Level->info->flags3 & LEVEL3_HAS_CUSTOM_COLORMAP)
+	{
+		SetDefaultColormap(Level->info->CustomColorMap.GetChars());
+	}
+	else if (Level->fadeto == 0)
 	{
 		SetDefaultColormap(Level->info->FadeTable.GetChars());
 	}


### PR DESCRIPTION
only for the non-truecolor sw renderer.

untested beyond just compiling gzdoom, but it should work, since it's the same as FadeTable except without the hardcoded fog changes it does