### PR TITLE
Added SendNetworkCommand

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2708,13 +2708,16 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 
 	case DEM_ZSC_CMD:
 		{
-			int cmd = ReadLong(stream);
+			FName cmd = ReadStringConst(stream);
 			unsigned int size = ReadWord(stream);
 
 			TArray<uint8_t> buffer = {};
-			buffer.Grow(size);
-			for (unsigned int i = 0u; i < size; ++i)
-				buffer.Push(ReadByte(stream));
+			if (size)
+			{
+				buffer.Grow(size);
+				for (unsigned int i = 0u; i < size; ++i)
+					buffer.Push(ReadByte(stream));
+			}
 
 			FNetworkCommand netCmd = { player, cmd, buffer };
 			primaryLevel->localEventManager->NetCommand(netCmd);
@@ -2779,7 +2782,8 @@ void Net_SkipCommand (int type, uint8_t **stream)
 			break;
 
 		case DEM_ZSC_CMD:
-			skip = 6 + (((*stream)[4] << 8) | (*stream)[5]);
+			skip = strlen((char*)(*stream)) + 1;
+			skip += (((*stream)[skip] << 8) | (*stream)[skip + 1]) + 2;
 			break;
 
 		case DEM_SUMMON2:

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2705,6 +2705,21 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 	case DEM_ENDSCREENJOB:
 		EndScreenJob();
 		break;
+
+	case DEM_ZSC_CMD:
+		{
+			int cmd = ReadLong(stream);
+			unsigned int size = ReadWord(stream);
+
+			TArray<uint8_t> buffer = {};
+			buffer.Grow(size);
+			for (unsigned int i = 0u; i < size; ++i)
+				buffer.Push(ReadByte(stream));
+
+			FNetworkCommand netCmd = { player, cmd, buffer };
+			primaryLevel->localEventManager->NetCommand(netCmd);
+		}
+	break;
 		
 	default:
 		I_Error ("Unknown net command: %d", type);
@@ -2761,6 +2776,10 @@ void Net_SkipCommand (int type, uint8_t **stream)
 
 		case DEM_NETEVENT:
 			skip = strlen((char *)(*stream)) + 15;
+			break;
+
+		case DEM_ZSC_CMD:
+			skip = 6 + (((*stream)[4] << 8) | (*stream)[5]);
 			break;
 
 		case DEM_SUMMON2:

--- a/src/d_protocol.h
+++ b/src/d_protocol.h
@@ -163,6 +163,7 @@ enum EDemoCommand
 	DEM_MDK,			// 71 String: Damage type
 	DEM_SETINV,			// 72 SetInventory
 	DEM_ENDSCREENJOB,
+	DEM_ZSC_CMD,		// 74 Long: Command id, Word: Byte size of command
 };
 
 // The following are implemented by cht_DoCheat in m_cheat.cpp

--- a/src/d_protocol.h
+++ b/src/d_protocol.h
@@ -163,7 +163,7 @@ enum EDemoCommand
 	DEM_MDK,			// 71 String: Damage type
 	DEM_SETINV,			// 72 SetInventory
 	DEM_ENDSCREENJOB,
-	DEM_ZSC_CMD,		// 74 Long: Command id, Word: Byte size of command
+	DEM_ZSC_CMD,		// 74 String: Command, Word: Byte size of command
 };
 
 // The following are implemented by cht_DoCheat in m_cheat.cpp

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -934,6 +934,67 @@ DEFINE_ACTION_FUNCTION(FNetworkCommand, ReadVector3)
 	ACTION_RETURN_VEC3(vec);
 }
 
+DEFINE_ACTION_FUNCTION(FNetworkCommand, ReadIntArray)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FNetworkCommand);
+	PARAM_OUTPOINTER(values, TArray<int>);
+	PARAM_INT(type)
+
+	unsigned int size = self->ReadLong();
+	for (unsigned int i = 0u; i < size; ++i)
+	{
+		switch (type)
+		{
+			case NET_BYTE:
+				values->Push(self->ReadByte());
+				break;
+
+			case NET_WORD:
+				values->Push(self->ReadWord());
+				break;
+
+			default:
+				values->Push(self->ReadLong());
+				break;
+		}
+	}
+
+	return 0;
+}
+
+DEFINE_ACTION_FUNCTION(FNetworkCommand, ReadFloatArray)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FNetworkCommand);
+	PARAM_OUTPOINTER(values, TArray<double>);
+
+	unsigned int size = self->ReadLong();
+	for (unsigned int i = 0u; i < size; ++i)
+		values->Push(self->ReadFloat());
+
+	return 0;
+}
+
+DEFINE_ACTION_FUNCTION(FNetworkCommand, ReadStringArray)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FNetworkCommand);
+	PARAM_OUTPOINTER(values, TArray<FString>);
+	PARAM_BOOL(skipEmpty);
+
+	unsigned int size = self->ReadLong();
+	for (unsigned int i = 0u; i < size; ++i)
+	{
+		FString res = {};
+		auto str = self->ReadString();
+		if (str != nullptr)
+			res = str;
+
+		if (!skipEmpty || !res.IsEmpty())
+			values->Push(res);
+	}
+
+	return 0;
+}
+
 DEFINE_ACTION_FUNCTION(FNetworkBuffer, AddByte)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(FNetworkBuffer);
@@ -1001,6 +1062,61 @@ DEFINE_ACTION_FUNCTION(FNetworkBuffer, AddVector3)
 	self->AddFloat(x);
 	self->AddFloat(y);
 	self->AddFloat(z);
+	return 0;
+}
+
+DEFINE_ACTION_FUNCTION(FNetworkBuffer, AddIntArray)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FNetworkBuffer);
+	PARAM_POINTER(values, TArray<int>);
+	PARAM_INT(type);
+
+	unsigned int size = values->Size();
+	self->AddLong(size);
+	for (unsigned int i = 0u; i < size; ++i)
+	{
+		switch (type)
+		{
+			case NET_BYTE:
+				self->AddByte((*values)[i]);
+				break;
+
+			case NET_WORD:
+				self->AddWord((*values)[i]);
+				break;
+
+			default:
+				self->AddLong((*values)[i]);
+				break;
+		}
+	}
+
+	return 0;
+}
+
+DEFINE_ACTION_FUNCTION(FNetworkBuffer, AddFloatArray)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FNetworkBuffer);
+	PARAM_POINTER(values, TArray<double>);
+
+	unsigned int size = values->Size();
+	self->AddLong(size);
+	for (unsigned int i = 0u; i < size; ++i)
+		self->AddFloat((*values)[i]);
+
+	return 0;
+}
+
+DEFINE_ACTION_FUNCTION(FNetworkBuffer, AddStringArray)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FNetworkBuffer);
+	PARAM_POINTER(values, TArray<FString>);
+
+	unsigned int size = values->Size();
+	self->AddLong(size);
+	for (unsigned int i = 0u; i < size; ++i)
+		self->AddString((*values)[i]);
+
 	return 0;
 }
 

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -57,6 +57,7 @@
 #include "a_dynlight.h"
 #include "types.h"
 #include "dictionary.h"
+#include "events.h"
 
 static TArray<FPropertyInfo*> properties;
 static TArray<AFuncDesc> AFTable;
@@ -806,6 +807,10 @@ void InitThingdef()
 	auto frp = NewStruct("FRailParams", nullptr);
 	frp->Size = sizeof(FRailParams);
 	frp->Align = alignof(FRailParams);
+
+	auto netcmdstruct = NewStruct("NetworkCommand", nullptr, true);
+	netcmdstruct->Size = sizeof(FNetworkCommand);
+	netcmdstruct->Align = alignof(FNetworkCommand);
 
 	auto fltd = NewStruct("FLineTraceData", nullptr);
 	fltd->Size = sizeof(FLineTraceData);

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -812,6 +812,10 @@ void InitThingdef()
 	netcmdstruct->Size = sizeof(FNetworkCommand);
 	netcmdstruct->Align = alignof(FNetworkCommand);
 
+	auto netbuffstruct = NewStruct("NetworkBuffer", nullptr);
+	netbuffstruct->Size = sizeof(FNetworkBuffer);
+	netbuffstruct->Align = alignof(FNetworkBuffer);
+
 	auto fltd = NewStruct("FLineTraceData", nullptr);
 	fltd->Size = sizeof(FLineTraceData);
 	fltd->Align = alignof(FLineTraceData);

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -812,10 +812,6 @@ void InitThingdef()
 	netcmdstruct->Size = sizeof(FNetworkCommand);
 	netcmdstruct->Align = alignof(FNetworkCommand);
 
-	auto netbuffstruct = NewStruct("NetworkBuffer", nullptr);
-	netbuffstruct->Size = sizeof(FNetworkBuffer);
-	netbuffstruct->Align = alignof(FNetworkBuffer);
-
 	auto fltd = NewStruct("FLineTraceData", nullptr);
 	fltd->Size = sizeof(FLineTraceData);
 	fltd->Align = alignof(FLineTraceData);

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -22,6 +22,9 @@ struct NetworkCommand native play version("4.12")
     native Name ReadName();
     native Vector2 ReadVector2();
     native Vector3 ReadVector3();
+    native void ReadIntArray(out Array<int> values, ENetCmd intSize = NET_LONG);
+    native void ReadFloatArray(out Array<double> values);
+    native void ReadStringArray(out Array<string> values, bool skipEmpty = false);
 }
 
 struct NetworkBuffer native version("4.12")
@@ -36,6 +39,9 @@ struct NetworkBuffer native version("4.12")
     native void AddName(Name value);
     native void AddVector2(Vector2 value);
     native void AddVector3(Vector3 value);
+    native void AddIntArray(Array<int> values, ENetCmd intSize = NET_LONG);
+    native void AddFloatArray(Array<double> values);
+    native void AddStringArray(Array<string> values);
 }
 
 struct RenderEvent native ui version("2.4")

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -1,3 +1,23 @@
+enum ENetCmd
+{
+	NET_BYTE = 1,
+	NET_WORD,
+	NET_LONG,
+	NET_FLOAT,
+	NET_STRING,
+}
+
+struct NetworkCommand native play version("4.12")
+{
+    native readonly int Player;
+    native readonly int Command;
+
+    native int ReadByte();
+    native int ReadWord();
+    native int ReadLong();
+    native double ReadFloat();
+    native string ReadString();
+}
 
 struct RenderEvent native ui version("2.4")
 {
@@ -127,6 +147,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual ui void ConsoleProcess(ConsoleEvent e) {}
     virtual ui void InterfaceProcess(ConsoleEvent e) {}
     virtual void NetworkProcess(ConsoleEvent e) {}
+    version("4.12") virtual void NetworkCommandProcess(NetworkCommand cmd) {}
     
     //
     virtual void CheckReplacement(ReplaceEvent e) {}
@@ -150,5 +171,6 @@ class EventHandler : StaticEventHandler native version("2.4")
 {
     clearscope static native StaticEventHandler Find(class<StaticEventHandler> type);
     clearscope static native void SendNetworkEvent(String name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
+    version("4.12") clearscope static native vararg bool SendNetworkCommand(int cmd, ...);
     clearscope static native void SendInterfaceEvent(int playerNum, string name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
 }

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -10,13 +10,32 @@ enum ENetCmd
 struct NetworkCommand native play version("4.12")
 {
     native readonly int Player;
-    native readonly int Command;
+    native readonly Name Command;
 
     native int ReadByte();
     native int ReadWord();
     native int ReadLong();
     native double ReadFloat();
     native string ReadString();
+
+    // Wrappers
+    native Name ReadName();
+    native Vector2 ReadVector2();
+    native Vector3 ReadVector3();
+}
+
+struct NetworkBuffer native version("4.12")
+{
+    native void AddByte(int value);
+    native void AddWord(int value);
+    native void AddLong(int value);
+    native void AddFloat(double value);
+    native void AddString(string value);
+
+    // Wrappers
+    native void AddName(Name value);
+    native void AddVector2(Vector2 value);
+    native void AddVector3(Vector3 value);
 }
 
 struct RenderEvent native ui version("2.4")
@@ -171,6 +190,7 @@ class EventHandler : StaticEventHandler native version("2.4")
 {
     clearscope static native StaticEventHandler Find(class<StaticEventHandler> type);
     clearscope static native void SendNetworkEvent(String name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
-    version("4.12") clearscope static native vararg bool SendNetworkCommand(int cmd, ...);
+    version("4.12") clearscope static native vararg bool SendNetworkCommand(Name cmd, ...);
+    version("4.12") clearscope static native bool SendNetworkBuffer(Name cmd, NetworkBuffer buffer);
     clearscope static native void SendInterfaceEvent(int playerNum, string name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
 }

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -20,14 +20,18 @@ struct NetworkCommand native play version("4.12")
 
     // Wrappers
     native Name ReadName();
+    native double ReadMapUnit(); // 16.16 long -> double
+    native double ReadAngle(); // BAM long -> double
     native Vector2 ReadVector2();
     native Vector3 ReadVector3();
+    native Vector4 ReadVector4();
+    native Quat ReadQuat();
     native void ReadIntArray(out Array<int> values, ENetCmd intSize = NET_LONG);
     native void ReadFloatArray(out Array<double> values);
     native void ReadStringArray(out Array<string> values, bool skipEmpty = false);
 }
 
-struct NetworkBuffer native version("4.12")
+class NetworkBuffer native version("4.12")
 {
     native void AddByte(int value);
     native void AddWord(int value);
@@ -37,8 +41,12 @@ struct NetworkBuffer native version("4.12")
 
     // Wrappers
     native void AddName(Name value);
+    native void AddMapUnit(double value); // double -> 16.16 long
+    native void AddAngle(double value); // double -> BAM long
     native void AddVector2(Vector2 value);
     native void AddVector3(Vector3 value);
+    native void AddVector4(Vector4 value);
+    native void AddQuat(Quat value);
     native void AddIntArray(Array<int> values, ENetCmd intSize = NET_LONG);
     native void AddFloatArray(Array<double> values);
     native void AddStringArray(Array<string> values);


### PR DESCRIPTION
Allows for a custom message to be sent over the network without the need for SendNetworkEvent. This includes all the possible valid types of byte, word, long, float, and string. Mainly nice for efficiently serializing data over the network without having to rely on bloated string parsing and creation. This will cover pretty much all future cases of expanding network events. For instance, objects can be serialized with a `SerializeObject()` function that sends its fields over the network and a `DeserializeObject(NetworkCommand cmd)` function that can reassign everything on the other side. While this can be done with strings now, I can tell you from experience it's very annoying. As a side bonus it's completely gated from console usage unlike `netevent` meaning no more `isManual` checks.