### PR TITLE
Fix `..` to root folder in relative include

### DIFF
--- a/src/common/scripting/frontend/zcc_parser.cpp
+++ b/src/common/scripting/frontend/zcc_parser.cpp
@@ -71,9 +71,16 @@ static FString ResolveIncludePath(const FString &path,const FString &lumpname){
 			{
 				relativePath = relativePath.Mid(3);
 				auto slash_index = fullPath.LastIndexOf("/");
-				if (slash_index != -1) {
+				if (slash_index != -1)
+				{
 					fullPath = fullPath.Mid(0, slash_index);
-				} else {
+				}
+				else if (fullPath.IsNotEmpty())
+				{
+					fullPath = "";
+				}
+				else
+				{
 					pathOk = false;
 					break;
 				}


### PR DESCRIPTION
using `..` to go back to the root folder was previously unaccounted for