### PR TITLE
Export FScanner parser to ZScript as ScriptScanner

### DIFF
--- a/src/common/engine/sc_man.cpp
+++ b/src/common/engine/sc_man.cpp
@@ -263,6 +263,7 @@ void FScanner::PrepareScript ()
 	StateOptions = false;
 	StringBuffer[0] = '\0';
 	BigStringBuffer = "";
+	ParseError = false;
 }
 
 //==========================================================================
@@ -1095,7 +1096,7 @@ void FScanner::ScriptError (const char *message, ...)
 	ParseError = true;
 	if (NoFatalErrors)
 	{
-		Printf(TEXTCOLOR_RED "Script error, \"%s\"" TEXTCOLOR_RED " line %d:\n" TEXTCOLOR_RED "%s\n", ScriptName.GetChars(),
+		Printf(TEXTCOLOR_RED "%sScript error, \"%s\"" TEXTCOLOR_RED " line %d:\n" TEXTCOLOR_RED "%s\n", PrependMessage.GetChars(), ScriptName.GetChars(),
 			AlreadyGot ? AlreadyGotLine : Line, composed.GetChars());
 		return;
 	}
@@ -1407,6 +1408,7 @@ public:
 	void SetCMode(bool cmode) { return wrapped.SetCMode(cmode); }
 	void SetNoOctals(bool cmode) { return wrapped.SetNoOctals(cmode); }
 	void SetEscape(bool esc) { return wrapped.SetNoOctals(esc); }
+	void SetNoFatalErrors(bool cmode) { return wrapped.SetNoFatalErrors(cmode); }
 
 	void AddSymbol(const char* name, uint32_t value) { return wrapped.AddSymbol(name, value); }
 	void AddSymbol(const char* name, int32_t value) { return wrapped.AddSymbol(name, value); }
@@ -1729,6 +1731,15 @@ DEFINE_ACTION_FUNCTION(DScriptScanner, Close)
 	PARAM_SELF_PROLOGUE(DScriptScanner);
 
 	self->Close();
+	return 0;
+}
+
+DEFINE_ACTION_FUNCTION(DScriptScanner, SetNoFatalErrors)
+{
+	PARAM_SELF_PROLOGUE(DScriptScanner);
+	PARAM_BOOL(cmode);
+
+	self->SetNoFatalErrors(cmode);
 	return 0;
 }
 

--- a/src/common/engine/sc_man.h
+++ b/src/common/engine/sc_man.h
@@ -194,6 +194,7 @@ public:
 
 	void ScriptError(const char *message, ...) GCCPRINTF(2,3);
 	void ScriptMessage(const char *message, ...) GCCPRINTF(2,3);
+	void SetPrependMessage(const FString& message) { PrependMessage = message; }
 
 	bool isText();
 
@@ -240,6 +241,7 @@ protected:
 	bool StateOptions;
 	bool Escape;
 	VersionInfo ParseVersion = { 0, 0, 0 };	// no ZScript extensions by default
+	FString PrependMessage = "";
 
 
 	bool ScanValue(bool allowfloat, bool evaluate);

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -940,6 +940,67 @@ struct QuatStruct native
 	// native Quat Unit();
 }
 
+struct ScriptSavedPos
+{
+	voidptr SavedScriptPtr;
+	int SavedScriptLine;
+}
+
+class ScriptScanner native
+{
+	native void OpenString(String name, String script);
+	native void OpenLumpNum(int lump);
+	native void Close();
+
+	native void SavePos(out ScriptSavedPos pos);
+	native void RestorePos(out ScriptSavedPos pos);
+	native void UnGet();
+	native bool isText();
+	native int GetMessageLine();
+	native void SetPrependMessage(String message);
+
+	native vararg void ScriptError(String fmt, ...);
+	native vararg void ScriptMessage(String fmt, ...);
+
+	native void SetCMode(bool cmode);
+	native void SetNoOctals(bool cmode);
+	native void SetEscape(bool esc);
+	native void SkipToEndOfBlock();
+	native void StartBraces(out ScriptSavedPos braceend);
+	native bool FoundEndBrace(out ScriptSavedPos braceend);
+
+	native bool CheckValue(bool allowfloat, bool evaluate = true);
+	native bool CheckBoolToken();
+	native bool CheckNumber(bool evaluate = false);
+	native bool CheckString(String name);
+	native bool CheckFloat(bool evaluate = false);
+
+	native bool GetNumber(bool evaluate = false);
+	native bool GetString();
+	native bool GetFloat(bool evaluate = false);
+
+	native void AddSymbol(String name, int value);
+	native void AddSymbolUnsigned(String name, uint value);
+	native void AddSymbolFloat(String name, double value);
+
+	native void MustGetValue(bool allowfloat, bool evaluate = true);
+	native void MustGetFloat(bool evaluate = false);
+	native void MustGetNumber(bool evaluate = false);
+	native void MustGetString();
+	native void MustGetStringName(String name);
+	native void MustGetBoolToken();
+	
+	// This DOES NOT advance the parser! This returns the string the parser got.
+	native String GetStringContents();
+
+	native readonly bool End;
+	native readonly bool ParseError;
+	native readonly bool Crossed;
+	native readonly int Line;
+	native readonly int Number;
+	native readonly double Float;
+}
+
 // this struct does not exist. It is just a type for being referenced by an opaque pointer.
 struct VMFunction native version("4.10")
 {

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -965,6 +965,7 @@ class ScriptScanner native
 	native void SetCMode(bool cmode);
 	native void SetNoOctals(bool cmode);
 	native void SetEscape(bool esc);
+	native void SetNoFatalErrors(bool cmode);
 	native void SkipToEndOfBlock();
 	native void StartBraces(out ScriptSavedPos braceend);
 	native bool FoundEndBrace(out ScriptSavedPos braceend);


### PR DESCRIPTION
This PR exposes the internal `FScanner` parser to ZScript as `ScriptScanner`.

`ScriptScanner`s are created with `Create` functions, and destroyed by calling `Destroy` (after which it must not be used). `SetPrependMessage` is used to set the message that will be prepended to the displayed error messages in case of failure. The rest of the exported functions work unchanged from their native counterparts.