### PR TITLE
Fix the default controller axes on Linux. The third axis is actually …

### DIFF
--- a/src/common/platform/posix/sdl/i_joystick.cpp
+++ b/src/common/platform/posix/sdl/i_joystick.cpp
@@ -268,7 +268,9 @@ protected:
 
 	friend class SDLInputJoystickManager;
 };
-const EJoyAxis SDLInputJoystick::DefaultAxes[5] = {JOYAXIS_Side, JOYAXIS_Forward, JOYAXIS_Pitch, JOYAXIS_Yaw, JOYAXIS_Up};
+
+// [Nash 4 Feb 2024] seems like on Linux, the third axis is actually the Left Trigger, resulting in the player uncontrollably looking upwards.
+const EJoyAxis SDLInputJoystick::DefaultAxes[5] = {JOYAXIS_Side, JOYAXIS_Forward, JOYAXIS_None, JOYAXIS_Yaw, JOYAXIS_Pitch};
 
 class SDLInputJoystickManager
 {


### PR DESCRIPTION
…the Left Trigger, which causes the player to uncontrollably look upwards. Fixed by mapping said axis to nothing.