### PR TITLE
Expose hud_oldscale and hud_scalefactor to the menu; add mGrayCheckVal

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1077,9 +1077,11 @@ OptionMenu "ScalingOptions" protected
 	StaticText "$SCALEMNU_OVERRIDE", 1
 	ScaleSlider "$SCALEMNU_MESSAGES", 			"con_scaletext", 0.0, 8.0, 1.0, "$SCALEMNU_USEUI"
 	ScaleSlider "$SCALEMNU_CONSOLE", 			"con_scale", 0.0, 8.0, 1.0, "$SCALEMNU_USEUI"
-	ScaleSlider "$SCALEMNU_STATBAR",			"st_scale", -1.0, 8.0, 1.0, "$SCALEMNU_USEUI", "$SCALEMNU_USEFS"
-	ScaleSlider "$SCALEMNU_HUD", 				"hud_scale", -1.0, 8.0, 1.0, "$SCALEMNU_USEUI", "$SCALEMNU_USEFS"
-	ScaleSlider "$SCALEMNU_ALTHUD",				"hud_althudscale", 0.0, 8.0, 1.0, "$SCALEMNU_USEUI"
+	Option "$SCALEMNU_HUD_OLDSCALE",			"hud_oldscale", "OnOff"
+	Slider "$SCALEMNU_HUD_SCALEFACTOR",			"hud_scalefactor", 0.0, 1.0, 0.025, 3, "hud_oldscale", 1
+	ScaleSlider "$SCALEMNU_STATBAR",			"st_scale", -1.0, 8.0, 1.0, "$SCALEMNU_USEUI", "$SCALEMNU_USEFS", "hud_oldscale"
+	ScaleSlider "$SCALEMNU_HUD", 				"hud_scale", -1.0, 8.0, 1.0, "$SCALEMNU_USEUI", "$SCALEMNU_USEFS", "hud_oldscale"
+	ScaleSlider "$SCALEMNU_ALTHUD",				"hud_althudscale", 0.0, 8.0, 1.0, "$SCALEMNU_USEUI", "", "hud_oldscale"
 	StaticText " "
 	Option "$SCALEMNU_HUDASPECT", 				"hud_aspectscale", "OnOff"
 	StaticText " "

--- a/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
@@ -37,13 +37,15 @@ class OptionMenuItem : MenuItemBase
 	String mLabel;
 	bool mCentered;
 	CVar mGrayCheck;
+	int mGrayCheckVal;
 
-	protected void Init(String label, String command, bool center = false, CVar graycheck = null)
+	protected void Init(String label, String command, bool center = false, CVar graycheck = null, int graycheckVal = 0)
 	{
 		Super.Init(0, 0, command);
 		mLabel = label;
 		mCentered = center;
 		mGrayCheck = graycheck;
+		mGrayCheckVal = graycheckVal;
 	}
 
 	protected void drawText(int x, int y, int color, String text, bool grayed = false)
@@ -75,7 +77,7 @@ class OptionMenuItem : MenuItemBase
 
 	virtual bool IsGrayed()
 	{
-		return mGrayCheck != null && !mGrayCheck.GetInt();
+		return mGrayCheck != null && mGrayCheck.GetInt() == mGrayCheckVal;
 	}
 
 	override bool Selectable()
@@ -263,9 +265,9 @@ class OptionMenuItemOptionBase : OptionMenuItem
 
 	const OP_VALUES = 0x11001;
 
-	protected void Init(String label, Name command, Name values, CVar graycheck, int center)
+	protected void Init(String label, Name command, Name values, CVar graycheck, int center, int graycheckVal = 0)
 	{
-		Super.Init(label, command, false, graycheck);
+		Super.Init(label, command, false, graycheck, graycheckVal);
 		mValues = values;
 		mCenter = center;
 	}
@@ -361,9 +363,9 @@ class OptionMenuItemOption : OptionMenuItemOptionBase
 
 	private static native void SetCVarDescription(CVar cv, String label);
 
-	OptionMenuItemOption Init(String label, Name command, Name values, CVar graycheck = null, int center = 0)
+	OptionMenuItemOption Init(String label, Name command, Name values, CVar graycheck = null, int center = 0, int graycheckVal = 0)
 	{
-		Super.Init(label, command, values, graycheck, center);
+		Super.Init(label, command, values, graycheck, center, graycheckVal);
 		mCVar = CVar.FindCVar(mAction);
 		if (mCVar) SetCVarDescription(mCVar, label);
 		return self;
@@ -699,9 +701,9 @@ class OptionMenuSliderBase : OptionMenuItem
 	int mDrawX;
 	int mSliderShort;
 
-	protected void Init(String label, double min, double max, double step, int showval, Name command = 'none', CVar graycheck = NULL)
+	protected void Init(String label, double min, double max, double step, int showval, Name command = 'none', CVar graycheck = NULL, int graycheckVal = 0)
 	{
-		Super.Init(label, command, false, graycheck);
+		Super.Init(label, command, false, graycheck, graycheckVal);
 		mMin = min;
 		mMax = max;
 		mStep = step;
@@ -855,9 +857,9 @@ class OptionMenuItemSlider : OptionMenuSliderBase
 {
 	CVar mCVar;
 
-	OptionMenuItemSlider Init(String label, Name command, double min, double max, double step, int showval = 1, CVar graycheck = NULL)
+	OptionMenuItemSlider Init(String label, Name command, double min, double max, double step, int showval = 1, CVar graycheck = NULL, int graycheckVal = 0)
 	{
-		Super.Init(label, min, max, step, showval, command, graycheck);
+		Super.Init(label, min, max, step, showval, command, graycheck, graycheckVal);
 		mCVar =CVar.FindCVar(command);
 		return self;
 	}
@@ -895,9 +897,9 @@ class OptionMenuItemColorPicker : OptionMenuItem
 
 	const CPF_RESET = 0x20001;
 
-	OptionMenuItemColorPicker Init(String label, Name command, CVar graycheck = null)
+	OptionMenuItemColorPicker Init(String label, Name command, CVar graycheck = null, int graycheckVal = 0)
 	{
-		Super.Init(label, command, false, graycheck);
+		Super.Init(label, command, false, graycheck, graycheckVal);
 		CVar cv = CVar.FindCVar(command);
 		if (cv != null && cv.GetRealType() != CVar.CVAR_Color) cv = null;
 		mCVar = cv;
@@ -974,9 +976,9 @@ class OptionMenuFieldBase : OptionMenuItem
 {
 	CVar mCVar;
 
-	void Init (String label, Name command, CVar graycheck = null)
+	void Init (String label, Name command, CVar graycheck = null, int graycheckVal = 0)
 	{
-		Super.Init(label, command, false, graycheck);
+		Super.Init(label, command, false, graycheck, graycheckVal);
 		mCVar = CVar.FindCVar(mAction);
 	}
 
@@ -1037,9 +1039,9 @@ class OptionMenuItemTextField : OptionMenuFieldBase
 {
 	TextEnterMenu mEnter;
 
-	OptionMenuItemTextField Init (String label, Name command, CVar graycheck = null)
+	OptionMenuItemTextField Init (String label, Name command, CVar graycheck = null, int graycheckVal = 0)
 	{
-		Super.Init(label, command, graycheck);
+		Super.Init(label, command, graycheck, graycheckVal);
 		mEnter = null;
 		return self;
 	}
@@ -1109,9 +1111,9 @@ class OptionMenuItemTextField : OptionMenuFieldBase
 
 class OptionMenuItemNumberField : OptionMenuFieldBase
 {
-	OptionMenuItemNumberField Init (String label, Name command, float minimum = 0, float maximum = 100, float step = 1, CVar graycheck = null)
+	OptionMenuItemNumberField Init (String label, Name command, float minimum = 0, float maximum = 100, float step = 1, CVar graycheck = null, int graycheckVal = 0)
 	{
-		Super.Init(label, command, graycheck);
+		Super.Init(label, command, graycheck, graycheckVal);
 		mMinimum = min(minimum, maximum);
 		mMaximum = max(minimum, maximum);
 		mStep = max(1, step);
@@ -1169,9 +1171,9 @@ class OptionMenuItemScaleSlider : OptionMenuItemSlider
 	String TextNegOne;
 	int mClickVal;
 
-	OptionMenuItemScaleSlider Init(String label, Name command, double min, double max, double step, String zero, String negone = "", CVar graycheck = null)
+	OptionMenuItemScaleSlider Init(String label, Name command, double min, double max, double step, String zero, String negone = "", CVar graycheck = null, int graycheckVal = 0)
 	{
-		Super.Init(label, command, min, max, step, 0, graycheck);
+		Super.Init(label, command, min, max, step, 0, graycheck, graycheckVal);
 		mCVar =CVar.FindCVar(command);
 		TextZero = zero;
 		TextNEgOne = negone;
@@ -1237,9 +1239,9 @@ class OptionMenuItemFlagOption : OptionMenuItemOption
 {
 	int mBitShift;
 
-	OptionMenuItemFlagOption Init(String label, Name command, Name values, int bitShift, CVar greycheck = null, int center = 0)
+	OptionMenuItemFlagOption Init(String label, Name command, Name values, int bitShift, CVar greycheck = null, int center = 0, int graycheckVal = 0)
 	{
-		Super.Init(label, command, values, greycheck, center);
+		Super.Init(label, command, values, greycheck, center, graycheckVal);
 		mBitShift = bitShift;
 
 		return self;


### PR DESCRIPTION
This adds two separate changes, but since the menu one is mechanically related to the one to OptionMenuItem, they have to go together:
1. Adds the `graycheckVal` argument to OptionMenu items, and the corresponding `mGrayCheckVal` field to OptionMenuItem. This will allow users to specify an explicit value for the graycheck cvar, so that items can be grayed-out not only when it's 0/false. It's a bit awkward because in some elements `graycheckVal` follows `graycheck` directly, but in others the `centered` argument is in the middle, but there's nothing I can do about it and I think it's better to have it this way than not at all.
2. Exposes `hud_oldscale` and `hud_scalefactor` to the menu (with corresponding new entries to LANGUAGE.csv). With the help of the new `graycheckval`, when `hud_oldscale` is disabled, the traditional HUD scale sliders become grayed-out. `hud_scalefactor` is exposed with 0.025 increments.

https://github.com/ZDoom/gzdoom/assets/42670463/037accf2-ff04-4616-8654-cdbf82f8c99e

There are no changes to the default values, so this shouldn't lead to any confusion among the users.

P.S. Please don't mind that in the video the scalefactor slider goes up to 2.000; in the commit it's limited to 0.0-1.0. Although ideally I *would* like the ability to make it go higher, but I don't know how to do that.