### PR TITLE
- Fix factual error in comment (re. PR#2316)

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -2178,7 +2178,7 @@ class LevelCompatibility : LevelPostProcessor
 				// Emulate the effect of the hidden Commander Keen's death
 				// since the Keen actor is modified by DEHACKED and doesn't work as intended:
 
-				// 1) Replace the Keen with an imp
+				// 1) Replace the Keen with a zombieman
 				SetThingEdNum(101, 3004);
 
 				// 2) Set its special to emulate A_KeenDie


### PR DESCRIPTION
Follow-up to [2316#issuecomment-1867937069](https://github.com/ZDoom/gzdoom/pull/2316#issuecomment-1867937069) - wrong monster type mentioned in comment, would like to fix it.

Sorry about this! (It still does work as intended, though.)

