### PR TITLE
ZSprite Minor Additions

### DIFF
--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -1224,6 +1224,7 @@ void DZSprite::Serialize(FSerializer& arc)
 		("prev", Prev)
 		("scale", Scale)
 		("roll", Roll)
+		("prevroll", PrevRoll)
 		("offset", Offset)
 		("alpha", Alpha)
 		("texture", Texture)
@@ -1247,6 +1248,7 @@ DEFINE_FIELD(DZSprite, Prev);
 DEFINE_FIELD(DZSprite, Scale);
 DEFINE_FIELD(DZSprite, Offset);
 DEFINE_FIELD(DZSprite, Roll);
+DEFINE_FIELD(DZSprite, PrevRoll);
 DEFINE_FIELD(DZSprite, Alpha);
 DEFINE_FIELD(DZSprite, Texture);
 DEFINE_FIELD(DZSprite, Translation);

--- a/wadsrc/static/zscript/zsprite.zs
+++ b/wadsrc/static/zscript/zsprite.zs
@@ -2,7 +2,7 @@ Class ZSprite : Thinker native
 {
 	native Vector3		Pos, Vel, Prev;
 	native Vector2		Scale, Offset;
-	native double		Roll, Alpha;
+	native double		Roll, Alpha, PrevRoll;
 	native TextureID	Texture;
 	native TranslationID	Translation;
 	native uint16		Flags;
@@ -19,7 +19,7 @@ Class ZSprite : Thinker native
 	native bool IsFrozen();
 
 	static ZSprite Spawn(Class<ZSprite> type, TextureID tex, Vector3 pos, Vector3 vel, double alpha = 1.0, int flags = 0,
-						  double roll = 0.0, Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal)
+						  double roll = 0.0, Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal, TranslationID trans = 0)
 	{
 		if (!Level)	return null;
 
@@ -34,6 +34,7 @@ Class ZSprite : Thinker native
 			p.Scale = scale;
 			p.Offset = offset;
 			p.SetRenderStyle(style);
+			p.Translation = trans;
 			p.Flags = flags;
 		}
 		return p;


### PR DESCRIPTION
- Exposed PrevRoll, enabling roll interpolation disabling without affecting position interpolation.
- Reinstated the translation parameter for the `Spawn` function.