### PR TITLE
Fix vanilla weapon functions passing ammo count to DepleteAmmo

### DIFF
--- a/wadsrc/static/zscript/actors/doom/doomweapons.zs
+++ b/wadsrc/static/zscript/actors/doom/doomweapons.zs
@@ -31,7 +31,7 @@ extend class StateProvider
 		Weapon weap = player.ReadyWeapon;
 		if (weap != null && invoker == weap && stateinfo != null && stateinfo.mStateType == STATE_Psprite)
 		{
-			if (!weap.DepleteAmmo (weap.bAltFire, true, 1))
+			if (!weap.DepleteAmmo (weap.bAltFire, true))
 				return;
 			
 			State flash = weap.FindState('Flash');

--- a/wadsrc/static/zscript/actors/doom/weaponbfg.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponbfg.zs
@@ -107,7 +107,7 @@ extend class StateProvider
 		if (invoker != weap || stateinfo == null || stateinfo.mStateType != STATE_Psprite) weap = null;
 		if (weap != null)
 		{
-			if (!weap.DepleteAmmo (weap.bAltFire, true, 1))
+			if (!weap.DepleteAmmo (weap.bAltFire, true))
 				return;
 
 			doesautoaim = weap.bNoAutoaim;

--- a/wadsrc/static/zscript/actors/doom/weaponchaingun.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponchaingun.zs
@@ -60,7 +60,7 @@ extend class StateProvider
 		Weapon weap = player.ReadyWeapon;
 		if (weap != null && invoker == weap && stateinfo != null && stateinfo.mStateType == STATE_Psprite)
 		{
-			if (!weap.DepleteAmmo (weap.bAltFire, true, 1))
+			if (!weap.DepleteAmmo (weap.bAltFire, true))
 				return;
 
 			A_StartSound ("weapons/chngun", CHAN_WEAPON);

--- a/wadsrc/static/zscript/actors/doom/weaponpistol.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponpistol.zs
@@ -85,7 +85,7 @@ extend class StateProvider
 			Weapon weap = player.ReadyWeapon;
 			if (weap != null && invoker == weap && stateinfo != null && stateinfo.mStateType == STATE_Psprite)
 			{
-				if (!weap.DepleteAmmo (weap.bAltFire, true, 1))
+				if (!weap.DepleteAmmo (weap.bAltFire, true))
 					return;
 
 				player.SetPsprite(PSP_FLASH, weap.FindState('Flash'), true);

--- a/wadsrc/static/zscript/actors/doom/weaponplasma.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponplasma.zs
@@ -133,7 +133,7 @@ extend class StateProvider
 		Weapon weap = player.ReadyWeapon;
 		if (weap != null && invoker == weap && stateinfo != null && stateinfo.mStateType == STATE_Psprite)
 		{
-			if (!weap.DepleteAmmo (weap.bAltFire, true, 1))
+			if (!weap.DepleteAmmo (weap.bAltFire, true))
 				return;
 			
 			State flash = weap.FindState('Flash');

--- a/wadsrc/static/zscript/actors/doom/weaponrlaunch.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponrlaunch.zs
@@ -152,7 +152,7 @@ extend class StateProvider
 		Weapon weap = player.ReadyWeapon;
 		if (weap != null && invoker == weap && stateinfo != null && stateinfo.mStateType == STATE_Psprite)
 		{
-			if (!weap.DepleteAmmo (weap.bAltFire, true, 1))
+			if (!weap.DepleteAmmo (weap.bAltFire, true))
 				return;
 		}
 		
@@ -177,7 +177,7 @@ extend class StateProvider
 		Weapon weap = player.ReadyWeapon;
 		if (weap != null && invoker == weap && stateinfo != null && stateinfo.mStateType == STATE_Psprite)
 		{
-			if (!weap.DepleteAmmo (weap.bAltFire, true, 1))
+			if (!weap.DepleteAmmo (weap.bAltFire, true))
 				return;
 		}
 			

--- a/wadsrc/static/zscript/actors/doom/weaponshotgun.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponshotgun.zs
@@ -66,7 +66,7 @@ extend class StateProvider
 		Weapon weap = player.ReadyWeapon;
 		if (weap != null && invoker == weap && stateinfo != null && stateinfo.mStateType == STATE_Psprite)
 		{
-			if (!weap.DepleteAmmo (weap.bAltFire, true, 1))
+			if (!weap.DepleteAmmo (weap.bAltFire, true))
 				return;
 			
 			player.SetPsprite(PSP_FLASH, weap.FindState('Flash'), true);

--- a/wadsrc/static/zscript/actors/doom/weaponssg.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponssg.zs
@@ -74,7 +74,7 @@ extend class StateProvider
 		Weapon weap = player.ReadyWeapon;
 		if (weap != null && invoker == weap && stateinfo != null && stateinfo.mStateType == STATE_Psprite)
 		{
-			if (!weap.DepleteAmmo (weap.bAltFire, true, 2))
+			if (!weap.DepleteAmmo (weap.bAltFire, true))
 				return;
 			
 			player.SetPsprite(PSP_FLASH, weap.FindState('Flash'), true);

--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -964,14 +964,14 @@ class Weapon : StateProvider
 		count1 = (Ammo1 != null) ? Ammo1.Amount : 0;
 		count2 = (Ammo2 != null) ? Ammo2.Amount : 0;
 
-		if (ammocount >= 0)
+		if (bDehAmmo && Ammo1 == null)
+		{
+			lAmmoUse1 = 0;
+		}
+		else if (ammocount >= 0)
 		{
 			lAmmoUse1 = ammocount;
 			lAmmoUse2 = ammocount;
-		}
-		else if (bDehAmmo && Ammo1 == null)
-		{
-			lAmmoUse1 = 0;
 		}
 		else
 		{

--- a/wadsrc/static/zscript/actors/strife/weaponmauler.zs
+++ b/wadsrc/static/zscript/actors/strife/weaponmauler.zs
@@ -62,7 +62,7 @@ class Mauler : StrifeWeapon
 		Weapon weap = player.ReadyWeapon;
 		if (weap != null)
 		{
-			if (!weap.DepleteAmmo (weap.bAltFire, true, 2))
+			if (!weap.DepleteAmmo (weap.bAltFire, true))
 				return;
 			
 		}


### PR DESCRIPTION
checkammo was previously ignored for non-dehacked weapons, but with commit 99850ea216ef13d56fb6e65e927aabd76d91b601 changing that, the vanilla attack functions caused issues