### PR TITLE
Disable texture filtering by default

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_cvars.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_cvars.cpp
@@ -120,7 +120,7 @@ CUSTOM_CVARD(Float, gl_texture_filter_anisotropic, 8.f, CVAR_ARCHIVE | CVAR_GLOB
 	screen->SetTextureFilterMode();
 }
 
-CUSTOM_CVARD(Int, gl_texture_filter, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL, "changes the texture filtering settings")
+CUSTOM_CVARD(Int, gl_texture_filter, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL, "changes the texture filtering settings")
 {
 	if (self < 0 || self > 6) self=4;
 	screen->SetTextureFilterMode();


### PR DESCRIPTION
In the beginning, GZDoom turned on texture filtering by default.

[This had made many people very angry](https://www.goodreads.com/quotes/852503-in-the-beginning-the-universe-was-created-this-had-made)¹, [and has been widely regarded as a bad move](https://www.doomworld.com/forum/topic/137248-do-you-think-gzdoom-should-have-texture-filtering-on-by-default/?tab=comments#comment-2667005).

1. Although, not as many as the Unity3D install fee debacle. :stuck_out_tongue:

And if someone wants texture filtering, they still have the option to enable it themselves.

Also, I'm not super adamant about having this merged, even if the Douglas Adams quote gives that impression... I just thought it would be a more sane default for GZDoom, especially since most GZDoom-based games are built with low-resolutions sprites and textures.