### PR TITLE
Add Actor.HasReceived

### DIFF
--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -518,6 +518,11 @@ class Actor : Thinker native
 		return true;
 	}
 
+	// [AA] Called by inventory items at the end of CallTryPickup to let actors
+	// do something with the items they've received. 'Item' might be null for
+	// items that disappear on pickup.
+	virtual void HasReceived(Inventory item) {}
+
   // Called in TryMove if the mover ran into another Actor. This isn't called on players
 	// if they're currently predicting. Guarantees collisions unlike CanCollideWith.
 	virtual void CollidedWith(Actor other, bool passive) {}

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -645,6 +645,8 @@ class Inventory : Actor
 					}
 				}
 			}
+			// [AA] Let the toucher do something with the item they've just received:
+			toucher.HasReceived(self);
 		}
 		return res, toucher;
 	}


### PR DESCRIPTION
A complimentary feature to https://github.com/ZDoom/gzdoom/pull/2295. This one adds a `HasReceived()` function to Actor called at the end of CallTryPickup(). It'll inform the actor about the fact that they've received an item, which can be used for all sorts of things.