### PR TITLE
enum for SpecialMissileHit/SpecialBounceHit returns

### DIFF
--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -89,13 +89,6 @@ class Actor : Thinker native
 	const DEFMORPHTICS = 40 * TICRATE;
 	const MELEEDELTA = 20;
 
-	enum EMissileHitResult
-	{
-		MHIT_DEFAULT = -1,
-		MHIT_DESTROY = 0,
-		MHIT_PASS = 1,
-	}
-
 	// flags are not defined here, the native fields for those get synthesized from the internal tables.
 	
 	// for some comments on these fields, see their native representations in actor.h.

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -89,6 +89,12 @@ class Actor : Thinker native
 	const DEFMORPHTICS = 40 * TICRATE;
 	const MELEEDELTA = 20;
 
+	enum EMissileHitResult
+	{
+		MHIT_DEFAULT = -1,
+		MHIT_DESTROY = 0,
+		MHIT_PASS = 1,
+	}
 
 	// flags are not defined here, the native fields for those get synthesized from the internal tables.
 	
@@ -540,13 +546,13 @@ class Actor : Thinker native
 	// This is called before a missile gets exploded.
 	virtual int SpecialMissileHit (Actor victim)
 	{
-		return -1;
+		return MHIT_DEFAULT;
 	}
 
 	// This is called when a missile bounces off something.
 	virtual int SpecialBounceHit(Actor bounceMobj, Line bounceLine, SecPlane bouncePlane)
 	{
-		return -1;
+		return MHIT_DEFAULT;
 	}
 
 	// Called when the player presses 'use' and an actor is found, except if the

--- a/wadsrc/static/zscript/actors/hexen/magelightning.zs
+++ b/wadsrc/static/zscript/actors/hexen/magelightning.zs
@@ -147,7 +147,7 @@ class Lightning : Actor
 				tracer = thing;
 			}
 		}
-		return 1; // lightning zaps through all sprites
+		return MHIT_PASS; // lightning zaps through all sprites
 	}
 	
 }
@@ -417,7 +417,7 @@ class LightningZap : Actor
 				}
 			}
 		}
-		return -1;
+		return MHIT_DEFAULT;
 	}
 	
 	//============================================================================

--- a/wadsrc/static/zscript/actors/hexen/magestaff.zs
+++ b/wadsrc/static/zscript/actors/hexen/magestaff.zs
@@ -260,9 +260,9 @@ class MageStaffFX2 : Actor
 		if (victim != target && !victim.player && !victim.bBoss)
 		{
 			victim.DamageMobj (self, target, 10, 'Fire');
-			return 1;	// Keep going
+			return MHIT_PASS;	// Keep going
 		}
-		return -1;
+		return MHIT_DEFAULT;
 	}
 
 	override bool SpecialBlastHandling (Actor source, double strength)

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -612,6 +612,13 @@ enum EPickStart
 }
 
 
+enum EMissileHitResult
+{
+	MHIT_DEFAULT = -1,
+	MHIT_DESTROY = 0,
+	MHIT_PASS = 1,
+}
+
 class SectorEffect : Thinker native
 {
 	native protected Sector m_Sector;


### PR DESCRIPTION
This really needs to be an enum instead of an explicit integer.

P.S. Don't mind the word "virtualized" in the commits, I just used the wrong term. This is purely cosmetic.