### PR TITLE
ZSprite Fix

### DIFF
--- a/wadsrc/static/zscript/zsprite.zs
+++ b/wadsrc/static/zscript/zsprite.zs
@@ -4,7 +4,7 @@ Class ZSprite : Thinker native
 	native Vector2		Scale, Offset;
 	native double		Roll, Alpha;
 	native TextureID	Texture;
-	native uint			Translation;
+	native TranslationID	Translation;
 	native uint16		Flags;
 	native int16		LightLevel;
 	native bool			bXFlip, bYFlip,
@@ -19,7 +19,7 @@ Class ZSprite : Thinker native
 	native bool IsFrozen();
 
 	static ZSprite Spawn(Class<ZSprite> type, TextureID tex, Vector3 pos, Vector3 vel, double alpha = 1.0, int flags = 0,
-						  double roll = 0.0, Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal, int trans = 0)
+						  double roll = 0.0, Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal)
 	{
 		if (!Level)	return null;
 
@@ -34,7 +34,6 @@ Class ZSprite : Thinker native
 			p.Scale = scale;
 			p.Offset = offset;
 			p.SetRenderStyle(style);
-			p.Translation = trans;
 			p.Flags = flags;
 		}
 		return p;


### PR DESCRIPTION
Fixed missing translation spots.

- Removed translation parameter from ZSprite's `Spawn` function since it's no longer compatible.