### PR TITLE
pc_cp2.wad MAP38 completion fix

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -2171,7 +2171,21 @@ class LevelCompatibility : LevelPostProcessor
 				// fix bad skill flags for a monster that's required to be killed.
 				SetThingSkills(1184, 1);
 				break;
-			}			
+			}
+
+			case '3B4AAD34E46443BD505CC6053FCD842A': // pc_cp2.wad map38
+			{
+				// Emulate the effect of the hidden Commander Keen's death
+				// since the Keen actor is modified by DEHACKED and doesn't work as intended:
+
+				// 1) Replace the Keen with an imp
+				SetThingEdNum(101, 3004);
+
+				// 2) Set its special to emulate A_KeenDie
+				SetThingSpecial(101, Door_Open);
+				SetThingArgument(101, 0, 666);
+				SetThingArgument(101, 1, 16);
+			}
 		}
 	}
 }


### PR DESCRIPTION
[MAP38](https://doomwiki.org/wiki/MAP38:_Reactor_Rush_(2048_Unleashed)) of [2048 Unleashed](https://www.doomworld.com/idgames/levels/doom2/Ports/megawads/pc_cp2) (pc_cp2.wad) cannot be completed in single player because it relies on a hidden Commander Keen (Thing 101) to call `A_KeenDie` to open some doors, but the Keen actor is heavily modified by DEHACKED and does not call that anymore (and does not even die in the first place due to much higher health).

This PR fixes the issue by replacing the offending Keen with an imp and setting its special to emulate the effects of `A_KeenDie` (open doors tagged 666). This allows the gameplay to progress normally so that the map can now be finished.

This map is rather short, so I've played through it from start to finish and made sure it actually works now. If further verification is necessary, please follow these instructions after starting the map:

1. First, go straight ahead for a bit and then turn left, you will see a lightning bolt symbol.
2. Shoot the symbol to reveal a switch, then press the switch.
3. After about 40 seconds, the four pillars in the corners of this room in will open, one of these pillars reveals a switch that allows you to progress further. (Without the fix, the pillars do not open and you get stuck.)