### PR TITLE
Exposed FindStateByString() to ZScript.

### DIFF
--- a/src/p_states.cpp
+++ b/src/p_states.cpp
@@ -387,7 +387,7 @@ FState *FStateLabelStorage::GetState(int pos, PClassActor *cls, bool exact)
 
 //==========================================================================
 //
-// State label conversion function for scripts
+// State label conversion functions for scripts
 //
 //==========================================================================
 
@@ -395,7 +395,7 @@ DEFINE_ACTION_FUNCTION(AActor, FindState)
 {
 	PARAM_SELF_PROLOGUE(AActor);
 	PARAM_INT(newstate);
-	PARAM_BOOL(exact)
+	PARAM_BOOL(exact);
 	ACTION_RETURN_STATE(StateLabels.GetState(newstate, self->GetClass(), exact));
 }
 
@@ -405,6 +405,15 @@ DEFINE_ACTION_FUNCTION(AActor, ResolveState)
 	PARAM_ACTION_PROLOGUE(AActor);
 	PARAM_STATE_ACTION(newstate);
 	ACTION_RETURN_STATE(newstate);
+}
+
+// find state by string instead of label
+DEFINE_ACTION_FUNCTION(AActor, FindStateByString)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_STRING(newstate);
+	PARAM_BOOL(exact);
+	ACTION_RETURN_STATE(self->GetClass()->FindStateByString(newstate.GetChars(), exact));
 }
 
 //==========================================================================

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -798,6 +798,7 @@ class Actor : Thinker native
 	native bool CheckMissileRange();
 	native bool SetState(state st, bool nofunction = false);
 	clearscope native state FindState(statelabel st, bool exact = false) const;
+	clearscope native state FindStateByString(string st, bool exact = false) const;
 	bool SetStateLabel(statelabel st, bool nofunction = false) { return SetState(FindState(st), nofunction); }
 	native action state ResolveState(statelabel st);	// this one, unlike FindState, is context aware.
 	native void LinkToWorld(LinkContext ctx = null);


### PR DESCRIPTION
This allows for using ZScript code to jump to different versions of states without using If/Else blocks or Switch cases. [For example, this state jump can now be shortened to just a String.Format().](https://github.com/inkoalawetrust/Smart-Marines/blob/ae71147158abfcd04564b338f329b7ee5878157f/ZScript/Marine/Marine_Deaths.zsc#L129-L148)

[findstatebystring example.zip](https://github.com/ZDoom/gzdoom/files/14056563/findstatebystring.example.zip)
