### PR TITLE
GCC-13 support, when precompiled headers are off

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -44,7 +44,7 @@ jobs:
 
         - name: Linux GCC 12
           os: ubuntu-22.04
-          extra_options: -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+          extra_options: -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12
           deps_cmdline: sudo apt update && sudo apt install libsdl2-dev libvpx-dev libgtk-3-dev libwebp-dev
           build_type: MinSizeRel
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -44,7 +44,7 @@ jobs:
 
         - name: Linux GCC 12
           os: ubuntu-22.04
-          extra_options: -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12
+          extra_options: -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
           deps_cmdline: sudo apt update && sudo apt install libsdl2-dev libvpx-dev libgtk-3-dev libwebp-dev
           build_type: MinSizeRel
 

--- a/src/common/engine/palettecontainer.cpp
+++ b/src/common/engine/palettecontainer.cpp
@@ -32,6 +32,7 @@
 **
 */
 
+#include <cmath>
 #include "palutil.h"
 #include "sc_man.h"
 #include "m_crc32.h"

--- a/src/common/objects/autosegs.cpp
+++ b/src/common/objects/autosegs.cpp
@@ -42,6 +42,7 @@
 ** compile with something other than Visual C++ or GCC.
 */
 
+#include <cassert>
 #include "autosegs.h"
 
 #ifdef _WIN32

--- a/src/common/objects/autosegs.h
+++ b/src/common/objects/autosegs.h
@@ -36,6 +36,7 @@
 #define AUTOSEGS_H
 
 #include <type_traits>
+#include <cstdint>
 
 #if defined(__clang__)
 #if defined(__has_feature) && __has_feature(address_sanitizer)

--- a/src/common/textures/bitmap.h
+++ b/src/common/textures/bitmap.h
@@ -36,6 +36,7 @@
 #ifndef __BITMAP_H__
 #define __BITMAP_H__
 
+#include <cstring>
 #include "palentry.h"
 
 struct FCopyInfo;

--- a/src/common/thirdparty/md5.h
+++ b/src/common/thirdparty/md5.h
@@ -18,6 +18,8 @@
 #ifndef MD5_H
 #define MD5_H
 
+#include <cstdint>
+
 struct MD5Context
 {
 	MD5Context() { Init(); }

--- a/src/common/utility/engineerrors.cpp
+++ b/src/common/utility/engineerrors.cpp
@@ -35,8 +35,9 @@
 
 bool gameisdead;
 
-#ifdef _WIN32
 #include <cstdarg>
+
+#ifdef _WIN32
 #include <windows.h>
 #include "zstring.h"
 void I_DebugPrint(const char *cp)

--- a/src/common/utility/palette.cpp
+++ b/src/common/utility/palette.cpp
@@ -33,6 +33,8 @@
 */
 
 #include <algorithm>
+#include <cfloat>
+#include <cmath>
 #include "palutil.h"
 #include "palentry.h"
 #include "sc_man.h"

--- a/src/common/utility/writezip.cpp
+++ b/src/common/utility/writezip.cpp
@@ -39,6 +39,7 @@
 #include "files.h"
 #include "m_swap.h"
 #include "w_zip.h"
+#include "fs_decompress.h"
 
 using FileSys::FCompressedBuffer;
 

--- a/src/common/widgets/netstartwindow.cpp
+++ b/src/common/widgets/netstartwindow.cpp
@@ -2,6 +2,7 @@
 #include "netstartwindow.h"
 #include "version.h"
 #include "engineerrors.h"
+#include "gstrings.h"
 #include <zwidget/core/timer.h>
 #include <zwidget/widgets/textlabel/textlabel.h>
 #include <zwidget/widgets/pushbutton/pushbutton.h>

--- a/src/launcher/settingspage.h
+++ b/src/launcher/settingspage.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <zwidget/core/widget.h>
+#include "gstrings.h"
 
 #define RENDER_BACKENDS
 


### PR DESCRIPTION
While packaging gzdoom for my Gentoo overlay, I ran into this weird build failure due to Gentoo's package manager passing "-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON" to CMake unconditionally.

Disabling precompiled headers makes GCC-13 do its usual header-related breakage: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Once GitHub Actions gets an Ubuntu-24.04 image, in 2-3 months, we'll be able to get GCC-13 and test this scenario in CI.