### PR TITLE
SpriteOffset fix

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -424,11 +424,10 @@ bool HWSprite::CalculateVertices(HWDrawInfo *di, FVector3 *v, DVector3 *vp)
 		// want those calculations here. Credit to PhantomBeta for this.
 		if (offx || offy)
 		{
-			FAngle zero = FAngle::fromDeg(0);
 			FQuaternion quat = FQuaternion::FromAngles(FAngle::fromDeg(270) - di->Viewpoint.HWAngles.Yaw, di->Viewpoint.HWAngles.Pitch, FAngle::fromDeg(0));
 			FVector3 sideVec = quat * FVector3(0, 1, 0);
 			FVector3 upVec = quat * FVector3(0, 0, 1);
-			FVector3 res = sideVec * offx + upVec * offy;
+			FVector3 res = sideVec * -offx + upVec * offy;
 			mat.Translate(res.X, res.Z, res.Y);
 		}
 


### PR DESCRIPTION
Fixed incorrect offsetting for SpriteOffset.

Specifically it wasn't consistent with the software renderer.