### PR TITLE
Added CollidedWith virtual for Actors

### DIFF
--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -511,6 +511,10 @@ class Actor : Thinker native
 		return true;
 	}
 
+	// Called in TryMove if the mover ran into another Actor. This isn't called on players
+	// if they're currently predicting. Guarantees collisions unlike CanCollideWith.
+	virtual void CollidedWith(Actor other, bool passive) {}
+
 	// Called by PIT_CheckThing to check if two actors actually can collide.
 	virtual bool CanCollideWith(Actor other, bool passive)
 	{


### PR DESCRIPTION
Guarantees a collision happened unlike CanCollideWith. Called in P_TryMove and P_CheckOnmobj so it only calls when an actual movement was attempted and not just a potential positional check. Also not called while the player is predicting to avoid having to manage it on the ZScript side. As a special note, this function is intentionally called before the collider is repositioned after a failed movement. This is so modders can get the exact position of the collision.