### PR TITLE
Fixed missing lines in listmenuitems

### DIFF
--- a/wadsrc/static/zscript/engine/ui/menu/listmenuitems.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/listmenuitems.zs
@@ -294,8 +294,12 @@ class ListMenuItemTextItem : ListMenuItemSelectable
 	override void Draw(bool selected, ListMenuDescriptor desc)
 	{
 		let font = menuDelegate.PickFont(mFont);
-		if (desc.mCenterText) x -= font.StringWidth(mText) / 2;
-		DrawText(desc, font, selected ? mColorSelected : mColor, mXpos, mYpos, mText);
+		double x = mXpos;
+		if (desc.mCenterText) 
+		{
+			x -= font.StringWidth(mText) / 2;
+		}
+		DrawText(desc, font, selected ? mColorSelected : mColor, x, mYpos, mText);
 	}
 
 	override int GetWidth()


### PR DESCRIPTION
Third time's the charm. Apologies for not testing it properly beforehand. I've checked with a fresh built this time, this definitely makes the CenterText MENUDEF flag work.