### PR TITLE
Swap the default binding for the "Start" and "Select" buttons on game…

### DIFF
--- a/wadsrc/static/engine/commonbinds.txt
+++ b/wadsrc/static/engine/commonbinds.txt
@@ -61,8 +61,8 @@ dpadleft invprev
 dpadright invnext
 dpaddown invuse
 dpadup togglemap
-pad_start pause
-pad_back menu_main
+pad_start menu_main
+pad_back pause
 lthumb crouch
 
 


### PR DESCRIPTION
…pads. Using "Start" to access the main menu is a more commonly-accepted standard set by most released games out there - players would tend to reach for that button first to access the menu.