### PR TITLE
VisualThinker Sprite & Frame Support

### DIFF
--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -1093,14 +1093,6 @@ void DVisualThinker::Tick()
 	if (ObjectFlags & OF_EuthanizeMe)
 		return;
 
-	// There won't be a standard particle for this, it's only for graphics.
-	if (!PT.texture.isValid())
-	{
-		Printf("No valid texture, destroyed");
-		Destroy();
-		return;
-	}
-
 	if (isFrozen())
 	{	// needed here because it won't retroactively update like actors do.
 		PT.subsector = Level->PointInRenderSubsector(PT.Pos);

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -1102,6 +1102,7 @@ void DVisualThinker::Tick()
 	}
 	Prev = PT.Pos;
 	PrevRoll = PT.Roll;
+	PrevAngle = Angle;
 	// Handle crossing a line portal
 	DVector2 newxy = Level->GetPortalOffsetPosition(PT.Pos.X, PT.Pos.Y, PT.Vel.X, PT.Vel.Y);
 	PT.Pos.X = newxy.X;
@@ -1163,6 +1164,22 @@ float DVisualThinker::InterpolatedRoll(double ticFrac) const
 		return PT.Roll;
 
 	return float(PrevRoll + (PT.Roll - PrevRoll) * ticFrac);
+}
+
+FAngle DVisualThinker::GetSpriteAngle(FAngle viewangle, double ticFrac) const
+{
+	if (VFlags & VTF_ABSOLUTEANGLE)
+	{
+		return Angle;
+	}
+	else
+	{
+		FAngle thisang;
+		if (!(VFlags & VTF_DONTINTERPOLATE))
+			thisang = PrevAngle + deltaangle(PrevAngle, Angle) * ticFrac;
+		else thisang = Angle;
+		return viewangle - (thisang + AddRotation);
+	}
 }
 
 
@@ -1257,6 +1274,11 @@ void DVisualThinker::Serialize(FSerializer& arc)
 		("scolor", PT.color)
 		("lightlevel", LightLevel)
 		("flags", PT.flags)
+		("angle", Angle)
+		("prevangle", PrevAngle)
+		("addrotation,", AddRotation)
+		("sprite", sprite)
+		("frame", frame)
 		("VFlags", VFlags)
 		;
 		
@@ -1278,4 +1300,9 @@ DEFINE_FIELD(DVisualThinker, PrevRoll);
 DEFINE_FIELD(DVisualThinker, Translation);
 DEFINE_FIELD(DVisualThinker, LightLevel);
 DEFINE_FIELD(DVisualThinker, cursector);
+DEFINE_FIELD(DVisualThinker, Angle);
+DEFINE_FIELD(DVisualThinker, PrevAngle);
+DEFINE_FIELD(DVisualThinker, AddRotation);
+DEFINE_FIELD(DVisualThinker, sprite);
+DEFINE_FIELD(DVisualThinker, frame);
 DEFINE_FIELD(DVisualThinker, VFlags);

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -1019,6 +1019,7 @@ void DVisualThinker::Construct()
 	PT.texture = FTextureID();
 	PT.style = STYLE_Normal;
 	PT.flags = 0;
+	VFlags = 0;
 	Translation = NO_TRANSLATION;
 	PT.subsector = nullptr;
 	cursector = nullptr;
@@ -1143,7 +1144,7 @@ int DVisualThinker::GetLightLevel(sector_t* rendersector) const
 {
 	int lightlevel = rendersector->GetSpriteLight();
 
-	if (bAddLightLevel)
+	if (VFlags & VTF_ADDLIGHTLEVEL)
 	{
 		lightlevel += LightLevel;
 	}
@@ -1156,7 +1157,8 @@ int DVisualThinker::GetLightLevel(sector_t* rendersector) const
 
 FVector3 DVisualThinker::InterpolatedPosition(double ticFrac) const
 {
-	if (bDontInterpolate) return FVector3(PT.Pos);
+	if (VFlags & VTF_DONTINTERPOLATE) 
+		return FVector3(PT.Pos);
 
 	DVector3 proc = Prev + (ticFrac * (PT.Pos - Prev));
 	return FVector3(proc);
@@ -1165,7 +1167,8 @@ FVector3 DVisualThinker::InterpolatedPosition(double ticFrac) const
 
 float DVisualThinker::InterpolatedRoll(double ticFrac) const
 {
-	if (bDontInterpolate) return PT.Roll;
+	if (!(VFlags & VTF_DONTINTERPOLATE)) 
+		return PT.Roll;
 
 	return float(PrevRoll + (PT.Roll - PrevRoll) * ticFrac);
 }
@@ -1206,7 +1209,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DVisualThinker, SetTranslation, SetTranslation)
 
 static int IsFrozen(DVisualThinker * self)
 {
-	return (self->Level->isFrozen() && !(self->PT.flags & SPF_NOTIMEFREEZE));
+	return !!(self->Level->isFrozen() && !(self->PT.flags & SPF_NOTIMEFREEZE));
 }
 
 bool DVisualThinker::isFrozen()
@@ -1260,12 +1263,10 @@ void DVisualThinker::Serialize(FSerializer& arc)
 		("translation", Translation)
 		("cursector", cursector)
 		("scolor", PT.color)
-		("flipx", bXFlip)
-		("flipy", bYFlip)
-		("dontinterpolate", bDontInterpolate)
-		("addlightlevel", bAddLightLevel)
 		("lightlevel", LightLevel)
-		("flags", PT.flags);
+		("flags", PT.flags)
+		("VFlags", VFlags)
+		;
 		
 }
 
@@ -1285,7 +1286,4 @@ DEFINE_FIELD(DVisualThinker, PrevRoll);
 DEFINE_FIELD(DVisualThinker, Translation);
 DEFINE_FIELD(DVisualThinker, LightLevel);
 DEFINE_FIELD(DVisualThinker, cursector);
-DEFINE_FIELD(DVisualThinker, bXFlip);
-DEFINE_FIELD(DVisualThinker, bYFlip);
-DEFINE_FIELD(DVisualThinker, bDontInterpolate);
-DEFINE_FIELD(DVisualThinker, bAddLightLevel);
+DEFINE_FIELD(DVisualThinker, VFlags);

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -160,6 +160,8 @@ enum EVThinkerFlags
 	VTF_YFLIP =						1 << 1,		// flip the sprite on the x/y axis.
 	VTF_DONTINTERPOLATE =			1 << 2,		// disable all interpolation
 	VTF_ADDLIGHTLEVEL =				1 << 3,		// adds sector light level to 'LightLevel'
+	VTF_ABSOLUTEANGLE =				1 << 4,		// SpriteAngle becomes consistent no matter what angle it's viewed from
+	VTF_SPRITEFLIP =				1 << 5,		// Same as Actor's spriteflip flag.
 };
 
 class DVisualThinker : public DThinker
@@ -176,6 +178,13 @@ public:
 	sector_t		*cursector;
 	uint8_t			VFlags;
 
+	FAngle			Angle,
+					PrevAngle,
+					AddRotation;		// Additional rotation to the sprite, i.e. 90 would make a front-facing sprite turn to the side.
+
+	int				sprite;				// used to find patch_t and flip value
+	uint8_t			frame;				// sprite frame to draw
+
 	// internal only variables
 	particle_t		PT;
 	HWSprite		*spr; //in an effort to cache the result. 
@@ -191,6 +200,7 @@ public:
 	int GetLightLevel(sector_t *rendersector) const;
 	FVector3 InterpolatedPosition(double ticFrac) const;
 	float InterpolatedRoll(double ticFrac) const;
+	FAngle GetSpriteAngle(FAngle viewangle, double ticFrac) const;
 
 	void Tick() override;
 	void UpdateSpriteInfo();

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -148,11 +148,20 @@ void P_DisconnectEffect (AActor *actor);
 // 
 // VisualThinkers
 // by Major Cooke
-// Credit to phantombeta, RicardoLuis0 & RaveYard for aid
+// Credit to phantombeta, RicardoLuis0, Rachael & RaveYard for aid
 // 
 //===========================================================================
 class HWSprite;
 struct FTranslationID;
+
+enum EVThinkerFlags
+{
+	VTF_XFLIP =						1 << 0,
+	VTF_YFLIP =						1 << 1,		// flip the sprite on the x/y axis.
+	VTF_DONTINTERPOLATE =			1 << 2,		// disable all interpolation
+	VTF_ADDLIGHTLEVEL =				1 << 3,		// adds sector light level to 'LightLevel'
+};
+
 class DVisualThinker : public DThinker
 {
 	DECLARE_CLASS(DVisualThinker, DThinker);
@@ -165,11 +174,7 @@ public:
 	FTranslationID	Translation;
 	FTextureID		AnimatedTexture;
 	sector_t		*cursector;
-
-	bool			bXFlip,
-					bYFlip,				// flip the sprite on the x/y axis.
-					bDontInterpolate,	// disable all interpolation
-					bAddLightLevel;		// adds sector light level to 'LightLevel'
+	uint8_t			VFlags;
 
 	// internal only variables
 	particle_t		PT;

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -1456,7 +1456,7 @@ void HWSprite::AdjustVisualThinker(HWDrawInfo* di, DVisualThinker* spr, sector_t
 			? TexAnim.UpdateStandaloneAnimation(spr->PT.animData, di->Level->maptime + timefrac)
 			: spr->PT.texture, !custom_anim);
 
-	if (spr->bDontInterpolate)
+	if (spr->VFlags & VTF_DONTINTERPOLATE)
 		timefrac = 0.;
 
 	FVector3 interp = spr->InterpolatedPosition(timefrac);
@@ -1480,12 +1480,13 @@ void HWSprite::AdjustVisualThinker(HWDrawInfo* di, DVisualThinker* spr, sector_t
 	auto r = spi.GetSpriteRect();
 	r.Scale(spr->Scale.X, spr->Scale.Y);
 
-	if (spr->bXFlip)	
+	if (spr->VFlags & VTF_XFLIP)	
 	{
 		std::swap(ul,ur);
 		r.left = -r.width - r.left;	// mirror the sprite's x-offset
 	}
-	if (spr->bYFlip)	std::swap(vt,vb);
+	if (spr->VFlags & VTF_YFLIP)	
+		std::swap(vt,vb);
 
 	float viewvecX = vp.ViewVector.X;
 	float viewvecY = vp.ViewVector.Y;

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -1426,6 +1426,7 @@ void HWSprite::ProcessParticle(HWDrawInfo *di, particle_t *particle, sector_t *s
 		if (particle_style != 2 && trans>=1.0f-FLT_EPSILON) hw_styleflags = STYLEHW_Solid;
 		else hw_styleflags = STYLEHW_NoAlphaTest;
 	}
+	fullbright = particle->flags & SPF_FULLBRIGHT;
 
 	if (sector->e->XFloor.lightlist.Size() != 0 && !di->isFullbrightScene() && !fullbright)
 		lightlist = &sector->e->XFloor.lightlist;

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1092,6 +1092,8 @@ enum EVThinkerFlags
 	VTF_YFLIP =						1 << 1,		// flip the sprite on the x/y axis.
 	VTF_DONTINTERPOLATE =			1 << 2,		// disable all interpolation
 	VTF_ADDLIGHTLEVEL =				1 << 3,		// adds sector light level to 'LightLevel'
+	VTF_ABSOLUTEANGLE =				1 << 4,		// SpriteAngle becomes consistent no matter what angle it's viewed from
+	VTF_SPRITEFLIP =				1 << 5,		// Same as Actor's spriteflip flag.
 };
 
 enum EGameType

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1086,6 +1086,14 @@ enum ETeleport
 	TELF_ROTATEBOOMINVERSE	= 64,
 };
 
+enum EVThinkerFlags
+{
+	VTF_XFLIP =						1 << 0,
+	VTF_YFLIP =						1 << 1,		// flip the sprite on the x/y axis.
+	VTF_DONTINTERPOLATE =			1 << 2,		// disable all interpolation
+	VTF_ADDLIGHTLEVEL =				1 << 3,		// adds sector light level to 'LightLevel'
+};
+
 enum EGameType
 {
 	GAME_Any	 = 0,

--- a/wadsrc/static/zscript/visualthinker.zs
+++ b/wadsrc/static/zscript/visualthinker.zs
@@ -11,11 +11,8 @@ Class VisualThinker : Thinker native
 	native TextureID		Texture;
 	native TranslationID	Translation;
 	native uint16			Flags;
+	native uint8			VFlags;
 	native int16			LightLevel;
-	native bool				bXFlip,
-							bYFlip,
-							bDontInterpolate,
-							bAddLightLevel;
 	native Color			scolor;
 
 	native Sector			CurSector; // can be null!
@@ -25,7 +22,8 @@ Class VisualThinker : Thinker native
 	native bool IsFrozen();
 
 	static VisualThinker Spawn(Class<VisualThinker> type, TextureID tex, Vector3 pos, Vector3 vel, double alpha = 1.0, int flags = 0,
-						  double roll = 0.0, Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal, TranslationID trans = 0)
+						  double roll = 0.0, Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal, TranslationID trans = 0, 
+						  int vflags = 0)
 	{
 		if (!Level)	return null;
 
@@ -42,6 +40,7 @@ Class VisualThinker : Thinker native
 			p.SetRenderStyle(style);
 			p.Translation = trans;
 			p.Flags = flags;
+			p.VFlags = vflags;
 		}
 		return p;
 	}

--- a/wadsrc/static/zscript/visualthinker.zs
+++ b/wadsrc/static/zscript/visualthinker.zs
@@ -7,8 +7,11 @@ Class VisualThinker : Thinker native
 							Offset;
 	native float			Roll,
 							PrevRoll,
+							Angle,
+							PrevAngle,
+							AddRotation,
 							Alpha;
-	native TextureID		Texture;
+	native TextureID		Texture;		// Has priority over sprite frames
 	native TranslationID	Translation;
 	native uint16			Flags;
 	native uint8			VFlags;
@@ -16,6 +19,9 @@ Class VisualThinker : Thinker native
 	native Color			scolor;
 
 	native Sector			CurSector; // can be null!
+	
+	native SpriteID			sprite;
+	native uint8			frame;
 
 	native void SetTranslation(Name trans);
 	native void SetRenderStyle(int mode); // see ERenderStyle


### PR DESCRIPTION
Adds support for adapting sprites and frames akin to actors, along with angles. This only affects graphics set with `sprite` and `frame` only - if `animatedtexture` is used, it will **NOT** perform sprite rotations.

Also replaces all the booleans with a single `VFlags` variable for cleanliness. These are solely for visual thinkers.