### PR TITLE
Portal Sprite Fix

### DIFF
--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -375,6 +375,7 @@ public:
 	int			chickenPeck = 0;			// chicken peck countdown
 	int			jumpTics = 0;				// delay the next jump for a moment
 	bool		onground = 0;				// Identifies if this player is on the ground or other object
+	bool		crossingPortal = 0;			// Crossing a portal, used only to disable interpolation.
 
 	int			respawn_time = 0;			// [RH] delay respawning until this tic
 	TObjPtr<AActor*>	camera = MakeObjPtr<AActor*>(nullptr);			// [RH] Whose eyes this player sees through

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -2602,13 +2602,19 @@ bool P_TryMove(AActor *thing, const DVector2 &pos,
 					auto p = thing->Level->GetConsolePlayer();
 					if (p) p->viewz += hit.pos.Z;	// needs to be done here because otherwise the renderer will not catch the change.
 					P_TranslatePortalAngle(ld, hit.angle);
+
+					if (port->mType == PORTT_INTERACTIVE || port->mType == PORTT_TELEPORT)
+					{
+						if (thing->player)
+							thing->player->crossingPortal = true;
+					}
 				}
 				R_AddInterpolationPoint(hit);
 			}
 			if (port->mType == PORTT_LINKED)
 			{
 				continue;
-		}
+			}
 		}
 		break;
 	}

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3691,7 +3691,13 @@ void AActor::CheckPortalTransition(bool islinked)
 			else break;
 		}
 	}
-	if (islinked && moved) LinkToWorld(&ctx);
+	if (moved) 
+	{
+		if (islinked)
+			LinkToWorld(&ctx);
+		if (player)
+			player->crossingPortal = true;
+	}
 }
 
 DEFINE_ACTION_FUNCTION(AActor, CheckPortalTransition)

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -465,6 +465,11 @@ bool P_NoInterpolation(player_t const *player, AActor const *actor)
 
 void R_InterpolateView (FRenderViewpoint &viewpoint, player_t *player, double Frac, InterpolationViewer *iview)
 {
+	if (player && player->crossingPortal)
+	{
+		NoInterpolateView = true;
+		player->crossingPortal = false;
+	}
 	if (NoInterpolateView)
 	{
 		InterpolationPath.Clear();


### PR DESCRIPTION
Fixed player sprites showing up when crossing portals by disabling interpolation.

**NOTE:** This is only temporary until I can work out a more permanent solution to the problems with interpolation. Currently, whenever crossing a portal, there's a high chance to show the player sprite, or even the void itself. Which means interpolation only works part of the time with interactive portals. 

It's highly immersion breaking and it's bothersome to no end suddenly seeing my player body just popping in out of nowhere. Compared to one tick of no view interpolation, that is much more preferable.