### PR TITLE
Exposed 'viewactive'

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -3154,6 +3154,7 @@ DEFINE_GLOBAL(globalfreeze)
 DEFINE_GLOBAL(gametic)
 DEFINE_GLOBAL(demoplayback)
 DEFINE_GLOBAL(automapactive);
+DEFINE_GLOBAL(viewactive);
 DEFINE_GLOBAL(Net_Arbitrator);
 DEFINE_GLOBAL(netgame);
 DEFINE_GLOBAL(paused);

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -8,7 +8,8 @@ extend struct _
 	native readonly Array<@TerrainDef> Terrains;
 	native int validcount;
 	native play @DehInfo deh;
-	native readonly bool automapactive;
+	native readonly ui bool automapactive;	// is automap enabled?
+	native readonly ui bool viewactive;		// if automap is active, true = main automap, false = overlay automap.
 	native readonly TextureID skyflatnum;
 	native readonly int gametic;
 	native readonly int Net_Arbitrator;


### PR DESCRIPTION
Now modders can check if the map is in overlay mode or not using this code.
```
if (automapactive)	
{	
	if (viewactive)
		Console.Printf("Overlay");
	else
		Console.Printf("Automap");
}
```
Also, made `automapactive` UI scoped since checking this on the play side may cause desyncs.

