### PR TITLE
Fix 'filter' for directories

### DIFF
--- a/src/common/filesystem/include/resourcefile.h
+++ b/src/common/filesystem/include/resourcefile.h
@@ -105,6 +105,7 @@ struct FResourceEntry
 	uint16_t Flags;
 	uint16_t Method;
 	int16_t Namespace;
+	const char* SystemFilePath;
 };
 
 void SetMainThread();

--- a/src/common/filesystem/source/file_directory.cpp
+++ b/src/common/filesystem/source/file_directory.cpp
@@ -172,7 +172,7 @@ FileReader FDirectory::GetEntryReader(uint32_t entry, int readertype, int)
 		std::string fn = mBasePath;
 		fn += Entries[entry].SystemFilePath ?
 			Entries[entry].SystemFilePath :
-	        Entries[entry].FileName;
+			Entries[entry].FileName;
 		fr.OpenFile(fn.c_str());
 		if (readertype == READER_CACHED)
 		{

--- a/src/common/filesystem/source/file_directory.cpp
+++ b/src/common/filesystem/source/file_directory.cpp
@@ -131,6 +131,7 @@ int FDirectory::AddDirectory(const char *dirpath, LumpFilterInfo* filter, FileSy
 					}
 					// for internal access we use the normalized form of the relative path.
 					Entries[count].FileName = NormalizeFileName(entry.FilePathRel.c_str());
+					Entries[count].SystemFilePath = stringpool->Strdup(Entries[count].FileName);
 					Entries[count].CompressedSize = Entries[count].Length = entry.Length;
 					Entries[count].Flags = RESFF_FULLPATH;
 					Entries[count].ResourceID = -1;
@@ -153,6 +154,7 @@ int FDirectory::AddDirectory(const char *dirpath, LumpFilterInfo* filter, FileSy
 bool FDirectory::Open(LumpFilterInfo* filter, FileSystemMessageFunc Printf)
 {
 	NumLumps = AddDirectory(FileName, filter, Printf);
+	PostProcessArchive(filter);
 	return true;
 }
 
@@ -167,7 +169,10 @@ FileReader FDirectory::GetEntryReader(uint32_t entry, int readertype, int)
 	FileReader fr;
 	if (entry < NumLumps)
 	{
-		std::string fn = mBasePath; fn += Entries[entry].FileName;
+		std::string fn = mBasePath;
+		fn += Entries[entry].SystemFilePath ?
+			Entries[entry].SystemFilePath :
+	        Entries[entry].FileName;
 		fr.OpenFile(fn.c_str());
 		if (readertype == READER_CACHED)
 		{


### PR DESCRIPTION
Fix for the directory filesystem: files under 'filter/' folder are not ignored anymore.

FileName-s now respect the game filter-s, i.e. ignoring files not under active filters, but adding files under active filters.

For each directory file entry, maintain the actual file path on a disk, because the `FilePath` in an entry can be modified by a filter.