### PR TITLE
CalculateVertices Refactor

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -498,6 +498,8 @@ enum ActorRenderFlag2
 	RF2_ONLYVISIBLEINMIRRORS	= 0x0002,	// [Nash] only renders in mirrors
 	RF2_BILLBOARDFACECAMERA		= 0x0004,	// Sprite billboard face camera (override gl_billboard_faces_camera)
 	RF2_BILLBOARDNOFACECAMERA	= 0x0008,	// Sprite billboard face camera angle (override gl_billboard_faces_camera)
+	RF2_FLIPSPRITEOFFSETX		= 0x0010,
+	RF2_FLIPSPRITEOFFSETY		= 0x0020,
 };
 
 // This translucency value produces the closest match to Heretic's TINTTAB.
@@ -1471,6 +1473,11 @@ public:
 		result.Pitch = PrevAngles.Pitch + deltaangle(PrevAngles.Pitch, Angles.Pitch) * ticFrac;
 		result.Roll = PrevAngles.Roll + deltaangle(PrevAngles.Roll, Angles.Roll) * ticFrac;
 		return result;
+	}
+	float GetSpriteOffset(bool y) const
+	{
+		if (y)	return (float)(renderflags2 & RF2_FLIPSPRITEOFFSETY ? SpriteOffset.Y : -SpriteOffset.Y);
+		else	return (float)(renderflags2 & RF2_FLIPSPRITEOFFSETX ? SpriteOffset.X : -SpriteOffset.X);
 	}
 	DAngle GetSpriteAngle(DAngle viewangle, double ticFrac)
 	{

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -1206,7 +1206,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DVisualThinker, SetTranslation, SetTranslation)
 
 static int IsFrozen(DVisualThinker * self)
 {
-	return (self->Level->isFrozen() && !(self->PT.flags & SPF_NOTIMEFREEZE));
+	return !!(self->Level->isFrozen() && !(self->PT.flags & SPF_NOTIMEFREEZE));
 }
 
 bool DVisualThinker::isFrozen()
@@ -1242,6 +1242,14 @@ int DVisualThinker::GetRenderStyle()
 	return PT.style;
 }
 
+float DVisualThinker::GetOffset(bool y) const // Needed for the renderer.
+{
+	if (y)
+		return (float)(bFlipOffsetY ? Offset.Y : -Offset.Y);
+	else
+		return (float)(bFlipOffsetX ? Offset.X : -Offset.X);
+}
+
 void DVisualThinker::Serialize(FSerializer& arc)
 {
 	Super::Serialize(arc);
@@ -1264,6 +1272,8 @@ void DVisualThinker::Serialize(FSerializer& arc)
 		("flipy", bYFlip)
 		("dontinterpolate", bDontInterpolate)
 		("addlightlevel", bAddLightLevel)
+		("flipoffsetx", bFlipOffsetX)
+		("flipoffsetY", bFlipOffsetY)
 		("lightlevel", LightLevel)
 		("flags", PT.flags);
 		
@@ -1289,3 +1299,5 @@ DEFINE_FIELD(DVisualThinker, bXFlip);
 DEFINE_FIELD(DVisualThinker, bYFlip);
 DEFINE_FIELD(DVisualThinker, bDontInterpolate);
 DEFINE_FIELD(DVisualThinker, bAddLightLevel);
+DEFINE_FIELD(DVisualThinker, bFlipOffsetX);
+DEFINE_FIELD(DVisualThinker, bFlipOffsetY);

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -166,7 +166,9 @@ public:
 	FTextureID		AnimatedTexture;
 	sector_t		*cursector;
 
-	bool			bXFlip,
+	bool			bFlipOffsetX,
+					bFlipOffsetY,
+					bXFlip,
 					bYFlip,				// flip the sprite on the x/y axis.
 					bDontInterpolate,	// disable all interpolation
 					bAddLightLevel;		// adds sector light level to 'LightLevel'
@@ -191,4 +193,5 @@ public:
 	void UpdateSpriteInfo();
 	void Serialize(FSerializer& arc) override;
 
+	float GetOffset(bool y) const;
 };

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -414,7 +414,7 @@ bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
 	const bool isWallSprite = (actor != nullptr) && (spritetype == RF_WALLSPRITE);
 	const bool useOffsets = (actor != nullptr) && !(actor->renderflags & RF_ROLLCENTER);
 
-	FVector2 offset = FVector2( -offx, -offy );
+	FVector2 offset = FVector2( offx, offy );
 
 	// Account for +ROLLCENTER flag. Takes the embedded image offsets and adds them in with SpriteOffsets.
 	if (drawRollSpriteActor && useOffsets)
@@ -961,8 +961,8 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 		if (!tex || !tex->isValid()) return;
 		auto& spi = tex->GetSpritePositioning(type == RF_FACESPRITE);
 
-		offx = (float)thing->SpriteOffset.X;
-		offy = (float)thing->SpriteOffset.Y;
+		offx = (float)thing->GetSpriteOffset(false);
+		offy = (float)thing->GetSpriteOffset(true);
 
 		vt = spi.GetSpriteVT();
 		vb = spi.GetSpriteVB();
@@ -1491,8 +1491,8 @@ void HWSprite::AdjustVisualThinker(HWDrawInfo* di, DVisualThinker* spr, sector_t
 	y = interp.Y;
 	z = interp.Z;
 
-	offx = (float)spr->Offset.X;
-	offy = (float)spr->Offset.Y;
+	offx = (float)spr->GetOffset(false);
+	offy = (float)spr->GetOffset(true);
 
 	if (spr->PT.flags & SPF_ROLL)
 		Angles.Roll = TAngle<double>::fromDeg(spr->InterpolatedRoll(timefrac));

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -340,19 +340,32 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 //
 //==========================================================================
 
-bool HWSprite::CalculateVertices(HWDrawInfo *di, FVector3 *v, DVector3 *vp)
+void HandleSpriteOffsets(Matrix3x4 *mat, const FRotator *HW, FVector2 *offset, bool XYBillboard)
 {
-	const auto &HWAngles = di->Viewpoint.HWAngles;
+	FAngle zero = FAngle::fromDeg(0);
+	FAngle pitch = (XYBillboard) ? HW->Pitch : zero;
+	FAngle yaw = FAngle::fromDeg(270.) - HW->Yaw;
+
+	FQuaternion quat = FQuaternion::FromAngles(yaw, pitch, zero);
+	FVector3 sideVec = quat * FVector3(0, 1, 0);
+	FVector3 upVec = quat * FVector3(0, 0, 1);
+	FVector3 res = sideVec * offset->X + upVec * offset->Y;
+	mat->Translate(res.X, res.Z, res.Y);
+}
+
+bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
+{
+	FVector3 center = FVector3((x1 + x2) * 0.5, (y1 + y2) * 0.5, (z1 + z2) * 0.5);
+	const auto& HWAngles = di->Viewpoint.HWAngles;
+	Matrix3x4 mat;
 	if (actor != nullptr && (actor->renderflags & RF_SPRITETYPEMASK) == RF_FLATSPRITE)
 	{
-		Matrix3x4 mat;
-		mat.MakeIdentity();
-
 		// [MC] Rotate around the center or offsets given to the sprites.
 		// Counteract any existing rotations, then rotate the angle.
 		// Tilt the actor up or down based on pitch (increase 'somersaults' forward).
 		// Then counteract the roll and DO A BARREL ROLL.
 
+		mat.MakeIdentity();
 		FAngle pitch = FAngle::fromDeg(-Angles.Pitch.Degrees());
 		pitch.Normalized180();
 
@@ -362,12 +375,9 @@ bool HWSprite::CalculateVertices(HWDrawInfo *di, FVector3 *v, DVector3 *vp)
 
 		if (actor->renderflags & RF_ROLLCENTER)
 		{
-			float cx = (x1 + x2) * 0.5;
-			float cy = (y1 + y2) * 0.5;
-
-			mat.Translate(cx - x, 0, cy - y);
+			mat.Translate(center.X - x, 0, center.Y - y);
 			mat.Rotate(0, 1, 0, - Angles.Roll.Degrees());
-			mat.Translate(-cx, -z, -cy);
+			mat.Translate(-center.X, -z, -center.Y);
 		}
 		else
 		{
@@ -393,51 +403,45 @@ bool HWSprite::CalculateVertices(HWDrawInfo *di, FVector3 *v, DVector3 *vp)
 
 	// [Nash] has +ROLLSPRITE
 	const bool drawRollSpriteActor = (actor != nullptr && actor->renderflags & RF_ROLLSPRITE);
-
 	const bool drawRollParticle = (particle != nullptr && particle->flags & SPF_ROLL);
-
+	const bool doRoll = (drawRollSpriteActor || drawRollParticle);
 
 	// [fgsfds] check sprite type mask
 	uint32_t spritetype = (uint32_t)-1;
 	if (actor != nullptr) spritetype = actor->renderflags & RF_SPRITETYPEMASK;
 
 	// [Nash] is a flat sprite
-	const bool isFlatSprite = (actor != nullptr) && (spritetype == RF_WALLSPRITE);
+	const bool isWallSprite = (actor != nullptr) && (spritetype == RF_WALLSPRITE);
 	const bool useOffsets = (actor != nullptr) && !(actor->renderflags & RF_ROLLCENTER);
 
+	FVector2 offset = FVector2( -offx, -offy );
+
+	// Account for +ROLLCENTER flag. Takes the embedded image offsets and adds them in with SpriteOffsets.
+	if (drawRollSpriteActor && useOffsets)
+	{
+		offset.X += center.X - x;
+		offset.Y += center.Z - z;
+	}
+
 	// [Nash] check for special sprite drawing modes
-	if (drawWithXYBillboard || drawBillboardFacingCamera || drawRollSpriteActor || drawRollParticle || isFlatSprite)
+	if (drawWithXYBillboard || isWallSprite)
 	{
 		// Compute center of sprite
-		float xcenter = (x1 + x2)*0.5;
-		float ycenter = (y1 + y2)*0.5;
-		float zcenter = (z1 + z2)*0.5;
-		float xx = -xcenter + x;
-		float zz = -zcenter + z;
-		float yy = -ycenter + y;
-		Matrix3x4 mat;
 		mat.MakeIdentity();
-		mat.Translate(xcenter, zcenter, ycenter); // move to sprite center
+		mat.Translate(center.X, center.Z, center.Y); // move to sprite center
 
-		// [MC] Sprite offsets. These must be calculated separately in their own matrix,
-		// otherwise "face sprites" would cause some issues whenever enabled. We don't 
-		// want those calculations here. Credit to PhantomBeta for this.
-		if (offx || offy)
-		{
-			FQuaternion quat = FQuaternion::FromAngles(FAngle::fromDeg(270) - di->Viewpoint.HWAngles.Yaw, di->Viewpoint.HWAngles.Pitch, FAngle::fromDeg(0));
-			FVector3 sideVec = quat * FVector3(0, 1, 0);
-			FVector3 upVec = quat * FVector3(0, 0, 1);
-			FVector3 res = sideVec * -offx + upVec * -offy;
-			mat.Translate(res.X, res.Z, res.Y);
-		}
+
+		// [MC] Sprite offsets.
+		if (!offset.isZero())
+			HandleSpriteOffsets(&mat, &HWAngles, &offset, true);
 
 		// Order of rotations matters. Perform yaw rotation (Y, face camera) before pitch (X, tilt up/down).
-		if (drawBillboardFacingCamera && !isFlatSprite)
+		if (drawBillboardFacingCamera && !isWallSprite)
 		{
 			// [CMB] Rotate relative to camera XY position, not just camera direction,
 			// which is nicer in VR
-			float xrel = xcenter - vp->X;
-			float yrel = ycenter - vp->Y;
+			float xrel = center.X - vp->X;
+			float yrel = center.Y - vp->Y;
 			float absAngleDeg = atan2(-yrel, xrel) * (180 / M_PI);
 			float counterRotationDeg = 270. - HWAngles.Yaw.Degrees(); // counteracts existing sprite rotation
 			float relAngleDeg = counterRotationDeg + absAngleDeg;
@@ -446,32 +450,27 @@ bool HWSprite::CalculateVertices(HWDrawInfo *di, FVector3 *v, DVector3 *vp)
 		}
 
 		// [fgsfds] calculate yaw vectors
-		float rollDegrees = 0;
+		float rollDegrees = doRoll ? Angles.Roll.Degrees() : 0;
 		float angleRad = (FAngle::fromDeg(270.) - HWAngles.Yaw).Radians();
-		if (actor || drawRollParticle)	rollDegrees = Angles.Roll.Degrees();
 
 		// [fgsfds] Rotate the sprite about the sight vector (roll) 
-		if (spritetype == RF_WALLSPRITE)
+		if (isWallSprite)
 		{
 			float yawvecX = Angles.Yaw.Cos();
 			float yawvecY = Angles.Yaw.Sin();
 			mat.Rotate(0, 1, 0, 0);
 			if (drawRollSpriteActor)
 			{
-				if (useOffsets)	mat.Translate(xx, zz, yy);
 				mat.Rotate(yawvecX, 0, yawvecY, rollDegrees);
-				if (useOffsets) mat.Translate(-xx, -zz, -yy);
 			}
 		}
-		else if (drawRollSpriteActor || drawRollParticle)
+		else if (doRoll)
 		{
-			if (useOffsets) mat.Translate(xx, zz, yy);
 			if (drawWithXYBillboard)
 			{
 				mat.Rotate(-sin(angleRad), 0, cos(angleRad), -HWAngles.Pitch.Degrees());
 			}
 			mat.Rotate(cos(angleRad), 0, sin(angleRad), rollDegrees);
-			if (useOffsets) mat.Translate(-xx, -zz, -yy);
 		}
 		else if (drawWithXYBillboard)
 		{
@@ -481,8 +480,8 @@ bool HWSprite::CalculateVertices(HWDrawInfo *di, FVector3 *v, DVector3 *vp)
 			mat.Rotate(-sin(angleRad), 0, cos(angleRad), -HWAngles.Pitch.Degrees());
 		}
 
-		mat.Translate(-xcenter, -zcenter, -ycenter); // retreat from sprite center
-		
+		mat.Translate(-center.X, -center.Z, -center.Y); // retreat from sprite center
+
 		v[0] = mat * FVector3(x1, z1, y1);
 		v[1] = mat * FVector3(x2, z1, y2);
 		v[2] = mat * FVector3(x1, z2, y1);
@@ -490,10 +489,38 @@ bool HWSprite::CalculateVertices(HWDrawInfo *di, FVector3 *v, DVector3 *vp)
 	}
 	else // traditional "Y" billboard mode
 	{
-		v[0] = FVector3(x1, z1, y1);
-		v[1] = FVector3(x2, z1, y2);
-		v[2] = FVector3(x1, z2, y1);
-		v[3] = FVector3(x2, z2, y2);
+		if (doRoll || !offset.isZero())
+		{
+			mat.MakeIdentity();
+
+			if (!offset.isZero())
+				HandleSpriteOffsets(&mat, &HWAngles, &offset, false);
+			
+			if (doRoll)
+			{
+				// Compute center of sprite
+				float angleRad = (FAngle::fromDeg(270.) - HWAngles.Yaw).Radians();
+				float rollDegrees = Angles.Roll.Degrees();
+
+				mat.Translate(center.X, center.Z, center.Y);
+				mat.Rotate(cos(angleRad), 0, sin(angleRad), rollDegrees);
+				mat.Translate(-center.X, -center.Z, -center.Y);
+			}
+
+			v[0] = mat * FVector3(x1, z1, y1);
+			v[1] = mat * FVector3(x2, z1, y2);
+			v[2] = mat * FVector3(x1, z2, y1);
+			v[3] = mat * FVector3(x2, z2, y2);
+			
+		}
+		else
+		{
+			v[0] = FVector3(x1, z1, y1);
+			v[1] = FVector3(x2, z1, y2);
+			v[2] = FVector3(x1, z2, y1);
+			v[3] = FVector3(x2, z2, y2);
+		}
+		
 	}
 	return false;
 }
@@ -1252,7 +1279,6 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	{
 		lightlist = nullptr;
 	}
-
 	PutSprite(di, hw_styleflags != STYLEHW_Solid);
 	rendered_sprites++;
 }

--- a/src/rendering/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.cpp
@@ -1046,7 +1046,7 @@ namespace swrenderer
 		// The X offsetting (SpriteOffset.X) is performed in r_sprite.cpp, in RenderSprite::Project().
 		sprite.pos = thing->InterpolatedPosition(Thread->Viewport->viewpoint.TicFrac);
 		sprite.pos += thing->WorldOffset;
-		sprite.pos.Z += thing->GetBobOffset(Thread->Viewport->viewpoint.TicFrac) - thing->SpriteOffset.Y;
+		sprite.pos.Z += thing->GetBobOffset(Thread->Viewport->viewpoint.TicFrac) + thing->GetSpriteOffset(true);
 		sprite.spritenum = thing->sprite;
 		sprite.tex = nullptr;
 		sprite.voxel = nullptr;

--- a/src/rendering/swrenderer/things/r_sprite.cpp
+++ b/src/rendering/swrenderer/things/r_sprite.cpp
@@ -81,7 +81,7 @@ namespace swrenderer
 		const double thingxscalemul = spriteScale.X / tex->GetScale().X;
 
 		// Calculate billboard line for the sprite
-		double SpriteOffX = (thing) ? thing->SpriteOffset.X : 0.;
+		double SpriteOffX = (thing) ? -thing->GetSpriteOffset(false) : 0.;
 		DVector2 dir = { viewport->viewpoint.Sin, -viewport->viewpoint.Cos };
 		DVector2 trs = pos.XY() - viewport->viewpoint.Pos.XY();
 		trs = { trs.X + SpriteOffX * dir.X, trs.Y + SpriteOffX * dir.Y };

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -381,6 +381,8 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(RF2, ONLYVISIBLEINMIRRORS, AActor, renderflags2),
 	DEFINE_FLAG(RF2, BILLBOARDFACECAMERA, AActor, renderflags2),
 	DEFINE_FLAG(RF2, BILLBOARDNOFACECAMERA, AActor, renderflags2),
+	DEFINE_FLAG(RF2, FLIPSPRITEOFFSETX, AActor, renderflags2),
+	DEFINE_FLAG(RF2, FLIPSPRITEOFFSETY, AActor, renderflags2),
 
 	// Bounce flags
 	DEFINE_FLAG2(BOUNCE_Walls, BOUNCEONWALLS, AActor, BounceFlags),

--- a/wadsrc/static/zscript/visualthinker.zs
+++ b/wadsrc/static/zscript/visualthinker.zs
@@ -12,7 +12,9 @@ Class VisualThinker : Thinker native
 	native TranslationID	Translation;
 	native uint16			Flags;
 	native int16			LightLevel;
-	native bool				bXFlip,
+	native bool				bFlipOffsetX,
+							bFlipOffsetY,
+							bXFlip,
 							bYFlip,
 							bDontInterpolate,
 							bAddLightLevel;


### PR DESCRIPTION
- [x] Added roll support for Y billboarding
- [x] Fixed a bunch of broken checks that prevented Y billboarding from working properly
- [x] Y billboarding takes precedence over sprite facing
- [x] Optimized ROLLCENTER: now combines the sprite's embedded offsets with SpriteOffset's instead of doing wasteful transforms before/after rotations
- [x] Greatly cleaned up a bunch of cruft
- [x] Add ability to flip (Sprite)Offset direction with a flag