### PR TITLE
ZSprites variable fix

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -1368,6 +1368,9 @@ void HWSprite::ProcessParticle (HWDrawInfo *di, particle_t *particle, sector_t *
 		float yvf = (particle->Vel.Y) * timefrac;
 		float zvf = (particle->Vel.Z) * timefrac;
 
+		offx = 0.f;
+		offy = 0.f;
+
 		x = float(particle->Pos.X) + xvf;
 		y = float(particle->Pos.Y) + yvf;
 		z = float(particle->Pos.Z) + zvf;


### PR DESCRIPTION
Fixed uninitialized variables causing issues with other compilers.

I.e. there's been reports of "blinking" particles and them disappearing while the player view is in motion, etc.