### PR TITLE
open the main game window earlier in the startup procedure.

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3096,6 +3096,13 @@ static int FileSystemPrintf(FSMessageLevel level, const char* fmt, ...)
 
 static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allwads, std::vector<std::string>& pwads)
 {
+	if (!restart)
+	{
+		V_InitScreenSize();
+		// This allocates a dummy framebuffer as a stand-in until V_Init2 is called.
+		V_InitScreen();
+		V_Init2();
+	}
 	SavegameFolder = iwad_info->Autoname;
 	gameinfo.gametype = iwad_info->gametype;
 	gameinfo.flags = iwad_info->flags;
@@ -3255,16 +3262,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	if (!batchrun) Printf ("V_Init: allocate screen.\n");
 	if (!restart)
 	{
-		V_InitScreenSize();
-		// This allocates a dummy framebuffer as a stand-in until V_Init2 is called.
-		V_InitScreen ();
-
-		if (StartScreen != nullptr)
-		{
-			V_Init2();
-			StartScreen->Render();
-		}
-
+		if (StartScreen != nullptr) StartScreen->Render();
 	}
 	else
 	{
@@ -3500,7 +3498,6 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 			return 1337; // special exit
 		}
 
-		if (StartScreen == nullptr) V_Init2();
 		if (StartScreen)
 		{
 			StartScreen->Progress(max_progress);	// advance progress bar to the end.


### PR DESCRIPTION
This opens the main game window right after the IWAD is selected instead of when it gets rendered to for the first time.

The old setup was acceptable while the log window was present but this has been removed along with the old IWAD picker.
With the new picker I got a 1-4 second long interval depending on the system I ran it on in which no window at all was visible which was quite a bit distracting.

Another advantage is that now the window is already fully open when the start screen appears so it isn't prone to being covered by the system's window opening animation anymore.
