### PR TITLE
- add new ccmd `cvarsearch` allows searching cvar by name, languageid…

### DIFF
--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -44,6 +44,7 @@
 #include "printf.h"
 #include "palutil.h"
 #include "i_interface.h"
+#include "gstrings.h"
 
 #include "dobject.h"
 #include "dobjtype.h"
@@ -1695,16 +1696,37 @@ CCMD (toggle)
 	}
 }
 
-void FBaseCVar::ListVars (const char *filter, bool plain)
+void FBaseCVar::ListVars (const char *filter, int listtype)
 {
 	int count = 0;
+
+	bool plain = listtype == LCT_Plain;
+	bool includedesc = listtype == LCT_FullSearch;
 
 	decltype(cvarMap)::Iterator it(cvarMap);
 	decltype(cvarMap)::Pair *pair;
 	while (it.NextPair(pair))
 	{
 		auto var = pair->Value;
-		if (CheckWildcards (filter, var->GetName()))
+
+		bool ismatch;
+
+		if (includedesc)
+		{
+			// search always allow partial matches
+			// also allow matching to cvar name, localised description, and description language-id
+
+			FString SearchString = FString("*") + filter + "*";
+			ismatch = CheckWildcards (SearchString.GetChars(), var->GetName()) ||
+				CheckWildcards (SearchString.GetChars(), var->GetDescription().GetChars()) ||
+				CheckWildcards (SearchString.GetChars(), GStrings.localize(var->GetDescription().GetChars()));
+		}
+		else
+		{
+			ismatch = CheckWildcards (filter, var->GetName());
+		}
+
+		if (ismatch)
 		{
 			uint32_t flags = var->GetFlags();
 			if (plain)
@@ -1718,7 +1740,8 @@ void FBaseCVar::ListVars (const char *filter, bool plain)
 			else
 			{
 				++count;
-				Printf ("%c%c%c%c%c %s = %s\n",
+
+				Printf ("%c%c%c%c%c %s = %s",
 					flags & CVAR_ARCHIVE ? 'A' : ' ',
 					flags & CVAR_USERINFO ? 'U' :
 						flags & CVAR_SERVERINFO ? 'S' :
@@ -1730,6 +1753,16 @@ void FBaseCVar::ListVars (const char *filter, bool plain)
 					flags & CVAR_IGNORE ? 'X' : ' ',
 					var->GetName(),
 					var->GetHumanString());
+
+				if (includedesc)
+					if (var->GetDescription().Len())
+						Printf(" // \"%s\"\n", GStrings.localize(var->GetDescription().GetChars()));
+					else
+						Printf("\n");
+				else
+					Printf("\n");
+				
+
 			}
 		}
 	}
@@ -1740,17 +1773,29 @@ CCMD (cvarlist)
 {
 	if (argv.argc() == 1)
 	{
-		FBaseCVar::ListVars (NULL, false);
+		FBaseCVar::ListVars (NULL, LCT_Default);
 	}
 	else
 	{
-		FBaseCVar::ListVars (argv[1], false);
+		FBaseCVar::ListVars (argv[1], LCT_Default);
 	}
 }
 
 CCMD (cvarlistplain)
 {
-	FBaseCVar::ListVars (NULL, true);
+	FBaseCVar::ListVars (NULL, LCT_Plain);
+}
+
+CCMD (cvarsearch)
+{
+	if (argv.argc() == 1)
+	{
+		FBaseCVar::ListVars (NULL, LCT_FullSearch);
+	}
+	else
+	{
+		FBaseCVar::ListVars (argv[1], LCT_FullSearch);
+	}
 }
 
 CCMD (archivecvar)

--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -1711,7 +1711,7 @@ void FBaseCVar::ListVars (const char *filter, int listtype)
 
 		bool ismatch;
 
-		if (includedesc)
+		if (filter && includedesc)
 		{
 			// search always allow partial matches
 			// also allow matching to cvar name, localised description, and description language-id

--- a/src/common/console/c_cvars.h
+++ b/src/common/console/c_cvars.h
@@ -89,6 +89,13 @@ enum ECVarType
 	CVAR_Dummy,			// Unknown
 };
 
+enum ListCCMDType
+{
+	LCT_Default,
+	LCT_Plain,
+	LCT_FullSearch,
+};
+
 
 class FIntCVarRef;
 union UCVarValue
@@ -201,7 +208,7 @@ public:
 	static void MarkZSCallbacks ();
 	static void ResetColors ();		// recalc color cvars' indices after screen change
 
-	static void ListVars (const char *filter, bool plain);
+	static void ListVars (const char *filter, int listtype);
 
 	const FString &GetDescription() const { return Description; };
 	const FString& GetToggleMessage(int which) { return ToggleMessages[which]; }


### PR DESCRIPTION
…, or description