### PR TITLE
Added 64-bit networking support

### DIFF
--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -120,8 +120,8 @@ CCMD (god)
 	if (CheckCheatmode ())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_GOD);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_GOD);
 }
 
 CCMD(god2)
@@ -129,8 +129,8 @@ CCMD(god2)
 	if (CheckCheatmode())
 		return;
 
-	Net_WriteByte(DEM_GENERICCHEAT);
-	Net_WriteByte(CHT_GOD2);
+	Net_WriteInt8(DEM_GENERICCHEAT);
+	Net_WriteInt8(CHT_GOD2);
 }
 
 CCMD (iddqd)
@@ -138,8 +138,8 @@ CCMD (iddqd)
 	if (CheckCheatmode ())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_IDDQD);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_IDDQD);
 }
 
 CCMD (buddha)
@@ -147,8 +147,8 @@ CCMD (buddha)
 	if (CheckCheatmode())
 		return;
 
-	Net_WriteByte(DEM_GENERICCHEAT);
-	Net_WriteByte(CHT_BUDDHA);
+	Net_WriteInt8(DEM_GENERICCHEAT);
+	Net_WriteInt8(CHT_BUDDHA);
 }
 
 CCMD(buddha2)
@@ -156,8 +156,8 @@ CCMD(buddha2)
 	if (CheckCheatmode())
 		return;
 
-	Net_WriteByte(DEM_GENERICCHEAT);
-	Net_WriteByte(CHT_BUDDHA2);
+	Net_WriteInt8(DEM_GENERICCHEAT);
+	Net_WriteInt8(CHT_BUDDHA2);
 }
 
 CCMD (notarget)
@@ -165,8 +165,8 @@ CCMD (notarget)
 	if (CheckCheatmode ())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_NOTARGET);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_NOTARGET);
 }
 
 CCMD (fly)
@@ -174,8 +174,8 @@ CCMD (fly)
 	if (CheckCheatmode ())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_FLY);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_FLY);
 }
 
 /*
@@ -190,8 +190,8 @@ CCMD (noclip)
 	if (CheckCheatmode ())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_NOCLIP);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_NOCLIP);
 }
 
 CCMD (noclip2)
@@ -199,8 +199,8 @@ CCMD (noclip2)
 	if (CheckCheatmode())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_NOCLIP2);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_NOCLIP2);
 }
 
 CCMD (powerup)
@@ -208,8 +208,8 @@ CCMD (powerup)
 	if (CheckCheatmode ())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_POWER);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_POWER);
 }
 
 CCMD (morphme)
@@ -219,12 +219,12 @@ CCMD (morphme)
 
 	if (argv.argc() == 1)
 	{
-		Net_WriteByte (DEM_GENERICCHEAT);
-		Net_WriteByte (CHT_MORPH);
+		Net_WriteInt8 (DEM_GENERICCHEAT);
+		Net_WriteInt8 (CHT_MORPH);
 	}
 	else
 	{
-		Net_WriteByte (DEM_MORPHEX);
+		Net_WriteInt8 (DEM_MORPHEX);
 		Net_WriteString (argv[1]);
 	}
 }
@@ -234,8 +234,8 @@ CCMD (anubis)
 	if (CheckCheatmode ())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_ANUBIS);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_ANUBIS);
 }
 
 // [GRB]
@@ -244,8 +244,8 @@ CCMD (resurrect)
 	if (CheckCheatmode ())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_RESSURECT);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_RESSURECT);
 }
 
 EXTERN_CVAR (Bool, chasedemo)
@@ -276,8 +276,8 @@ CCMD (chase)
 		if (gamestate != GS_LEVEL || (!(dmflags2 & DF2_CHASECAM) && deathmatch && CheckCheatmode ()))
 			return;
 
-		Net_WriteByte (DEM_GENERICCHEAT);
-		Net_WriteByte (CHT_CHASECAM);
+		Net_WriteInt8 (DEM_GENERICCHEAT);
+		Net_WriteInt8 (CHT_CHASECAM);
 	}
 }
 
@@ -386,12 +386,12 @@ CCMD (changemap)
 			{
 				if (argv.argc() > 2)
 				{
-					Net_WriteByte (DEM_CHANGEMAP2);
-					Net_WriteByte (atoi(argv[2]));
+					Net_WriteInt8 (DEM_CHANGEMAP2);
+					Net_WriteInt8 (atoi(argv[2]));
 				}
 				else
 				{
-					Net_WriteByte (DEM_CHANGEMAP);
+					Net_WriteInt8 (DEM_CHANGEMAP);
 				}
 				Net_WriteString (mapname);
 			}
@@ -446,12 +446,12 @@ CCMD (give)
 	if (CheckCheatmode () || argv.argc() < 2)
 		return;
 
-	Net_WriteByte (DEM_GIVECHEAT);
+	Net_WriteInt8 (DEM_GIVECHEAT);
 	Net_WriteString (argv[1]);
 	if (argv.argc() > 2)
-		Net_WriteLong(atoi(argv[2]));
+		Net_WriteInt32(atoi(argv[2]));
 	else
-		Net_WriteLong(0);
+		Net_WriteInt32(0);
 }
 
 CCMD (take)
@@ -459,12 +459,12 @@ CCMD (take)
 	if (CheckCheatmode () || argv.argc() < 2)
 		return;
 
-	Net_WriteByte (DEM_TAKECHEAT);
+	Net_WriteInt8 (DEM_TAKECHEAT);
 	Net_WriteString (argv[1]);
 	if (argv.argc() > 2)
-		Net_WriteLong(atoi (argv[2]));
+		Net_WriteInt32(atoi (argv[2]));
 	else
-		Net_WriteLong (0);
+		Net_WriteInt32 (0);
 }
 
 CCMD(setinv)
@@ -472,17 +472,17 @@ CCMD(setinv)
 	if (CheckCheatmode() || argv.argc() < 2)
 		return;
 
-	Net_WriteByte(DEM_SETINV);
+	Net_WriteInt8(DEM_SETINV);
 	Net_WriteString(argv[1]);
 	if (argv.argc() > 2)
-		Net_WriteLong(atoi(argv[2]));
+		Net_WriteInt32(atoi(argv[2]));
 	else
-		Net_WriteLong(0);
+		Net_WriteInt32(0);
 
 	if (argv.argc() > 3)
-		Net_WriteByte(!!atoi(argv[3]));
+		Net_WriteInt8(!!atoi(argv[3]));
 	else
-		Net_WriteByte(0);
+		Net_WriteInt8(0);
 
 }
 
@@ -513,18 +513,18 @@ CCMD (puke)
 
 		if (script > 0)
 		{
-			Net_WriteByte (DEM_RUNSCRIPT);
-			Net_WriteWord (script);
+			Net_WriteInt8 (DEM_RUNSCRIPT);
+			Net_WriteInt16 (script);
 		}
 		else
 		{
-			Net_WriteByte (DEM_RUNSCRIPT2);
-			Net_WriteWord (-script);
+			Net_WriteInt8 (DEM_RUNSCRIPT2);
+			Net_WriteInt16 (-script);
 		}
-		Net_WriteByte (argn);
+		Net_WriteInt8 (argn);
 		for (i = 0; i < argn; ++i)
 		{
-			Net_WriteLong (arg[i]);
+			Net_WriteInt32 (arg[i]);
 		}
 	}
 }
@@ -557,12 +557,12 @@ CCMD (pukename)
 				arg[i] = atoi(argv[argstart + i]);
 			}
 		}
-		Net_WriteByte(DEM_RUNNAMEDSCRIPT);
+		Net_WriteInt8(DEM_RUNNAMEDSCRIPT);
 		Net_WriteString(argv[1]);
-		Net_WriteByte(argn | (always << 7));
+		Net_WriteInt8(argn | (always << 7));
 		for (i = 0; i < argn; ++i)
 		{
-			Net_WriteLong(arg[i]);
+			Net_WriteInt32(arg[i]);
 		}
 	}
 }
@@ -603,12 +603,12 @@ CCMD (special)
 				return;
 			}
 		}
-		Net_WriteByte(DEM_RUNSPECIAL);
-		Net_WriteWord(specnum);
-		Net_WriteByte(argc - 2);
+		Net_WriteInt8(DEM_RUNSPECIAL);
+		Net_WriteInt16(specnum);
+		Net_WriteInt8(argc - 2);
 		for (int i = 2; i < argc; ++i)
 		{
-			Net_WriteLong(atoi(argv[i]));
+			Net_WriteInt32(atoi(argv[i]));
 		}
 	}
 }
@@ -639,10 +639,10 @@ CCMD (warp)
 	}
 	else
 	{
-		Net_WriteByte (DEM_WARPCHEAT);
-		Net_WriteWord (atoi (argv[1]));
-		Net_WriteWord (atoi (argv[2]));
-		Net_WriteWord (argv.argc() == 3 ? ONFLOORZ/65536 : atoi (argv[3]));
+		Net_WriteInt8 (DEM_WARPCHEAT);
+		Net_WriteInt16 (atoi (argv[1]));
+		Net_WriteInt16 (atoi (argv[2]));
+		Net_WriteInt16 (argv.argc() == 3 ? ONFLOORZ/65536 : atoi (argv[3]));
 	}
 }
 
@@ -951,8 +951,8 @@ CCMD(thaw)
 	if (CheckCheatmode())
 		return;
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_CLEARFROZENPROPS);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (CHT_CLEARFROZENPROPS);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -371,8 +371,8 @@ static void ShoveChatStr (const char *str, uint8_t who)
 		who |= 2;
 	}
 
-	Net_WriteByte (DEM_SAY);
-	Net_WriteByte (who);
+	Net_WriteInt8 (DEM_SAY);
+	Net_WriteInt8 (who);
 
 	if (chat_substitution && DoSubstitution (substBuff, str))
 	{

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -428,14 +428,14 @@ CUSTOM_CVAR (Int, dmflags, 0, CVAR_SERVERINFO | CVAR_NOINITCALL)
 
 	if (self & DF_NO_FREELOOK)
 	{
-		Net_WriteByte (DEM_CENTERVIEW);
+		Net_WriteInt8 (DEM_CENTERVIEW);
 	}
 	// If nofov is set, force everybody to the arbitrator's FOV.
 	if ((self & DF_NO_FOV) && consoleplayer == Net_Arbitrator)
 	{
 		float fov;
 
-		Net_WriteByte (DEM_FOV);
+		Net_WriteInt8 (DEM_FOV);
 
 		// If the game is started with DF_NO_FOV set, the arbitrator's
 		// DesiredFOV will not be set when this callback is run, so
@@ -2629,7 +2629,7 @@ void Mlook_ReleaseHandler()
 {
 	if (lookspring)
 	{
-		Net_WriteByte(DEM_CENTERVIEW);
+		Net_WriteInt8(DEM_CENTERVIEW);
 	}
 }
 

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -259,32 +259,42 @@ static struct TicSpecial
 		streamoffs = 0;
 	}
 
-	TicSpecial &operator << (uint8_t it)
+	TicSpecial &operator << (int8_t it)
 	{
 		if (streamptr)
 		{
 			CheckSpace (1);
-			WriteByte (it, &streamptr);
+			WriteInt8 (it, &streamptr);
 		}
 		return *this;
 	}
 
-	TicSpecial &operator << (short it)
+	TicSpecial &operator << (int16_t it)
 	{
 		if (streamptr)
 		{
 			CheckSpace (2);
-			WriteWord (it, &streamptr);
+			WriteInt16 (it, &streamptr);
 		}
 		return *this;
 	}
 
-	TicSpecial &operator << (int it)
+	TicSpecial &operator << (int32_t it)
 	{
 		if (streamptr)
 		{
 			CheckSpace (4);
-			WriteLong (it, &streamptr);
+			WriteInt32 (it, &streamptr);
+		}
+		return *this;
+	}
+
+	TicSpecial& operator << (int64_t it)
+	{
+		if (streamptr)
+		{
+			CheckSpace(8);
+			WriteInt64(it, &streamptr);
 		}
 		return *this;
 	}
@@ -295,6 +305,16 @@ static struct TicSpecial
 		{
 			CheckSpace (4);
 			WriteFloat (it, &streamptr);
+		}
+		return *this;
+	}
+
+	TicSpecial& operator << (double it)
+	{
+		if (streamptr)
+		{
+			CheckSpace(8);
+			WriteDouble(it, &streamptr);
 		}
 		return *this;
 	}
@@ -791,7 +811,7 @@ void GetPackets (void)
 					{
 						if (playeringame[i])
 						{
-							int resend = ReadLong (&foo);
+							int resend = ReadInt32 (&foo);
 							if (i != consoleplayer)
 							{
 								resendto[nodeforplayer[i]] = resend;
@@ -1246,7 +1266,7 @@ void NetUpdate (void)
 					// the other players.
 					if (l == 0)
 					{
-						WriteWord (localcmds[localstart].consistancy, &cmddata);
+						WriteInt16 (localcmds[localstart].consistancy, &cmddata);
 						// [RH] Write out special "ticcmds" before real ticcmd
 						if (specials.used[start])
 						{
@@ -1261,7 +1281,7 @@ void NetUpdate (void)
 						int len;
 						uint8_t *spec;
 
-						WriteWord (netcmds[playerbytes[l]][start].consistancy, &cmddata);
+						WriteInt16 (netcmds[playerbytes[l]][start].consistancy, &cmddata);
 						spec = NetSpecs[playerbytes[l]][start].GetData (&len);
 						if (spec != NULL)
 						{
@@ -1468,7 +1488,7 @@ bool DoArbitrate (void *userdata)
 
 			stream = &netbuffer[3];
 			startmap = ReadStringConst(&stream);
-			rngseed = ReadLong (&stream);
+			rngseed = ReadInt32 (&stream);
 			C_ReadCVars (&stream);
 		}
 		else if (netbuffer[0] == NCMD_SETUP+3)
@@ -1536,7 +1556,7 @@ bool DoArbitrate (void *userdata)
 		netbuffer[2] = NetMode;
 		stream = &netbuffer[3];
 		WriteString (startmap.GetChars(), &stream);
-		WriteLong (rngseed, &stream);
+		WriteInt32 (rngseed, &stream);
 		C_WriteCVars (&stream, CVAR_SERVERINFO, true);
 
 		SendSetup (data->playersdetected, data->gotsetup, int(stream - netbuffer));
@@ -1779,7 +1799,7 @@ void D_QuitNetGame (void)
 		for (i = 0; i < MAXPLAYERS; ++i)
 		{
 			if (playeringame[i] && i != consoleplayer)
-				WriteLong (resendto[nodeforplayer[i]], &foo);
+				WriteInt32 (resendto[nodeforplayer[i]], &foo);
 		}
 		k = int(foo - netbuffer);
 	}
@@ -2047,22 +2067,32 @@ void Net_NewMakeTic (void)
 	specials.NewMakeTic ();
 }
 
-void Net_WriteByte (uint8_t it)
+void Net_WriteInt8 (int8_t it)
 {
 	specials << it;
 }
 
-void Net_WriteWord (short it)
+void Net_WriteInt16 (int16_t it)
 {
 	specials << it;
 }
 
-void Net_WriteLong (int it)
+void Net_WriteInt32 (int32_t it)
+{
+	specials << it;
+}
+
+void Net_WriteInt64(int64_t it)
 {
 	specials << it;
 }
 
 void Net_WriteFloat (float it)
+{
+	specials << it;
+}
+
+void Net_WriteDouble(double it)
 {
 	specials << it;
 }
@@ -2171,7 +2201,7 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 	case DEM_SAY:
 		{
 			const char *name = players[player].userinfo.GetName();
-			uint8_t who = ReadByte (stream);
+			uint8_t who = ReadInt8 (stream);
 
 			s = ReadStringConst(stream);
 			if (((who & 1) == 0) || players[player].userinfo.GetTeam() == TEAM_NONE)
@@ -2227,7 +2257,7 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 
 	case DEM_GIVECHEAT:
 		s = ReadStringConst(stream);
-		cht_Give (&players[player], s, ReadLong (stream));
+		cht_Give (&players[player], s, ReadInt32 (stream));
 		if (player != consoleplayer)
 		{
 			FString message = GStrings("TXT_X_CHEATS");
@@ -2239,31 +2269,31 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 
 	case DEM_TAKECHEAT:
 		s = ReadStringConst(stream);
-		cht_Take (&players[player], s, ReadLong (stream));
+		cht_Take (&players[player], s, ReadInt32 (stream));
 		break;
 
 	case DEM_SETINV:
 		s = ReadStringConst(stream);
-		i = ReadLong(stream);
-		cht_SetInv(&players[player], s, i, !!ReadByte(stream));
+		i = ReadInt32(stream);
+		cht_SetInv(&players[player], s, i, !!ReadInt8(stream));
 		break;
 
 	case DEM_WARPCHEAT:
 		{
 			int x, y, z;
-			x = ReadWord (stream);
-			y = ReadWord (stream);
-			z = ReadWord (stream);
+			x = ReadInt16 (stream);
+			y = ReadInt16 (stream);
+			z = ReadInt16 (stream);
 			P_TeleportMove (players[player].mo, DVector3(x, y, z), true);
 		}
 		break;
 
 	case DEM_GENERICCHEAT:
-		cht_DoCheat (&players[player], ReadByte (stream));
+		cht_DoCheat (&players[player], ReadInt8 (stream));
 		break;
 
 	case DEM_CHANGEMAP2:
-		pos = ReadByte (stream);
+		pos = ReadInt8 (stream);
 		/* intentional fall-through */
 	case DEM_CHANGEMAP:
 		// Change to another map without disconnecting other players
@@ -2312,10 +2342,10 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 	case DEM_INVUSE:
 	case DEM_INVDROP:
 		{
-			uint32_t which = ReadLong (stream);
+			uint32_t which = ReadInt32 (stream);
 			int amt = -1;
 
-			if (type == DEM_INVDROP) amt = ReadLong(stream);
+			if (type == DEM_INVDROP) amt = ReadInt32(stream);
 
 			if (gamestate == GS_LEVEL && !paused
 				&& players[player].playerstate != PST_DEAD)
@@ -2357,10 +2387,10 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 			s = ReadStringConst(stream);
 			if (type >= DEM_SUMMON2 && type <= DEM_SUMMONFOE2)
 			{
-				angle = ReadWord(stream);
-				tid = ReadWord(stream);
-				special = ReadByte(stream);
-				for(i = 0; i < 5; i++) args[i] = ReadLong(stream);
+				angle = ReadInt16(stream);
+				tid = ReadInt16(stream);
+				special = ReadInt8(stream);
+				for(i = 0; i < 5; i++) args[i] = ReadInt32(stream);
 			}
 
 			typeinfo = PClass::FindActor(s);
@@ -2471,7 +2501,7 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 		{
 			break;
 		}
-		Net_WriteByte (DEM_DOAUTOSAVE);
+		Net_WriteInt8 (DEM_DOAUTOSAVE);
 		break;
 
 	case DEM_DOAUTOSAVE:
@@ -2506,8 +2536,8 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 	case DEM_RUNSCRIPT:
 	case DEM_RUNSCRIPT2:
 		{
-			int snum = ReadWord (stream);
-			int argn = ReadByte (stream);
+			int snum = ReadInt16 (stream);
+			int argn = ReadInt8 (stream);
 
 			RunScript(stream, players[player].mo, snum, argn, (type == DEM_RUNSCRIPT2) ? ACS_ALWAYS : 0);
 		}
@@ -2516,7 +2546,7 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 	case DEM_RUNNAMEDSCRIPT:
 		{
 			s = ReadStringConst(stream);
-			int argn = ReadByte(stream);
+			int argn = ReadInt8(stream);
 
 			RunScript(stream, players[player].mo, -FName(s).GetIndex(), argn & 127, (argn & 128) ? ACS_ALWAYS : 0);
 		}
@@ -2524,13 +2554,13 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 
 	case DEM_RUNSPECIAL:
 		{
-			int snum = ReadWord(stream);
-			int argn = ReadByte(stream);
+			int snum = ReadInt16(stream);
+			int argn = ReadInt8(stream);
 			int arg[5] = { 0, 0, 0, 0, 0 };
 
 			for (i = 0; i < argn; ++i)
 			{
-				int argval = ReadLong(stream);
+				int argval = ReadInt32(stream);
 				if ((unsigned)i < countof(arg))
 				{
 					arg[i] = argval;
@@ -2565,7 +2595,7 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 
 	case DEM_ADDCONTROLLER:
 		{
-			uint8_t playernum = ReadByte (stream);
+			uint8_t playernum = ReadInt8 (stream);
 			players[playernum].settings_controller = true;
 
 			if (consoleplayer == playernum || consoleplayer == Net_Arbitrator)
@@ -2575,7 +2605,7 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 
 	case DEM_DELCONTROLLER:
 		{
-			uint8_t playernum = ReadByte (stream);
+			uint8_t playernum = ReadInt8 (stream);
 			players[playernum].settings_controller = false;
 
 			if (consoleplayer == playernum || consoleplayer == Net_Arbitrator)
@@ -2640,14 +2670,14 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 			int pnum;
 			if (type == DEM_SETSLOTPNUM)
 			{
-				pnum = ReadByte(stream);
+				pnum = ReadInt8(stream);
 			}
 			else
 			{
 				pnum = player;
 			}
-			unsigned int slot = ReadByte(stream);
-			int count = ReadByte(stream);
+			unsigned int slot = ReadInt8(stream);
+			int count = ReadInt8(stream);
 			if (slot < NUM_WEAPON_SLOTS)
 			{
 				players[pnum].weapons.ClearSlot(slot);
@@ -2662,7 +2692,7 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 
 	case DEM_ADDSLOT:
 		{
-			int slot = ReadByte(stream);
+			int slot = ReadInt8(stream);
 			PClassActor *wpn = Net_ReadWeapon(stream);
 			players[player].weapons.AddSlot(slot, wpn, player == consoleplayer);
 		}
@@ -2670,15 +2700,15 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 
 	case DEM_ADDSLOTDEFAULT:
 		{
-			int slot = ReadByte(stream);
+			int slot = ReadInt8(stream);
 			PClassActor *wpn = Net_ReadWeapon(stream);
 			players[player].weapons.AddSlotDefault(slot, wpn, player == consoleplayer);
 		}
 		break;
 
 	case DEM_SETPITCHLIMIT:
-		players[player].MinPitch = DAngle::fromDeg(-ReadByte(stream));		// up
-		players[player].MaxPitch = DAngle::fromDeg(ReadByte(stream));		// down
+		players[player].MinPitch = DAngle::fromDeg(-ReadInt8(stream));		// up
+		players[player].MaxPitch = DAngle::fromDeg(ReadInt8(stream));		// down
 		break;
 
 	case DEM_REVERTCAMERA:
@@ -2693,11 +2723,11 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 	case DEM_NETEVENT:
 		{
 			s = ReadStringConst(stream);
-			int argn = ReadByte(stream);
+			int argn = ReadInt8(stream);
 			int arg[3] = { 0, 0, 0 };
 			for (int i = 0; i < 3; i++)
-				arg[i] = ReadLong(stream);
-			bool manual = !!ReadByte(stream);
+				arg[i] = ReadInt32(stream);
+			bool manual = !!ReadInt8(stream);
 			primaryLevel->localEventManager->Console(player, s, arg[0], arg[1], arg[2], manual, false);
 		}
 		break;
@@ -2709,14 +2739,14 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 	case DEM_ZSC_CMD:
 		{
 			FName cmd = ReadStringConst(stream);
-			unsigned int size = ReadWord(stream);
+			unsigned int size = ReadInt16(stream);
 
 			TArray<uint8_t> buffer = {};
 			if (size)
 			{
 				buffer.Grow(size);
 				for (unsigned int i = 0u; i < size; ++i)
-					buffer.Push(ReadByte(stream));
+					buffer.Push(ReadInt8(stream));
 			}
 
 			FNetworkCommand netCmd = { player, cmd, buffer };
@@ -2744,7 +2774,7 @@ static void RunScript(uint8_t **stream, AActor *pawn, int snum, int argn, int al
 	
 	for (i = 0; i < argn; ++i)
 	{
-		int argval = ReadLong(stream);
+		int argval = ReadInt32(stream);
 		if ((unsigned)i < countof(arg))
 		{
 			arg[i] = argval;
@@ -2993,11 +3023,11 @@ static void Network_Controller (int playernum, bool add)
 	}
 
 	if (add)
-		Net_WriteByte (DEM_ADDCONTROLLER);
+		Net_WriteInt8 (DEM_ADDCONTROLLER);
 	else
-		Net_WriteByte (DEM_DELCONTROLLER);
+		Net_WriteInt8 (DEM_DELCONTROLLER);
 
-	Net_WriteByte (playernum);
+	Net_WriteInt8 (playernum);
 }
 
 //==========================================================================

--- a/src/d_net.h
+++ b/src/d_net.h
@@ -64,10 +64,12 @@ void Net_CheckLastReceived(int);
 
 // [RH] Functions for making and using special "ticcmds"
 void Net_NewMakeTic ();
-void Net_WriteByte (uint8_t);
-void Net_WriteWord (short);
-void Net_WriteLong (int);
+void Net_WriteInt8 (int8_t);
+void Net_WriteInt16 (int16_t);
+void Net_WriteInt32 (int32_t);
+void Net_WriteInt64(int64_t);
 void Net_WriteFloat (float);
+void Net_WriteDouble(double);
 void Net_WriteString (const char *);
 void Net_WriteBytes (const uint8_t *, int len);
 

--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -571,7 +571,7 @@ void D_UserInfoChanged (FBaseCVar *cvar)
 
 	mysnprintf (foo, countof(foo), "\\%s\\%s", cvar->GetName(), escaped_val.GetChars());
 
-	Net_WriteByte (DEM_UINFCHANGED);
+	Net_WriteInt8 (DEM_UINFCHANGED);
 	Net_WriteString (foo);
 }
 
@@ -592,7 +592,7 @@ static const char *SetServerVar (char *name, ECVarType type, uint8_t **stream, b
 			{
 				return NULL;
 			}
-			bitdata = ReadByte (stream);
+			bitdata = ReadInt8 (stream);
 			mask = 1 << (bitdata & 31);
 			if (bitdata & 32)
 			{
@@ -608,8 +608,8 @@ static const char *SetServerVar (char *name, ECVarType type, uint8_t **stream, b
 	{
 		switch (type)
 		{
-		case CVAR_Bool:		value.Bool = ReadByte (stream) ? 1 : 0;	break;
-		case CVAR_Int:		value.Int = ReadLong (stream);			break;
+		case CVAR_Bool:		value.Bool = ReadInt8 (stream) ? 1 : 0;	break;
+		case CVAR_Int:		value.Int = ReadInt32 (stream);			break;
 		case CVAR_Float:	value.Float = ReadFloat (stream);		break;
 		case CVAR_String:	value.String = ReadString (stream);		break;
 		default: break;	// Silence GCC
@@ -665,13 +665,13 @@ bool D_SendServerInfoChange (FBaseCVar *cvar, UCVarValue value, ECVarType type)
 
 		namelen = strlen(cvar->GetName());
 
-		Net_WriteByte(DEM_SINFCHANGED);
-		Net_WriteByte((uint8_t)(namelen | (type << 6)));
+		Net_WriteInt8(DEM_SINFCHANGED);
+		Net_WriteInt8((uint8_t)(namelen | (type << 6)));
 		Net_WriteBytes((uint8_t*)cvar->GetName(), (int)namelen);
 		switch (type)
 		{
-		case CVAR_Bool:		Net_WriteByte(value.Bool);		break;
-		case CVAR_Int:		Net_WriteLong(value.Int);		break;
+		case CVAR_Bool:		Net_WriteInt8(value.Bool);		break;
+		case CVAR_Int:		Net_WriteInt32(value.Int);		break;
 		case CVAR_Float:	Net_WriteFloat(value.Float);	break;
 		case CVAR_String:	Net_WriteString(value.String);	break;
 		default: break; // Silence GCC
@@ -696,10 +696,10 @@ bool D_SendServerFlagChange (FBaseCVar *cvar, int bitnum, bool set, bool silent)
 
 		int namelen = (int)strlen(cvar->GetName());
 
-		Net_WriteByte(DEM_SINFCHANGEDXOR);
-		Net_WriteByte((uint8_t)namelen);
+		Net_WriteInt8(DEM_SINFCHANGEDXOR);
+		Net_WriteInt8((uint8_t)namelen);
 		Net_WriteBytes((uint8_t*)cvar->GetName(), namelen);
-		Net_WriteByte(uint8_t(bitnum | (set << 5)));
+		Net_WriteInt8(uint8_t(bitnum | (set << 5)));
 		return true;
 	}
 	return false;
@@ -712,7 +712,7 @@ void D_DoServerInfoChange (uint8_t **stream, bool singlebit)
 	int len;
 	int type;
 
-	len = ReadByte (stream);
+	len = ReadInt8 (stream);
 	type = len >> 6;
 	len &= 0x3f;
 	if (len == 0)

--- a/src/d_protocol.cpp
+++ b/src/d_protocol.cpp
@@ -55,24 +55,32 @@ const char *ReadStringConst(uint8_t **stream)
 	return string;
 }
 
-int ReadByte (uint8_t **stream)
+int8_t ReadInt8 (uint8_t **stream)
 {
-	uint8_t v = **stream;
+	int8_t v = **stream;
 	*stream += 1;
 	return v;
 }
 
-int ReadWord (uint8_t **stream)
+int16_t ReadInt16 (uint8_t **stream)
 {
-	short v = (((*stream)[0]) << 8) | (((*stream)[1]));
+	int16_t v = (((*stream)[0]) << 8) | (((*stream)[1]));
 	*stream += 2;
 	return v;
 }
 
-int ReadLong (uint8_t **stream)
+int32_t ReadInt32 (uint8_t **stream)
 {
-	int v = (((*stream)[0]) << 24) | (((*stream)[1]) << 16) | (((*stream)[2]) << 8) | (((*stream)[3]));
+	int32_t v = (((*stream)[0]) << 24) | (((*stream)[1]) << 16) | (((*stream)[2]) << 8) | (((*stream)[3]));
 	*stream += 4;
+	return v;
+}
+
+int64_t ReadInt64(uint8_t** stream)
+{
+	int64_t v = (int64_t((*stream)[0]) << 56) | (int64_t((*stream)[1]) << 48) | (int64_t((*stream)[2]) << 40) | (int64_t((*stream)[3]) << 32)
+				| (int64_t((*stream)[4]) << 24) | (int64_t((*stream)[5]) << 16) | (int64_t((*stream)[6]) << 8) | (int64_t((*stream)[7]));
+	*stream += 8;
 	return v;
 }
 
@@ -80,10 +88,21 @@ float ReadFloat (uint8_t **stream)
 {
 	union
 	{
-		int i;
+		int32_t i;
 		float f;
 	} fakeint;
-	fakeint.i = ReadLong (stream);
+	fakeint.i = ReadInt32 (stream);
+	return fakeint.f;
+}
+
+double ReadDouble(uint8_t** stream)
+{
+	union
+	{
+		int64_t i;
+		double f;
+	} fakeint;
+	fakeint.i = ReadInt64(stream);
 	return fakeint.f;
 }
 
@@ -100,20 +119,20 @@ void WriteString (const char *string, uint8_t **stream)
 }
 
 
-void WriteByte (uint8_t v, uint8_t **stream)
+void WriteInt8 (int8_t v, uint8_t **stream)
 {
 	**stream = v;
 	*stream += 1;
 }
 
-void WriteWord (short v, uint8_t **stream)
+void WriteInt16 (int16_t v, uint8_t **stream)
 {
 	(*stream)[0] = v >> 8;
 	(*stream)[1] = v & 255;
 	*stream += 2;
 }
 
-void WriteLong (int v, uint8_t **stream)
+void WriteInt32 (int32_t v, uint8_t **stream)
 {
 	(*stream)[0] = v >> 24;
 	(*stream)[1] = (v >> 16) & 255;
@@ -122,15 +141,39 @@ void WriteLong (int v, uint8_t **stream)
 	*stream += 4;
 }
 
+void WriteInt64(int64_t v, uint8_t** stream)
+{
+	(*stream)[0] = v >> 56;
+	(*stream)[1] = (v >> 48) & 255;
+	(*stream)[2] = (v >> 40) & 255;
+	(*stream)[3] = (v >> 32) & 255;
+	(*stream)[4] = (v >> 24) & 255;
+	(*stream)[5] = (v >> 16) & 255;
+	(*stream)[6] = (v >> 8) & 255;
+	(*stream)[7] = v & 255;
+	*stream += 8;
+}
+
 void WriteFloat (float v, uint8_t **stream)
 {
 	union
 	{
-		int i;
+		int32_t i;
 		float f;
 	} fakeint;
 	fakeint.f = v;
-	WriteLong (fakeint.i, stream);
+	WriteInt32 (fakeint.i, stream);
+}
+
+void WriteDouble(double v, uint8_t** stream)
+{
+	union
+	{
+		int64_t i;
+		double f;
+	} fakeint;
+	fakeint.f = v;
+	WriteInt64(fakeint.i, stream);
 }
 
 // Returns the number of bytes read
@@ -151,7 +194,7 @@ int UnpackUserCmd (usercmd_t *ucmd, const usercmd_t *basis, uint8_t **stream)
 		memset (ucmd, 0, sizeof(usercmd_t));
 	}
 
-	flags = ReadByte (stream);
+	flags = ReadInt8 (stream);
 
 	if (flags)
 	{
@@ -159,20 +202,20 @@ int UnpackUserCmd (usercmd_t *ucmd, const usercmd_t *basis, uint8_t **stream)
 		if (flags & UCMDF_BUTTONS)
 		{
 			uint32_t buttons = ucmd->buttons;
-			uint8_t in = ReadByte(stream);
+			uint8_t in = ReadInt8(stream);
 
 			buttons = (buttons & ~0x7F) | (in & 0x7F);
 			if (in & 0x80)
 			{
-				in = ReadByte(stream);
+				in = ReadInt8(stream);
 				buttons = (buttons & ~(0x7F << 7)) | ((in & 0x7F) << 7);
 				if (in & 0x80)
 				{
-					in = ReadByte(stream);
+					in = ReadInt8(stream);
 					buttons = (buttons & ~(0x7F << 14)) | ((in & 0x7F) << 14);
 					if (in & 0x80)
 					{
-						in = ReadByte(stream);
+						in = ReadInt8(stream);
 						buttons = (buttons & ~(0xFF << 21)) | (in << 21);
 					}
 				}
@@ -180,17 +223,17 @@ int UnpackUserCmd (usercmd_t *ucmd, const usercmd_t *basis, uint8_t **stream)
 			ucmd->buttons = buttons;
 		}
 		if (flags & UCMDF_PITCH)
-			ucmd->pitch = ReadWord (stream);
+			ucmd->pitch = ReadInt16 (stream);
 		if (flags & UCMDF_YAW)
-			ucmd->yaw = ReadWord (stream);
+			ucmd->yaw = ReadInt16 (stream);
 		if (flags & UCMDF_FORWARDMOVE)
-			ucmd->forwardmove = ReadWord (stream);
+			ucmd->forwardmove = ReadInt16 (stream);
 		if (flags & UCMDF_SIDEMOVE)
-			ucmd->sidemove = ReadWord (stream);
+			ucmd->sidemove = ReadInt16 (stream);
 		if (flags & UCMDF_UPMOVE)
-			ucmd->upmove = ReadWord (stream);
+			ucmd->upmove = ReadInt16 (stream);
 		if (flags & UCMDF_ROLL)
-			ucmd->roll = ReadWord (stream);
+			ucmd->roll = ReadInt16 (stream);
 	}
 
 	return int(*stream - start);
@@ -211,7 +254,7 @@ int PackUserCmd (const usercmd_t *ucmd, const usercmd_t *basis, uint8_t **stream
 		basis = &blank;
 	}
 
-	WriteByte (0, stream);			// Make room for the packing bits
+	WriteInt8 (0, stream);			// Make room for the packing bits
 
 	buttons_changed = ucmd->buttons ^ basis->buttons;
 	if (buttons_changed != 0)
@@ -235,16 +278,16 @@ int PackUserCmd (const usercmd_t *ucmd, const usercmd_t *basis, uint8_t **stream
 				}
 			}
 		}
-		WriteByte (bytes[0], stream);
+		WriteInt8 (bytes[0], stream);
 		if (bytes[0] & 0x80)
 		{
-			WriteByte (bytes[1], stream);
+			WriteInt8 (bytes[1], stream);
 			if (bytes[1] & 0x80)
 			{
-				WriteByte (bytes[2], stream);
+				WriteInt8 (bytes[2], stream);
 				if (bytes[2] & 0x80)
 				{
-					WriteByte (bytes[3], stream);
+					WriteInt8 (bytes[3], stream);
 				}
 			}
 		}
@@ -252,36 +295,36 @@ int PackUserCmd (const usercmd_t *ucmd, const usercmd_t *basis, uint8_t **stream
 	if (ucmd->pitch != basis->pitch)
 	{
 		flags |= UCMDF_PITCH;
-		WriteWord (ucmd->pitch, stream);
+		WriteInt16 (ucmd->pitch, stream);
 	}
 	if (ucmd->yaw != basis->yaw)
 	{
 		flags |= UCMDF_YAW;
-		WriteWord (ucmd->yaw, stream);
+		WriteInt16 (ucmd->yaw, stream);
 	}
 	if (ucmd->forwardmove != basis->forwardmove)
 	{
 		flags |= UCMDF_FORWARDMOVE;
-		WriteWord (ucmd->forwardmove, stream);
+		WriteInt16 (ucmd->forwardmove, stream);
 	}
 	if (ucmd->sidemove != basis->sidemove)
 	{
 		flags |= UCMDF_SIDEMOVE;
-		WriteWord (ucmd->sidemove, stream);
+		WriteInt16 (ucmd->sidemove, stream);
 	}
 	if (ucmd->upmove != basis->upmove)
 	{
 		flags |= UCMDF_UPMOVE;
-		WriteWord (ucmd->upmove, stream);
+		WriteInt16 (ucmd->upmove, stream);
 	}
 	if (ucmd->roll != basis->roll)
 	{
 		flags |= UCMDF_ROLL;
-		WriteWord (ucmd->roll, stream);
+		WriteInt16 (ucmd->roll, stream);
 	}
 
 	// Write the packing bits
-	WriteByte (flags, &temp);
+	WriteInt8 (flags, &temp);
 
 	return int(*stream - start);
 }
@@ -329,7 +372,7 @@ int WriteUserCmdMessage (usercmd_t *ucmd, const usercmd_t *basis, uint8_t **stre
 			ucmd->upmove != 0 ||
 			ucmd->roll != 0)
 		{
-			WriteByte (DEM_USERCMD, stream);
+			WriteInt8 (DEM_USERCMD, stream);
 			return PackUserCmd (ucmd, basis, stream) + 1;
 		}
 	}
@@ -342,11 +385,11 @@ int WriteUserCmdMessage (usercmd_t *ucmd, const usercmd_t *basis, uint8_t **stre
 		ucmd->upmove != basis->upmove ||
 		ucmd->roll != basis->roll)
 	{
-		WriteByte (DEM_USERCMD, stream);
+		WriteInt8 (DEM_USERCMD, stream);
 		return PackUserCmd (ucmd, basis, stream) + 1;
 	}
 
-	WriteByte (DEM_EMPTYUSERCMD, stream);
+	WriteInt8 (DEM_EMPTYUSERCMD, stream);
 	return 1;
 }
 
@@ -417,11 +460,11 @@ void ReadTicCmd (uint8_t **stream, int player, int tic)
 	int ticmod = tic % BACKUPTICS;
 
 	tcmd = &netcmds[player][ticmod];
-	tcmd->consistancy = ReadWord (stream);
+	tcmd->consistancy = ReadInt16 (stream);
 
 	start = *stream;
 
-	while ((type = ReadByte (stream)) != DEM_USERCMD && type != DEM_EMPTYUSERCMD)
+	while ((type = ReadInt8 (stream)) != DEM_USERCMD && type != DEM_EMPTYUSERCMD)
 		Net_SkipCommand (type, stream);
 
 	NetSpecs[player][ticmod].SetData (start, int(*stream - start - 1));
@@ -460,7 +503,7 @@ void RunNetSpecs (int player, int buf)
 			uint8_t *end = stream + len;
 			while (stream < end)
 			{
-				int type = ReadByte (&stream);
+				int type = ReadInt8 (&stream);
 				Net_DoCommand (type, &stream, player);
 			}
 			if (!demorecording)
@@ -475,7 +518,7 @@ uint8_t *lenspot;
 // for the length field.
 void StartChunk (int id, uint8_t **stream)
 {
-	WriteLong (id, stream);
+	WriteInt32 (id, stream);
 	lenspot = *stream;
 	*stream += 4;
 }
@@ -490,9 +533,9 @@ void FinishChunk (uint8_t **stream)
 		return;
 
 	len = int(*stream - lenspot - 4);
-	WriteLong (len, &lenspot);
+	WriteInt32 (len, &lenspot);
 	if (len & 1)
-		WriteByte (0, stream);
+		WriteInt8 (0, stream);
 
 	lenspot = NULL;
 }
@@ -503,6 +546,6 @@ void SkipChunk (uint8_t **stream)
 {
 	int len;
 
-	len = ReadLong (stream);
+	len = ReadInt32 (stream);
 	*stream += len + (len & 1);
 }

--- a/src/d_protocol.h
+++ b/src/d_protocol.h
@@ -247,16 +247,20 @@ int SkipTicCmd (uint8_t **stream, int count);
 void ReadTicCmd (uint8_t **stream, int player, int tic);
 void RunNetSpecs (int player, int buf);
 
-int ReadByte (uint8_t **stream);
-int ReadWord (uint8_t **stream);
-int ReadLong (uint8_t **stream);
+int8_t ReadInt8 (uint8_t **stream);
+int16_t ReadInt16 (uint8_t **stream);
+int32_t ReadInt32 (uint8_t **stream);
+int64_t ReadInt64(uint8_t** stream);
 float ReadFloat (uint8_t **stream);
+double ReadDouble(uint8_t** stream);
 char *ReadString (uint8_t **stream);
 const char *ReadStringConst(uint8_t **stream);
-void WriteByte (uint8_t val, uint8_t **stream);
-void WriteWord (short val, uint8_t **stream);
-void WriteLong (int val, uint8_t **stream);
+void WriteInt8 (int8_t val, uint8_t **stream);
+void WriteInt16 (int16_t val, uint8_t **stream);
+void WriteInt32 (int32_t val, uint8_t **stream);
+void WriteInt64(int64_t val, uint8_t** stream);
 void WriteFloat (float val, uint8_t **stream);
+void WriteDouble(double val, uint8_t** stream);
 void WriteString (const char *string, uint8_t **stream);
 
 #endif //__D_PROTOCOL_H__

--- a/src/g_dumpinfo.cpp
+++ b/src/g_dumpinfo.cpp
@@ -129,7 +129,7 @@ CCMD (spray)
 		return;
 	}
 	
-	Net_WriteByte (DEM_SPRAY);
+	Net_WriteInt8 (DEM_SPRAY);
 	Net_WriteString (argv[1]);
 }
 

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1320,7 +1320,7 @@ IMPLEMENT_CLASS(DAutosaver, false, false)
 
 void DAutosaver::Tick ()
 {
-	Net_WriteByte (DEM_CHECKAUTOSAVE);
+	Net_WriteInt8 (DEM_CHECKAUTOSAVE);
 	Destroy ();
 }
 

--- a/src/gamedata/a_weapons.cpp
+++ b/src/gamedata/a_weapons.cpp
@@ -450,15 +450,15 @@ void FWeaponSlots::SendDifferences(int playernum, const FWeaponSlots &other)
 		// The slots differ. Send mine.
 		if (playernum == consoleplayer)
 		{
-			Net_WriteByte(DEM_SETSLOT);
+			Net_WriteInt8(DEM_SETSLOT);
 		}
 		else
 		{
-			Net_WriteByte(DEM_SETSLOTPNUM);
-			Net_WriteByte(playernum);
+			Net_WriteInt8(DEM_SETSLOTPNUM);
+			Net_WriteInt8(playernum);
 		}
-		Net_WriteByte(i);
-		Net_WriteByte(Slots[i].Size());
+		Net_WriteInt8(i);
+		Net_WriteInt8(Slots[i].Size());
 		for (j = 0; j < Slots[i].Size(); ++j)
 		{
 			Net_WriteWeapon(Slots[i].GetWeapon(j));
@@ -596,9 +596,9 @@ CCMD (setslot)
 			Printf ("Slot %d cleared\n", slot);
 		}
 
-		Net_WriteByte(DEM_SETSLOT);
-		Net_WriteByte(slot);
-		Net_WriteByte(argv.argc()-2);
+		Net_WriteInt8(DEM_SETSLOT);
+		Net_WriteInt8(slot);
+		Net_WriteInt8(argv.argc()-2);
 		for (int i = 2; i < argv.argc(); i++)
 		{
 			Net_WriteWeapon(PClass::FindActor(argv[i]));
@@ -647,8 +647,8 @@ CCMD (addslot)
 	}
 	else
 	{
-		Net_WriteByte(DEM_ADDSLOT);
-		Net_WriteByte(slot);
+		Net_WriteInt8(DEM_ADDSLOT);
+		Net_WriteInt8(slot);
 		Net_WriteWeapon(type);
 	}
 }
@@ -723,8 +723,8 @@ CCMD (addslotdefault)
 	}
 	else
 	{
-		Net_WriteByte(DEM_ADDSLOTDEFAULT);
-		Net_WriteByte(slot);
+		Net_WriteInt8(DEM_ADDSLOTDEFAULT);
+		Net_WriteInt8(slot);
 		Net_WriteWeapon(type);
 	}
 }
@@ -857,7 +857,7 @@ static int ntoh_cmp(const void *a, const void *b)
 
 void P_WriteDemoWeaponsChunk(uint8_t **demo)
 {
-	WriteWord(Weapons_ntoh.Size(), demo);
+	WriteInt16(Weapons_ntoh.Size(), demo);
 	for (unsigned int i = 1; i < Weapons_ntoh.Size(); ++i)
 	{
 		WriteString(Weapons_ntoh[i]->TypeName.GetChars(), demo);
@@ -879,7 +879,7 @@ void P_ReadDemoWeaponsChunk(uint8_t **demo)
 	PClassActor *type;
 	const char *s;
 
-	count = ReadWord(demo);
+	count = ReadInt16(demo);
 	Weapons_ntoh.Resize(count);
 	Weapons_hton.Clear(count);
 
@@ -923,12 +923,12 @@ void Net_WriteWeapon(PClassActor *type)
 	assert(index >= 0 && index <= 32767);
 	if (index < 128)
 	{
-		Net_WriteByte(index);
+		Net_WriteInt8(index);
 	}
 	else
 	{
-		Net_WriteByte(0x80 | index);
-		Net_WriteByte(index >> 7);
+		Net_WriteInt8(0x80 | index);
+		Net_WriteInt8(index >> 7);
 	}
 }
 
@@ -942,10 +942,10 @@ PClassActor *Net_ReadWeapon(uint8_t **stream)
 {
 	int index;
 
-	index = ReadByte(stream);
+	index = ReadInt8(stream);
 	if (index & 0x80)
 	{
-		index = (index & 0x7F) | (ReadByte(stream) << 7);
+		index = (index & 0x7F) | (ReadInt8(stream) << 7);
 	}
 	if ((unsigned)index >= Weapons_ntoh.Size())
 	{

--- a/src/gamedata/info.cpp
+++ b/src/gamedata/info.cpp
@@ -785,17 +785,17 @@ static void SummonActor (int command, int command2, FCommandLine argv)
 			Printf ("Unknown actor '%s'\n", argv[1]);
 			return;
 		}
-		Net_WriteByte (argv.argc() > 2 ? command2 : command);
+		Net_WriteInt8 (argv.argc() > 2 ? command2 : command);
 		Net_WriteString (type->TypeName.GetChars());
 
 		if (argv.argc () > 2)
 		{
-			Net_WriteWord (atoi (argv[2])); // angle
-			Net_WriteWord ((argv.argc() > 3) ? atoi(argv[3]) : 0); // TID
-			Net_WriteByte ((argv.argc() > 4) ? atoi(argv[4]) : 0); // special
+			Net_WriteInt16 (atoi (argv[2])); // angle
+			Net_WriteInt16 ((argv.argc() > 3) ? atoi(argv[3]) : 0); // TID
+			Net_WriteInt8 ((argv.argc() > 4) ? atoi(argv[4]) : 0); // special
 			for (int i = 5; i < 10; i++)
 			{ // args[5]
-				Net_WriteLong((i < argv.argc()) ? atoi(argv[i]) : 0);
+				Net_WriteInt32((i < argv.argc()) ? atoi(argv[i]) : 0);
 			}
 		}
 	}

--- a/src/gamedata/statistics.cpp
+++ b/src/gamedata/statistics.cpp
@@ -602,7 +602,7 @@ CCMD(finishgame)
 		return;
 	}
 	// This CCMD simulates an end-of-game action and exists to end mods that never exit their last Level->
-	Net_WriteByte(DEM_FINISHGAME);
+	Net_WriteInt8(DEM_FINISHGAME);
 }
 
 ADD_STAT(statistics)

--- a/src/m_cheat.cpp
+++ b/src/m_cheat.cpp
@@ -676,6 +676,6 @@ CCMD (mdk)
 		return;
 
 	const char *name = argv.argc() > 1 ? argv[1] : "";
-	Net_WriteByte (DEM_MDK);
+	Net_WriteInt8 (DEM_MDK);
 	Net_WriteString(name);
 }

--- a/src/p_conversation.cpp
+++ b/src/p_conversation.cpp
@@ -276,17 +276,17 @@ DEFINE_ACTION_FUNCTION(DConversationMenu, SendConversationReply)
 	switch (node)
 	{
 	case -1:
-		Net_WriteByte(DEM_CONVNULL);
+		Net_WriteInt8(DEM_CONVNULL);
 		break;
 
 	case -2:
-		Net_WriteByte(DEM_CONVCLOSE);
+		Net_WriteInt8(DEM_CONVCLOSE);
 		break;
 
 	default:
-		Net_WriteByte(DEM_CONVREPLY);
-		Net_WriteWord(node);
-		Net_WriteByte(reply);
+		Net_WriteInt8(DEM_CONVREPLY);
+		Net_WriteInt16(node);
+		Net_WriteInt8(reply);
 		break;
 	}
 	StaticLastReply = reply;
@@ -677,8 +677,8 @@ void P_ConversationCommand (int netcode, int pnum, uint8_t **stream)
 	}
 	if (netcode == DEM_CONVREPLY)
 	{
-		int nodenum = ReadWord(stream);
-		int replynum = ReadByte(stream);
+		int nodenum = ReadInt16(stream);
+		int replynum = ReadInt8(stream);
 		HandleReply(player, pnum == consoleplayer, nodenum, replynum);
 	}
 	else

--- a/src/playsim/bots/b_bot.cpp
+++ b/src/playsim/bots/b_bot.cpp
@@ -214,7 +214,7 @@ CCMD (removebots)
 		return;
 	}
 
-	Net_WriteByte (DEM_KILLBOTS);
+	Net_WriteInt8 (DEM_KILLBOTS);
 }
 
 CCMD (freeze)
@@ -228,8 +228,8 @@ CCMD (freeze)
 		return;
 	}
 
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (CHT_FREEZE);
+	Net_WriteInt8(DEM_GENERICCHEAT);
+	Net_WriteInt8(CHT_FREEZE);
 }
 
 CCMD (listbots)

--- a/src/playsim/bots/b_game.cpp
+++ b/src/playsim/bots/b_game.cpp
@@ -296,8 +296,8 @@ bool FCajunMaster::SpawnBot (const char *name, int color)
 
 	thebot->inuse = BOTINUSE_Waiting;
 
-	Net_WriteByte (DEM_ADDBOT);
-	Net_WriteByte (botshift);
+	Net_WriteInt8 (DEM_ADDBOT);
+	Net_WriteInt8 (botshift);
 	{
 		//Set color.
 		FString concat = thebot->Info;
@@ -311,23 +311,23 @@ bool FCajunMaster::SpawnBot (const char *name, int color)
 		}
 		Net_WriteString (concat.GetChars());
 	}
-	Net_WriteByte(thebot->skill.aiming);
-	Net_WriteByte(thebot->skill.perfection);
-	Net_WriteByte(thebot->skill.reaction);
-	Net_WriteByte(thebot->skill.isp);
+	Net_WriteInt8(thebot->skill.aiming);
+	Net_WriteInt8(thebot->skill.perfection);
+	Net_WriteInt8(thebot->skill.reaction);
+	Net_WriteInt8(thebot->skill.isp);
 
 	return true;
 }
 
 void FCajunMaster::TryAddBot (FLevelLocals *Level, uint8_t **stream, int player)
 {
-	int botshift = ReadByte (stream);
+	int botshift = ReadInt8 (stream);
 	char *info = ReadString (stream);
 	botskill_t skill;
-	skill.aiming = ReadByte (stream);
-	skill.perfection = ReadByte (stream);
-	skill.reaction = ReadByte (stream);
-	skill.isp = ReadByte (stream);
+	skill.aiming = ReadInt8 (stream);
+	skill.perfection = ReadInt8 (stream);
+	skill.reaction = ReadInt8 (stream);
+	skill.isp = ReadInt8 (stream);
 
 	botinfo_t *thebot = NULL;
 

--- a/src/playsim/p_interaction.cpp
+++ b/src/playsim/p_interaction.cpp
@@ -1883,8 +1883,8 @@ CCMD (kill)
 			if (CheckCheatmode ())
 				return;
 
-			Net_WriteByte (DEM_GENERICCHEAT);
-			Net_WriteByte (CHT_MASSACRE);
+			Net_WriteInt8 (DEM_GENERICCHEAT);
+			Net_WriteInt8 (CHT_MASSACRE);
 		}
 		else if (!stricmp (argv[1], "baddies"))
 		{
@@ -1892,12 +1892,12 @@ CCMD (kill)
 			if (CheckCheatmode ())
 				return;
 
-			Net_WriteByte (DEM_GENERICCHEAT);
-			Net_WriteByte (CHT_MASSACRE2);
+			Net_WriteInt8 (DEM_GENERICCHEAT);
+			Net_WriteInt8 (CHT_MASSACRE2);
 		}
 		else
 		{
-			Net_WriteByte (DEM_KILLCLASSCHEAT);
+			Net_WriteInt8 (DEM_KILLCLASSCHEAT);
 			Net_WriteString (argv[1]);
 		}
 	}
@@ -1908,7 +1908,7 @@ CCMD (kill)
 			return;
 
 		// Kill the player
-		Net_WriteByte (DEM_SUICIDE);
+		Net_WriteInt8 (DEM_SUICIDE);
 	}
 	C_HideConsole ();
 }
@@ -1920,7 +1920,7 @@ CCMD(remove)
 		if (CheckCheatmode())
 			return;
 
-		Net_WriteByte(DEM_REMOVE);
+		Net_WriteInt8(DEM_REMOVE);
 		Net_WriteString(argv[1]);
 		C_HideConsole();
 	}

--- a/src/playsim/p_lnspec.cpp
+++ b/src/playsim/p_lnspec.cpp
@@ -3180,7 +3180,7 @@ FUNC(LS_Autosave)
 	if (gameaction != ga_savegame)
 	{
 		Level->flags2 &= ~LEVEL2_NOAUTOSAVEHINT;
-		Net_WriteByte (DEM_CHECKAUTOSAVE);
+		Net_WriteInt8 (DEM_CHECKAUTOSAVE);
 	}
 	return true;
 }

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -478,7 +478,7 @@ void player_t::SetFOV(float fov)
 		{
 			if (consoleplayer == Net_Arbitrator)
 			{
-				Net_WriteByte(DEM_MYFOV);
+				Net_WriteInt8(DEM_MYFOV);
 			}
 			else
 			{
@@ -488,7 +488,7 @@ void player_t::SetFOV(float fov)
 		}
 		else
 		{
-			Net_WriteByte(DEM_MYFOV);
+			Net_WriteInt8(DEM_MYFOV);
 		}
 		Net_WriteFloat(clamp<float>(fov, 5.f, 179.f));
 	}
@@ -637,9 +637,9 @@ void player_t::SendPitchLimits() const
 			uppitch = downpitch = (int)maxviewpitch;
 		}
 
-		Net_WriteByte(DEM_SETPITCHLIMIT);
-		Net_WriteByte(uppitch);
-		Net_WriteByte(downpitch);
+		Net_WriteInt8(DEM_SETPITCHLIMIT);
+		Net_WriteInt8(uppitch);
+		Net_WriteInt8(downpitch);
 	}
 }
 

--- a/src/st_stuff.cpp
+++ b/src/st_stuff.cpp
@@ -439,8 +439,8 @@ static bool CheatAddKey (cheatseq_t *cheat, uint8_t key, bool *eat)
 
 static bool Cht_Generic (cheatseq_t *cheat)
 {
-	Net_WriteByte (DEM_GENERICCHEAT);
-	Net_WriteByte (cheat->Args[0]);
+	Net_WriteInt8 (DEM_GENERICCHEAT);
+	Net_WriteInt8 (cheat->Args[0]);
 	return true;
 }
 

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -1,21 +1,23 @@
 enum ENetCmd
 {
-	NET_BYTE = 1,
-	NET_WORD,
-	NET_LONG,
+	NET_INT8 = 1,
+	NET_INT16,
+	NET_INT,
 	NET_FLOAT,
+	NET_DOUBLE,
 	NET_STRING,
-}
+};
 
 struct NetworkCommand native play version("4.12")
 {
     native readonly int Player;
     native readonly Name Command;
 
-    native int ReadByte();
-    native int ReadWord();
-    native int ReadLong();
+    native int ReadInt8();
+    native int ReadInt16();
+    native int ReadInt();
     native double ReadFloat();
+    native double ReadDouble();
     native string ReadString();
 
     // Wrappers
@@ -26,17 +28,18 @@ struct NetworkCommand native play version("4.12")
     native Vector3 ReadVector3();
     native Vector4 ReadVector4();
     native Quat ReadQuat();
-    native void ReadIntArray(out Array<int> values, ENetCmd intSize = NET_LONG);
-    native void ReadFloatArray(out Array<double> values);
+    native void ReadIntArray(out Array<int> values, ENetCmd intSize = NET_INT);
+    native void ReadDoubleArray(out Array<double> values, bool doublePrecision = true);
     native void ReadStringArray(out Array<string> values, bool skipEmpty = false);
 }
 
 class NetworkBuffer native version("4.12")
 {
-    native void AddByte(int value);
-    native void AddWord(int value);
-    native void AddLong(int value);
+    native void AddInt8(int value);
+    native void AddInt16(int value);
+    native void AddInt(int value);
     native void AddFloat(double value);
+    native void AddDouble(double value);
     native void AddString(string value);
 
     // Wrappers
@@ -47,8 +50,8 @@ class NetworkBuffer native version("4.12")
     native void AddVector3(Vector3 value);
     native void AddVector4(Vector4 value);
     native void AddQuat(Quat value);
-    native void AddIntArray(Array<int> values, ENetCmd intSize = NET_LONG);
-    native void AddFloatArray(Array<double> values);
+    native void AddIntArray(Array<int> values, ENetCmd intSize = NET_INT);
+    native void AddDoubleArray(Array<double> values, bool doublePrecision = true);
     native void AddStringArray(Array<string> values);
 }
 


### PR DESCRIPTION
Added to allow for both doubles and 64-bit ints to be sent over the network without data loss. Doubles are the more common case as the new ZScript networking functionality can make use of them. Also fixes int sizing (e.g. short->int16_t, int->int32_t). Functions have been renamed to more appropriately represent what they read/write (were longs ever used?).