### PR TITLE
Added AutomapOffsets property and fixed the automap not accounting for SpriteRotation.

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -2952,7 +2952,8 @@ void DAutomap::drawThings ()
 			if (am_cheat > 0 || !(t->flags6 & MF6_NOTONAUTOMAP)
 				|| (am_thingrenderstyles && !(t->renderflags & RF_INVISIBLE) && !(t->flags6 & MF6_NOTONAUTOMAP)))
 			{
-				DVector3 pos = t->InterpolatedPosition(r_viewpoint.TicFrac) + t->Level->Displacements.getOffset(sec.PortalGroup, MapPortalGroup);
+				DVector3 fracPos = t->InterpolatedPosition(r_viewpoint.TicFrac);
+				FVector2 pos = FVector2(float(fracPos.X),float(fracPos.Y)) + FVector2(t->Level->Displacements.getOffset(sec.PortalGroup, MapPortalGroup)) + FVector2(t->AutomapOffsets);
 				p.x = pos.X;
 				p.y = pos.Y;
 
@@ -2969,7 +2970,7 @@ void DAutomap::drawThings ()
 						const size_t spriteIndex = sprite.spriteframes + (show > 1 ? t->frame : 0);
 
 						frame = &SpriteFrames[spriteIndex];
-						DAngle angle = DAngle::fromDeg(270. + 22.5) - t->InterpolatedAngles(r_viewpoint.TicFrac).Yaw - t->SpriteRotation; 
+						DAngle angle = DAngle::fromDeg(270.) - t->InterpolatedAngles(r_viewpoint.TicFrac).Yaw - t->SpriteRotation; 
 						if (frame->Texture[0] != frame->Texture[1]) angle += DAngle::fromDeg(180. / 16);
 						if (am_rotate == 1 || (am_rotate == 2 && viewactive))
 						{

--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -2962,14 +2962,14 @@ void DAutomap::drawThings ()
 					spriteframe_t *frame;
 					int rotation = 0;
 
-					// try all modes backwards until a valid texture has been found.	
+					// try all modes backwards until a valid texture has been found.
 					for(int show = am_showthingsprites; show > 0 && texture == nullptr; show--)
 					{
 						const spritedef_t& sprite = sprites[t->sprite];
 						const size_t spriteIndex = sprite.spriteframes + (show > 1 ? t->frame : 0);
 
 						frame = &SpriteFrames[spriteIndex];
-						DAngle angle = DAngle::fromDeg(270. + 22.5) - t->InterpolatedAngles(r_viewpoint.TicFrac).Yaw;
+						DAngle angle = DAngle::fromDeg(270. + 22.5) - t->InterpolatedAngles(r_viewpoint.TicFrac).Yaw - t->SpriteRotation; 
 						if (frame->Texture[0] != frame->Texture[1]) angle += DAngle::fromDeg(180. / 16);
 						if (am_rotate == 1 || (am_rotate == 2 && viewactive))
 						{

--- a/src/common/engine/namedef.h
+++ b/src/common/engine/namedef.h
@@ -80,13 +80,15 @@ xx(__decorate_internal_float__)
 // Per-actor sound channels (for deprecated PlaySoundEx function) Do not separate this block!!!
 xx(Auto)
 xx(Weapon)
-xx(BobPivot3D)
 xx(Voice)
 xx(Item)
 xx(Body)
 xx(SoundSlot5)
 xx(SoundSlot6)
 xx(SoundSlot7)
+
+// Actor properties
+xx(BobPivot3D)
 
 xx(LevelLocals)
 xx(Level)

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1103,6 +1103,7 @@ public:
 
 	DAngle			SpriteAngle;
 	DAngle			SpriteRotation;
+	DVector2		AutomapOffsets;		// Offset the actors' sprite view on the automap by these coordinates.
 	DRotator		Angles;
 	DRotator		ViewAngles;			// Angle offsets for cameras
 	TObjPtr<DViewPosition*> ViewPos;			// Position offsets for cameras

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -2141,6 +2141,7 @@ DEFINE_FIELD_NAMED(AActor, ViewAngles.Roll, viewroll)
 DEFINE_FIELD(AActor, LightLevel)
 DEFINE_FIELD(AActor, ShadowAimFactor)
 DEFINE_FIELD(AActor, ShadowPenaltyFactor)
+DEFINE_FIELD(AActor, AutomapOffsets)
 
 DEFINE_FIELD_X(FCheckPosition, FCheckPosition, thing);
 DEFINE_FIELD_X(FCheckPosition, FCheckPosition, pos);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -260,6 +260,7 @@ class Actor : Thinker native
 	native readonly int SpawnTime;
 	private native int InventoryID;	// internal counter.
 	native uint freezetics;
+	native Vector2 AutomapOffsets;
 
 	meta String Obituary;		// Player was killed by this actor
 	meta String HitObituary;		// Player was killed by this actor in melee
@@ -364,6 +365,7 @@ class Actor : Thinker native
 	property LightLevel: LightLevel;
 	property ShadowAimFactor: ShadowAimFactor;
 	property ShadowPenaltyFactor: ShadowPenaltyFactor;
+	property AutomapOffsets : AutomapOffsets;
 	
 	// need some definition work first
 	//FRenderStyle RenderStyle;
@@ -443,6 +445,7 @@ class Actor : Thinker native
 		SelfDamageFactor 1;
 		ShadowAimFactor 1;
 		ShadowPenaltyFactor 1;
+		AutomapOffsets (0,0);
 		StealthAlpha 0;
 		WoundHealth 6;
 		GibHealth int.min;


### PR DESCRIPTION
This PR fixes the automap not accounting for actors' SpriteRotation property. Removes a hardcoded angle offset of + 22.5 degrees. And I also added an AutomapOffsets Vector2 property, which allows actors to visually offset their position in the automap when things are set to be rendered as sprites. Which for example can make actors made of different components in the same XY space to not appear sunken into each other.

I also changed the sprite position code in the automap to use FVector2, since I don't think it needs the additional precision (And member variable) of the DVector3 it used before.

I also wanted to make AutomapOffsets into an FVector2, but it just prints ZScript errors that the property isn't a non-constant parameter in the line in Actor.zs where it's set to (0,0) by default.