### PR TITLE
Disable JIT VM by default when compiling for OpenBSD

### DIFF
--- a/src/common/scripting/vm/vmframe.cpp
+++ b/src/common/scripting/vm/vmframe.cpp
@@ -45,7 +45,7 @@
 #include "version.h"
 
 #ifdef HAVE_VM_JIT
-#ifdef __DragonFly__
+#if defined(__DragonFly__) || defined(__OpenBSD__)
 CUSTOM_CVAR(Bool, vm_jit, false, CVAR_NOINITCALL)
 #else
 CUSTOM_CVAR(Bool, vm_jit, true, CVAR_NOINITCALL)


### PR DESCRIPTION
Disable the JIT VM due to OpenBSD's use of W^X.