### PR TITLE
Streamlined implementation of mGrayCheck and IsGrayed() in option menu items

### DIFF
--- a/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
@@ -900,22 +900,24 @@ class OptionMenuItemSlider : OptionMenuSliderBase
 class OptionMenuItemColorPicker : OptionMenuItem
 {
 	CVar mCVar;
+	CVar mGrayCheck;
 
 	const CPF_RESET = 0x20001;
 
-	OptionMenuItemColorPicker Init(String label, Name command)
+	OptionMenuItemColorPicker Init(String label, Name command, CVar graycheck = null)
 	{
 		Super.Init(label, command);
 		CVar cv = CVar.FindCVar(command);
 		if (cv != null && cv.GetRealType() != CVar.CVAR_Color) cv = null;
 		mCVar = cv;
+		mGrayCheck = graycheck;
 		return self;
 	}
 
 	//=============================================================================
 	override int Draw(OptionMenuDescriptor desc, int y, int indent, bool selected)
 	{
-		drawLabel(indent, y, selected? OptionMenuSettings.mFontColorSelection : OptionMenuSettings.mFontColor);
+		drawLabel(indent, y, selected? OptionMenuSettings.mFontColorSelection : OptionMenuSettings.mFontColor,  isGrayed());
 
 		if (mCVar != null)
 		{
@@ -962,6 +964,16 @@ class OptionMenuItemColorPicker : OptionMenuItem
 			}
 		}
 		return false;
+	}
+
+	virtual bool IsGrayed(void)
+	{
+		return mGrayCheck != NULL && !mGrayCheck.GetInt();
+	}
+
+	override bool Selectable()
+	{
+		return !isGrayed();
 	}
 }
 

--- a/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
@@ -36,12 +36,14 @@ class OptionMenuItem : MenuItemBase
 {
 	String mLabel;
 	bool mCentered;
+	CVar mGrayCheck;
 
-	protected void Init(String label, String command, bool center = false)
+	protected void Init(String label, String command, bool center = false, CVar graycheck = null)
 	{
 		Super.Init(0, 0, command);
 		mLabel = label;
 		mCentered = center;
+		mGrayCheck = graycheck;
 	}
 
 	protected void drawText(int x, int y, int color, String text, bool grayed = false)
@@ -66,10 +68,14 @@ class OptionMenuItem : MenuItemBase
 		Menu.DrawOptionText(indent + CursorSpace(), y, color, text, grayed, localize);
 	}
 
-
 	int CursorSpace()
 	{
 		return (14 * CleanXfac_1);
+	}
+
+	virtual bool IsGrayed()
+	{
+		return mGrayCheck != null && !mGrayCheck.GetInt();
 	}
 
 	override bool Selectable()
@@ -85,7 +91,7 @@ class OptionMenuItem : MenuItemBase
 	}
 
 	override bool MouseEvent(int type, int x, int y)
-{
+	{
 		if (Selectable() && type == Menu.MOUSE_Release)
 		{
 			return Menu.GetCurrentMenu().MenuEvent(Menu.MKEY_Enter, true);
@@ -253,16 +259,14 @@ class OptionMenuItemOptionBase : OptionMenuItem
 {
 	// command is a CVAR
 	Name mValues;	// Entry in OptionValues table
-	CVar mGrayCheck;
 	int mCenter;
 
 	const OP_VALUES = 0x11001;
 
 	protected void Init(String label, Name command, Name values, CVar graycheck, int center)
 	{
-		Super.Init(label, command);
+		Super.Init(label, command, false, graycheck);
 		mValues = values;
-		mGrayCheck = graycheck;
 		mCenter = center;
 	}
 
@@ -337,11 +341,6 @@ class OptionMenuItemOptionBase : OptionMenuItem
 			return Super.MenuEvent(mkey, fromcontroller);
 		}
 		return true;
-	}
-
-	virtual bool isGrayed()
-	{
-		return mGrayCheck != null && !mGrayCheck.GetInt();
 	}
 
 	override bool Selectable()
@@ -699,18 +698,16 @@ class OptionMenuSliderBase : OptionMenuItem
 	int mShowValue;
 	int mDrawX;
 	int mSliderShort;
-	CVar mGrayCheck;
 
 	protected void Init(String label, double min, double max, double step, int showval, Name command = 'none', CVar graycheck = NULL)
 	{
-		Super.Init(label, command);
+		Super.Init(label, command, false, graycheck);
 		mMin = min;
 		mMax = max;
 		mStep = step;
 		mShowValue = showval;
 		mDrawX = 0;
 		mSliderShort = 0;
-		mGrayCheck = graycheck;
 	}
 
 	virtual double GetSliderValue()
@@ -720,11 +717,6 @@ class OptionMenuSliderBase : OptionMenuItem
 
 	virtual void SetSliderValue(double val)
 	{
-	}
-
-	virtual bool IsGrayed(void)
-	{
-		return mGrayCheck != NULL && !mGrayCheck.GetInt();
 	}
 
 	override bool Selectable(void)
@@ -900,17 +892,15 @@ class OptionMenuItemSlider : OptionMenuSliderBase
 class OptionMenuItemColorPicker : OptionMenuItem
 {
 	CVar mCVar;
-	CVar mGrayCheck;
 
 	const CPF_RESET = 0x20001;
 
 	OptionMenuItemColorPicker Init(String label, Name command, CVar graycheck = null)
 	{
-		Super.Init(label, command);
+		Super.Init(label, command, false, graycheck);
 		CVar cv = CVar.FindCVar(command);
 		if (cv != null && cv.GetRealType() != CVar.CVAR_Color) cv = null;
 		mCVar = cv;
-		mGrayCheck = graycheck;
 		return self;
 	}
 
@@ -966,11 +956,6 @@ class OptionMenuItemColorPicker : OptionMenuItem
 		return false;
 	}
 
-	virtual bool IsGrayed(void)
-	{
-		return mGrayCheck != NULL && !mGrayCheck.GetInt();
-	}
-
 	override bool Selectable()
 	{
 		return !isGrayed();
@@ -987,11 +972,12 @@ class OptionMenuItemColorPicker : OptionMenuItem
 
 class OptionMenuFieldBase : OptionMenuItem
 {
+	CVar mCVar;
+
 	void Init (String label, Name command, CVar graycheck = null)
 	{
-		Super.Init(label, command);
+		Super.Init(label, command, false, graycheck);
 		mCVar = CVar.FindCVar(mAction);
-		mGrayCheck  = graycheck;
 	}
 
 	String GetCVarString()
@@ -1009,9 +995,8 @@ class OptionMenuFieldBase : OptionMenuItem
 
 	override int Draw (OptionMenuDescriptor d, int y, int indent, bool selected)
 	{
-		bool grayed = mGrayCheck != null && !mGrayCheck.GetInt();
-		drawLabel(indent, y, selected ? OptionMenuSettings.mFontColorSelection : OptionMenuSettings.mFontColor, grayed);
-		drawValue(indent, y, OptionMenuSettings.mFontColorValue, Represent(), grayed, false);
+		drawLabel(indent, y, selected ? OptionMenuSettings.mFontColorSelection : OptionMenuSettings.mFontColor, isGrayed());
+		drawValue(indent, y, OptionMenuSettings.mFontColorValue, Represent(), isGrayed(), false);
 		return indent;
 	}
 
@@ -1036,11 +1021,8 @@ class OptionMenuFieldBase : OptionMenuItem
 
 	override bool Selectable()
 	{
-		return mGrayCheck == null || mGrayCheck.GetInt() != 0;
+		return !isGrayed();
 	}
-
-	CVar mCVar;
-	CVar mGrayCheck;
 }
 
 //=============================================================================
@@ -1142,7 +1124,6 @@ class OptionMenuItemNumberField : OptionMenuFieldBase
 		return String.format("%.3f", mCVar.GetFloat());
 	}
 
-
 	override bool MenuEvent (int mkey, bool fromcontroller)
 	{
 		if (mCVar)
@@ -1188,9 +1169,9 @@ class OptionMenuItemScaleSlider : OptionMenuItemSlider
 	String TextNegOne;
 	int mClickVal;
 
-	OptionMenuItemScaleSlider Init(String label, Name command, double min, double max, double step, String zero, String negone = "")
+	OptionMenuItemScaleSlider Init(String label, Name command, double min, double max, double step, String zero, String negone = "", CVar graycheck = null)
 	{
-		Super.Init(label, command, min, max, step, 0);
+		Super.Init(label, command, min, max, step, 0, graycheck);
 		mCVar =CVar.FindCVar(command);
 		TextZero = zero;
 		TextNEgOne = negone;
@@ -1207,12 +1188,12 @@ class OptionMenuItemScaleSlider : OptionMenuItemSlider
 		if ((Selection == 0 || Selection == -1) && mClickVal <= 0)
 		{
 			String text = Selection == 0? TextZero : Selection == -1? TextNegOne  : "";
-			drawValue(indent, y, OptionMenuSettings.mFontColorValue, text);
+			drawValue(indent, y, OptionMenuSettings.mFontColorValue, text, isGrayed());
 		}
 		else
 		{
 			mDrawX = indent + CursorSpace();
-			DrawSlider (mDrawX, y, mMin, mMax, GetSliderValue(), mShowValue, indent);
+			DrawSlider (mDrawX, y, mMin, mMax, GetSliderValue(), mShowValue, indent, isGrayed());
 		}
 		return indent;
 	}


### PR DESCRIPTION
(Updated with 2nd commit) This now adds a streamlined implementation of mGrayCheck and IsGrayed() across Option menu items. Instead of being haphazardly added to different elements, the main field and function is implemented in OptionMenuItem and used across other elements. This also adds graycheck to ScaleSlider, ColorPicker and TextField (the former two didn't have it, and the latter did but in an incomplete form where the element would become unselectable but not actually visibly greyed-out). Hopefully, I didn't miss anything.