### PR TITLE
Add support for animated images loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,10 @@ if( MSVC )
 	# Disable run-time type information
 	set( ALL_C_FLAGS "/GF /Gy /permissive-" )
 
+ 	if (MSVC_TOOLSET_VERSION GREATER_EQUAL 142)
+  		set( ALL_C_FLAGS "${ALL_C_FLAGS} /Zc:lambda" ) 
+  	endif()
+
 	if ( HAVE_VULKAN )
 		set( ALL_C_FLAGS "${ALL_C_FLAGS} /DHAVE_VULKAN" )
 	endif()

--- a/src/common/textures/bitmap.cpp
+++ b/src/common/textures/bitmap.cpp
@@ -226,7 +226,8 @@ static const CopyFunc copyfuncs[][12]={
 	COPY_FUNCS(bCopyAlpha),
 	COPY_FUNCS(bCopyNewAlpha),
 	COPY_FUNCS(bOverlay),
-	COPY_FUNCS(bOverwrite)
+	COPY_FUNCS(bOverwrite),
+	COPY_FUNCS(bComposeAlpha)
 };
 #undef COPY_FUNCS
 
@@ -257,21 +258,21 @@ bool ClipCopyPixelRect(const FClipRect *cr, int &originx, int &originy,
 		step_y = pstep_y;
 		break;
 
-	case 1: // rotate 90° right
+	case 1: // rotate 90Â° right
 		pixxoffset = 0;
 		pixyoffset = srcheight - 1;
 		step_x = -pstep_y;
 		step_y = pstep_x;
 		break;
 
-	case 2:	// rotate 180°
+	case 2:	// rotate 180Â°
 		pixxoffset = srcwidth - 1;
 		pixyoffset = srcheight - 1;
 		step_x = -pstep_x;
 		step_y = -pstep_y;
 		break;
 
-	case 3: // rotate 90° left
+	case 3: // rotate 90Â° left
 		pixxoffset = srcwidth - 1;
 		pixyoffset = 0;
 		step_x = pstep_y;
@@ -285,7 +286,7 @@ bool ClipCopyPixelRect(const FClipRect *cr, int &originx, int &originy,
 		step_y = pstep_y;
 		break;
 
-	case 5:	// flip horizontally and rotate 90° right
+	case 5:	// flip horizontally and rotate 90Â° right
 		pixxoffset = srcwidth - 1;
 		pixyoffset = srcheight - 1;
 		step_x = -pstep_y;
@@ -299,7 +300,7 @@ bool ClipCopyPixelRect(const FClipRect *cr, int &originx, int &originy,
 		step_y = -pstep_y;
 		break;
 
-	case 7:	// flip horizontally and rotate 90° left
+	case 7:	// flip horizontally and rotate 90Â° left
 		pixxoffset = 0;
 		pixyoffset = 0;
 		step_x = pstep_y;
@@ -443,7 +444,8 @@ static const CopyPalettedFunc copypalettedfuncs[]=
 	iCopyPaletted<cBGRA, bCopyAlpha>,
 	iCopyPaletted<cBGRA, bCopyNewAlpha>,
 	iCopyPaletted<cBGRA, bOverlay>,
-	iCopyPaletted<cBGRA, bOverwrite>
+	iCopyPaletted<cBGRA, bOverwrite>,
+	iCopyPaletted<cBGRA, bComposeAlpha>
 };
 
 //===========================================================================

--- a/src/common/textures/bitmap.h
+++ b/src/common/textures/bitmap.h
@@ -424,7 +424,8 @@ enum ECopyOp
 	OP_COPYALPHA,
 	OP_COPYNEWALPHA,
 	OP_OVERLAY,
-	OP_OVERWRITE
+	OP_OVERWRITE,
+	OP_COMPOSEALPHA		// Only intended for internal use.
 };
 
 struct FCopyInfo
@@ -507,5 +508,11 @@ struct bModulate
 	static __forceinline bool ProcessAlpha0() { return false; }
 };
 
+struct bComposeAlpha
+{
+	static __forceinline void OpC(uint8_t &d, uint8_t s, uint8_t a, FCopyInfo *i) { d = (s*a + d*(255-a))/255; }
+	static __forceinline void OpA(uint8_t &d, uint8_t s, FCopyInfo *i) { d = (s*255 + d*(255-s))/255; }
+	static __forceinline bool ProcessAlpha0() { return false; }
+};
 
 #endif

--- a/src/common/textures/formats/stbtexture.cpp
+++ b/src/common/textures/formats/stbtexture.cpp
@@ -63,15 +63,11 @@
 
 class FStbTexture : public FImageSource
 {
-private:
-	std::vector<int, FImageArenaAllocator<int>> durations;
 
 public:
-	FStbTexture (int lumpnum, int w, int h, int frames, int* delays);
+	FStbTexture (int lumpnum, int w, int h);
 	PalettedPixels CreatePalettedPixels(int conversion, int frame = 0) override;
 	int CopyPixels(FBitmap *bmp, int conversion, int frame = 0) override;
-	int GetDurationOfFrame(int frame) override;
-	int CopyPixelsIntoFrames(std::function<FBitmap* (int)> GetBitmap, int conversion) override;
 };
 
 
@@ -90,25 +86,10 @@ FImageSource *StbImage_TryCreate(FileReader & file, int lumpnum)
 {
 	int x, y, comp;
 	file.Seek(0, FileReader::SeekSet);
-	// Test GIF first.
-	stbi__context ctx;
-	stbi__start_callbacks(&ctx, &callbacks, &file);
-	if (stbi__gif_test(&ctx))
-	{
-		int frames;
-		int* delays = nullptr;
-		// Of course the entire damn file will have to be loaded because of the API.
-		auto images = stbi__load_gif_main(&ctx, &delays, &x, &y, &frames, &comp, STBI_rgb_alpha);
-		if (images)
-		{
-			STBI_FREE(images);
-			return new FStbTexture(lumpnum, x, y, frames, delays);
-		}
-	}
 	int result = stbi_info_from_callbacks(&callbacks, &file, &x, &y, &comp);
 	if (result == 1)
 	{
-		return new FStbTexture(lumpnum, x, y, 0, nullptr);
+		return new FStbTexture(lumpnum, x, y);
 	}
 
 	return nullptr;
@@ -120,30 +101,13 @@ FImageSource *StbImage_TryCreate(FileReader & file, int lumpnum)
 //
 //==========================================================================
 
-FStbTexture::FStbTexture (int lumpnum, int w, int h, int frames, int* delays)
+FStbTexture::FStbTexture (int lumpnum, int w, int h)
 	: FImageSource(lumpnum)
 {
 	Width = w;
 	Height = h;
 	LeftOffset = 0;
 	TopOffset = 0;
-	if (frames > 1)
-	{
-		for (int i = 0; i < frames; i++)
-		{
-			durations.push_back(delays[i]);
-		}
-		STBI_FREE(delays);
-		NumOfFrames = frames;
-	}
-}
-
-int FStbTexture::GetDurationOfFrame(int frame)
-{
-	if (frame == 0 || (frame - 1) >= durations.size())
-		return 1000;
-
-	return durations[frame - 1];
 }
 
 //==========================================================================
@@ -156,7 +120,7 @@ PalettedPixels FStbTexture::CreatePalettedPixels(int conversion, int frame)
 {
 	FBitmap bitmap;
 	bitmap.Create(Width, Height);
-	CopyPixels(&bitmap, conversion, frame);
+	CopyPixels(&bitmap, conversion);
 	const uint8_t *data = bitmap.GetPixels();
 
 	uint8_t *dest_p;
@@ -191,62 +155,10 @@ PalettedPixels FStbTexture::CreatePalettedPixels(int conversion, int frame)
 //
 //==========================================================================
 
-int FStbTexture::CopyPixelsIntoFrames(std::function<FBitmap* (int)> GetBitmap, int conversion)
-{
-	auto lump = fileSystem.OpenFileReader (SourceLump); 
-	int x, y, chan;
-	if (NumOfFrames > 1)
-	{
-		// Animated GIF image.
-		stbi__context ctx;
-		stbi__start_callbacks(&ctx, &callbacks, &lump);
-		if (stbi__gif_test(&ctx))
-		{
-			int frames;
-			int* delays = nullptr;
-			auto images = stbi__load_gif_main(&ctx, &delays, &x, &y, &frames, &chan, STBI_rgb_alpha);
-			if (images)
-			{
-				for (int frame = 0; frame < frames; frame++)
-				{
-					GetBitmap(frame)->CopyPixelDataRGB(0, 0, (uint8_t*)(images) + ((frame) * x * y * STBI_rgb_alpha), x, y, 4, x*4, 0, CF_RGBA);
-				}
-				STBI_FREE(images);
-				return -1;
-			}
-		}
-	}
-	return 0;
-}
-
-//==========================================================================
-//
-//
-//
-//==========================================================================
-
 int FStbTexture::CopyPixels(FBitmap *bmp, int conversion, int frame)
 {
 	auto lump = fileSystem.OpenFileReader (SourceLump); 
 	int x, y, chan;
-	if (NumOfFrames > 1 && frame > 0)
-	{
-		// Animated GIF image.
-		stbi__context ctx;
-		stbi__start_callbacks(&ctx, &callbacks, &lump);
-		if (stbi__gif_test(&ctx))
-		{
-			int frames;
-			int* delays = nullptr;
-			auto images = stbi__load_gif_main(&ctx, &delays, &x, &y, &frames, &chan, STBI_rgb_alpha);
-			if (images)
-			{
-				bmp->CopyPixelDataRGB(0, 0, (uint8_t*)(images) + ((frame - 1) * x * y * STBI_rgb_alpha), x, y, 4, x*4, 0, CF_RGBA);
-				STBI_FREE(images);
-				return -1;
-			}
-		}
-	}
 	auto image = stbi_load_from_callbacks(&callbacks, &lump, &x, &y, &chan, STBI_rgb_alpha); 	
 	if (image)
 		bmp->CopyPixelDataRGB(0, 0, image, x, y, 4, x*4, 0, CF_RGBA); 	

--- a/src/common/textures/image.h
+++ b/src/common/textures/image.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <functional>
 #include "tarray.h"
 #include "bitmap.h"
 #include "memarena.h"
@@ -56,6 +57,37 @@ public:
 
 };
 
+// Allocator for std::vector that allocates from ImageArena.
+template <class T>
+class FImageArenaAllocator
+{
+public:
+	typedef T value_type;
+
+	FImageArenaAllocator() = default;
+
+	template <class U>
+	constexpr FImageArenaAllocator(const FImageArenaAllocator<U>&) noexcept {}
+
+    [[nodiscard]] T* allocate(std::size_t n) {
+        if (n > std::numeric_limits<std::size_t>::max() / sizeof(T))
+            throw std::bad_array_new_length();
+
+        if (auto p = static_cast<T*>(ImageArena.Alloc(n * sizeof(T))))
+		{
+            return p;
+        }
+
+        throw std::bad_alloc();
+    }
+
+	void deallocate(T* p, std::size_t n) noexcept
+	{
+		// FMemArena can't deallocate, only allocate.
+		memset(p, 0, sizeof(T) * n);
+	}
+};
+
 // This represents a naked image. It has no high level logic attached to it.
 // All it can do is provide raw image data to its users.
 class FImageSource
@@ -68,8 +100,10 @@ protected:
 
 	int SourceLump;
 	int Width = 0, Height = 0;
-	int LeftOffset = 0, TopOffset = 0;			// Offsets stored in the image.
-	bool bUseGamePalette = false;				// true if this is an image without its own color set.
+	int LeftOffset = 0, TopOffset = 0;				// Global offsets stored in the image.
+	// Per-frame, non-global offsets stored in animated images.
+	std::vector<std::pair<int, int>, FImageArenaAllocator<std::pair<int, int>>> FrameOffsets;
+	bool bUseGamePalette = false;					// true if this is an image without its own color set.
 	int ImageID = -1;
 	int NumOfFrames = 1;
 
@@ -126,6 +160,12 @@ public:
 	// Gets duration of frame in miliseconds.
 	virtual int GetDurationOfFrame(int frame) { return 1000; }
 
+	// Can this animated image (re)use past frame content?
+	bool UsesPastFrame() { return true; }
+
+	virtual int CopyPixelsIntoFrames(std::function<FBitmap* (int)> GetBitmap, int conversion);
+	virtual void CreatePalettedPixelsOfFrames(std::function<PalettedPixels& (int)> GetPixels, int conversion);
+
 	// Conversion option
 	enum EType
 	{
@@ -155,6 +195,14 @@ public:
 	std::pair<int, int> GetOffsets() const
 	{
 		return std::make_pair(LeftOffset, TopOffset);
+	}
+
+	std::pair<int, int> GetOffsets(int frame)
+	{
+		if (frame == 0 || (frame - 1) >= FrameOffsets.size())
+			return std::make_pair(LeftOffset, TopOffset);
+		
+		return FrameOffsets[frame - 1];
 	}
 
 	void SetOffsets(int x, int y)

--- a/src/common/textures/m_png.h
+++ b/src/common/textures/m_png.h
@@ -34,6 +34,7 @@
 */
 
 #include <stdio.h>
+#include <deque>
 #include "zstring.h"
 #include "files.h"
 #include "palentry.h"
@@ -115,6 +116,11 @@ bool M_GetPNGText (PNGHandle *png, const char *keyword, char *buffer, size_t buf
 // image data into the provided buffer. Returns true on success.
 bool M_ReadIDAT (FileSys::FileReader &file, uint8_t *buffer, int width, int height, int pitch,
 				 uint8_t bitdepth, uint8_t colortype, uint8_t interlace, unsigned int idatlen);
+
+// Reads scattered fdAT chunks of a frame.
+bool M_ReadfdAT (FileReader &file, uint8_t *buffer, int width, int height, int pitch,
+				 uint8_t bitdepth, uint8_t colortype, uint8_t interlace, std::deque<uint32_t>& StartsOffdATs,
+				 int fdATCount);
 
 
 class FGameTexture;

--- a/src/common/textures/texturemanager.cpp
+++ b/src/common/textures/texturemanager.cpp
@@ -102,6 +102,7 @@ void FTextureManager::DeleteAll()
 
 	BuildTileData.Clear();
 	tmanips.Clear();
+	AnimatedTextures.Clear();
 }
 
 //==========================================================================
@@ -410,6 +411,7 @@ FTextureID FTextureManager::AddGameTexture (FGameTexture *texture, bool addtohas
 {
 	int bucket;
 	int hash;
+	FImageSource* img = nullptr;
 
 	if (texture == NULL) return FTextureID(-1);
 
@@ -437,6 +439,15 @@ FTextureID FTextureManager::AddGameTexture (FGameTexture *texture, bool addtohas
 	if (bucket >= 0) HashFirst[bucket] = trans;
 	auto id = FTextureID(trans);
 	texture->SetID(id);
+
+	if (!texture->GetTexture())
+		return id;
+	
+	img = texture->GetTexture()->GetImage();
+	if (texture->GetTexture()->TexFrame == 0 && img && img->GetNumOfFrames() > 1)
+	{
+		AnimatedTextures.Push(id);
+	}
 	return id;
 }
 

--- a/src/common/textures/texturemanager.h
+++ b/src/common/textures/texturemanager.h
@@ -98,6 +98,9 @@ public:
 	void SetLinkedTexture(int lump, FGameTexture* tex);
 	FGameTexture* GetLinkedTexture(int lump);
 
+	// Used to optimize animated textures lookup.
+	TArray<FTextureID> AnimatedTextures;
+
 	enum
 	{
 		TEXMAN_TryAny = 1,

--- a/src/common/textures/textures.h
+++ b/src/common/textures/textures.h
@@ -219,6 +219,7 @@ protected:
 	bool bHdr = false; 				// only canvas textures for now.
 	int8_t bTranslucent = -1;
 	int8_t areacount = 0;			// this is capped at 4 sections.
+	int TexFrame = 0;
 
 
 public:
@@ -378,7 +379,6 @@ class FImageTexture : public FTexture
 {
 	FImageSource* mImage;
 	bool bNoRemap0 = false;
-	int TexFrame = 0;
 protected:
 	void SetFromImage();
 public:

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -44,6 +44,7 @@
 #include "animations.h"
 #include "texturemanager.h"
 #include "image.h"
+#include "md5.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -287,6 +288,39 @@ void FTextureAnimator::InitAnimated (void)
 			}
 		}
 	}
+}
+
+void FTextureAnimator::InitAnimatedTextures()
+{
+	auto AnimatedTextures = TexMan.AnimatedTextures;
+
+	for (int i = 0; i < AnimatedTextures.Size(); i++)
+	{
+		FTextureID picnum = AnimatedTextures[i];
+		FGameTexture* gametex = TexMan.GetGameTexture(picnum);
+		FTexture* basetexture = gametex->GetTexture();
+		FImageSource* image = basetexture->GetImage();
+		TArray<FAnimDef::FAnimFrame> frames (32);
+
+		for (int i = 0; i < image->GetNumOfFrames(); i++)
+		{
+			FTexture* texture = CreateImageTexture(image, i + 1);
+			FGameTexture* newtex = MakeGameTexture(texture, "", gametex->GetUseType());
+			if (i == 0)
+			{
+				TexMan.ReplaceTexture(picnum, newtex, true);
+				picnum = newtex->GetID();
+			}
+			FTextureID textureId = (i == 0) ? newtex->GetID() : TexMan.AddGameTexture(newtex);
+			FAnimDef::FAnimFrame animFrame;
+			animFrame.SpeedMin = image->GetDurationOfFrame(i + 1);
+			animFrame.SpeedRange = 0;
+			animFrame.FramePic = textureId;
+			frames.Push(animFrame);
+		}
+		(void)AddComplexAnim(picnum, frames);
+	}
+	TexMan.AnimatedTextures.Clear();
 }
 
 //==========================================================================

--- a/src/gamedata/textures/animations.h
+++ b/src/gamedata/textures/animations.h
@@ -77,6 +77,7 @@ class FTextureAnimator
 
 	void FixAnimations();
 	void InitAnimated();
+	void InitAnimatedTextures();
 	void InitAnimDefs();
 	void InitSwitchList();
 	void ProcessSwitchDef(FScanner& sc);
@@ -107,6 +108,7 @@ public:
 	void Init()
 	{
 		DeleteAll();
+		InitAnimatedTextures();
 		InitAnimated();
 		InitAnimDefs();
 		FixAnimations();


### PR DESCRIPTION
This PR adds support for creating animated textures from animated images.

(I removed animated GIF support and the ImageArena custom allocator for std::vector from the previous PR so it should be in more of a state for merging later).