### PR TITLE
Add Compatibility=Extended for Blasphemer

### DIFF
--- a/wadsrc_extra/static/iwadinfo.txt
+++ b/wadsrc_extra/static/iwadinfo.txt
@@ -227,6 +227,7 @@ IWad
 	Config = "Heretic"
 	IWADName = "blasphemer.wad"
 	Mapinfo = "mapinfo/heretic.txt"
+	Compatibility = "Extended"
 	MustContain = "E1M1", "E2M1", "TITLE", "BLASPHEM"
 	BannerColors = "73 00 00", "00 00 00"
 }


### PR DESCRIPTION
Blasphemer is this "free Heretic" project, which is already supported as an IWAD by GZDoom. Episodes 4 and 5 are not being listed in the main menu by GZDoom. They do have maps for these episodes, though they are currently placeholders. More importantly though the WAD includes the `EXTENDED` lump, so the appropriate behavior for it would be to have this set.

If this is merged, it should fix Blasphemer/blasphemer#14.