### PR TITLE
Fix "unexpected end of TTF file" error

### DIFF
--- a/src/common/widgets/widgetresourcedata.cpp
+++ b/src/common/widgets/widgetresourcedata.cpp
@@ -54,7 +54,7 @@ std::vector<SingleFontData> LoadWidgetFontData(const std::string& name)
 	std::vector<SingleFontData> returnv;
 	if (!stricmp(name.c_str(), "notosans"))
 	{
-		returnv.resize(5);
+		returnv.resize(3);
 		returnv[0].fontdata = LoadFile("widgets/noto/notosans-regular.ttf");
 		returnv[1].fontdata = LoadFile("widgets/noto/notosansarmenian-regular.ttf");
 		returnv[2].fontdata = LoadFile("widgets/noto/notosansgeorgian-regular.ttf");
@@ -62,6 +62,7 @@ std::vector<SingleFontData> LoadWidgetFontData(const std::string& name)
 		wchar_t wbuffer[256];
 		if (GetWindowsDirectoryW(wbuffer, 256))
 		{
+			returnv.resize(5);
 			FString windir(wbuffer);
 			returnv[3].fontdata = LoadDiskFile((windir + "/fonts/yugothm.ttc").GetChars());
 			returnv[3].language = "ja";


### PR DESCRIPTION
Changed returnv vector size to 3 by default and set size 5 for WIN32 only.

Got this error on linux build:
![Screenshot from 2024-01-11 07-11-59](https://github.com/ZDoom/gzdoom/assets/927963/cf2c0202-3166-4a6a-a3aa-0d7ad6e81255)
