### PR TITLE
- add two parameters to GetSpriteTexture: spritenum and framenum, sin…

### DIFF
--- a/src/p_states.cpp
+++ b/src/p_states.cpp
@@ -67,15 +67,20 @@ DEFINE_ACTION_FUNCTION(FState, GetSpriteTexture)
 	PARAM_INT(skin);
 	PARAM_FLOAT(scalex);
 	PARAM_FLOAT(scaley);
+	PARAM_INT(spritenum);
+	PARAM_INT(framenum);
+
+	int sprnum = (spritenum == -1) ? self->sprite : spritenum;
+	int frnum = (framenum == -1) ? self->GetFrame() : framenum;
 
 	spriteframe_t *sprframe;
 	if (skin == 0)
 	{
-		sprframe = &SpriteFrames[sprites[self->sprite].spriteframes + self->GetFrame()];
+		sprframe = &SpriteFrames[sprites[sprnum].spriteframes + frnum];
 	}
 	else
 	{
-		sprframe = &SpriteFrames[sprites[Skins[skin].sprite].spriteframes + self->GetFrame()];
+		sprframe = &SpriteFrames[sprites[Skins[skin].sprite].spriteframes + frnum];
 		scalex = Skins[skin].Scale.X;
 		scaley = Skins[skin].Scale.Y;
 	}

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -581,7 +581,7 @@ struct State native
 	
 	native int DistanceTo(state other);
 	native bool ValidateSpriteFrame();
-	native TextureID, bool, Vector2 GetSpriteTexture(int rotation, int skin = 0, Vector2 scale = (0,0));
+	native TextureID, bool, Vector2 GetSpriteTexture(int rotation, int skin = 0, Vector2 scale = (0,0), int spritenum = -1, int framenum = -1);
 	native bool InStateSequence(State base);
 }
 


### PR DESCRIPTION
…ce some states are "####" "#"

The use case for this would be to allow for a complete framework for custom sprite rendering based on Actor rendering, except using VisualThinkers instead