### PR TITLE
Made the damage of polyobjects customizable.

### DIFF
--- a/src/maploader/maploader.h
+++ b/src/maploader/maploader.h
@@ -152,7 +152,7 @@ private:
 	// Polyobjects
 	void InitSideLists();
 	void IterFindPolySides(FPolyObj *po, side_t *side);
-	void SpawnPolyobj(int index, int tag, int type);
+	void SpawnPolyobj(int index, int tag, int type, int damage);
 	void TranslateToStartSpot(int tag, const DVector2 &origin);
 	void InitPolyBlockMap(void);
 

--- a/src/maploader/polyobjects.cpp
+++ b/src/maploader/polyobjects.cpp
@@ -148,7 +148,22 @@ static int posicmp(const void *a, const void *b)
 	return (*(const side_t **)a)->linedef->args[1] - (*(const side_t **)b)->linedef->args[1];
 }
 
-void MapLoader::SpawnPolyobj (int index, int tag, int type)
+int SetPolyobjDamage(int type, int damage)
+{
+	int dam;
+	if (type != SMT_PolySpawn)
+	{
+		if (damage == 1)
+			dam = 3;
+		else if (damage > 1)
+			dam = TELEFRAG_DAMAGE;
+		else if (damage < 0)
+			dam = abs(damage);
+	}
+	return (type != SMT_PolySpawn) ? dam : 0;
+}
+
+void MapLoader::SpawnPolyobj (int index, int tag, int type, int damage)
 {
 	unsigned int ii;
 	int i;
@@ -181,8 +196,9 @@ void MapLoader::SpawnPolyobj (int index, int tag, int type)
 				sd->linedef->args[0] = 0;
 				IterFindPolySides(&Level->Polyobjects[index], sd);
 				po->MirrorNum = sd->linedef->args[1];
-				po->crush = (type != SMT_PolySpawn) ? 3 : 0;
+				po->crush = SetPolyobjDamage(type,damage);
 				po->bHurtOnTouch = (type == SMT_PolySpawnHurt);
+
 				po->tag = tag;
 				po->seqType = sd->linedef->args[2];
 				if (po->seqType < 0 || po->seqType > (MAX_SNDSEQS - 1))
@@ -222,7 +238,7 @@ void MapLoader::SpawnPolyobj (int index, int tag, int type)
 		qsort(&po->Sidedefs[0], po->Sidedefs.Size(), sizeof(po->Sidedefs[0]), posicmp);
 		if (po->Sidedefs.Size() > 0)
 		{
-			po->crush = (type != SMT_PolySpawn) ? 3 : 0;
+			po->crush = SetPolyobjDamage(type,damage);
 			po->bHurtOnTouch = (type == SMT_PolySpawnHurt);
 			po->tag = tag;
 			po->seqType = po->Sidedefs[0]->linedef->args[3];
@@ -359,13 +375,13 @@ void MapLoader::PO_Init (void)
 	// Find the startSpot points, and spawn each polyobj
 	for (int i=polythings.Size()-1; i >= 0; i--)
 	{
-		// 9301 (3001) = no crush, 9302 (3002) = crushing, 9303 = hurting touch
+		// 9301 (3001) = no crush, 9302 (3002) = crushing, 9303 = hurting touch, Health = crusher/hurter damage
 		int type = polythings[i]->info->Special;
 		if (type >= SMT_PolySpawn && type <= SMT_PolySpawnHurt)
 		{ 
 			// Polyobj StartSpot Pt.
 			Level->Polyobjects[polyIndex].StartSpot.pos = polythings[i]->pos.XY();
-			SpawnPolyobj(polyIndex, polythings[i]->angle, type);
+			SpawnPolyobj(polyIndex, polythings[i]->angle, type, polythings[i]->Health);
 			polyIndex++;
 		} 
 	}


### PR DESCRIPTION
The damage done by polyobjects can now be changed by altering the health value of the start spots.

A health of 1 (Default) is the default damage of 3, anything above 1 is instant death, and negative health values are the exact damage the polyobject does with every collision with an actor.