### PR TITLE
Added unique network ID system for Objects

### DIFF
--- a/src/common/objects/dobject.h
+++ b/src/common/objects/dobject.h
@@ -351,6 +351,17 @@ protected:
 		friend T* Create(Args&&... args);
 
 	friend class JitCompiler;
+
+private:
+	// This is intentionally left unserialized.
+	uint32_t _networkID;
+
+public:
+	inline bool IsNetworked() const { return (ObjectFlags & OF_Networked); }
+	inline uint32_t GetNetworkID() const { return _networkID; }
+	void SetNetworkID(const uint32_t id);
+	void ClearNetworkID();
+	virtual void EnableNetworking(const bool enable);
 };
 
 // This is the only method aside from calling CreateNew that should be used for creating DObjects

--- a/src/common/objects/dobjgc.h
+++ b/src/common/objects/dobjgc.h
@@ -26,6 +26,7 @@ enum EObjectFlags
 	OF_Transient		= 1 << 11,		// Object should not be archived (references to it will be nulled on disk)
 	OF_Spawned			= 1 << 12,      // Thinker was spawned at all (some thinkers get deleted before spawning)
 	OF_Released			= 1 << 13,		// Object was released from the GC system and should not be processed by GC function
+	OF_Networked		= 1 << 14,		// Object has a unique network identifier that makes it synchronizable between all clients.
 };
 
 template<class T> class TObjPtr;

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3100,6 +3100,8 @@ static int FileSystemPrintf(FSMessageLevel level, const char* fmt, ...)
 
 static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allwads, std::vector<std::string>& pwads)
 {
+	NetworkEntityManager::InitializeNetworkEntities();
+
 	if (!restart)
 	{
 		V_InitScreenSize();

--- a/src/d_net.h
+++ b/src/d_net.h
@@ -95,6 +95,29 @@ extern	int 			nodeforplayer[MAXPLAYERS];
 extern	ticcmd_t		netcmds[MAXPLAYERS][BACKUPTICS];
 extern	int 			ticdup;
 
+class player_t;
+class DObject;
+
+class NetworkEntityManager
+{
+private:
+	inline static TArray<DObject*> s_netEntities = {};
+	inline static TArray<uint32_t> s_openNetIDs = {};
+
+public:
+	NetworkEntityManager() = delete;
+
+	inline static uint32_t WorldNetID = 0u;
+	inline static uint32_t ClientNetIDStart = 1u;
+	inline static uint32_t NetIDStart = MAXPLAYERS + 1u;
+
+	static void InitializeNetworkEntities();
+	static void SetClientNetworkEntity(player_t* const client);
+	static void AddNetworkEntity(DObject* const ent);
+	static void RemoveNetworkEntity(DObject* const ent);
+	static DObject* GetNetworkEntity(const uint32_t id);
+};
+
 // [RH]
 // New generic packet structure:
 //

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1424,6 +1424,7 @@ void FLevelLocals::PlayerReborn (int player)
 	p->oldbuttons = ~0, p->attackdown = true; p->usedown = true;	// don't do anything immediately
 	p->original_oldbuttons = ~0;
 	p->playerstate = PST_LIVE;
+	NetworkEntityManager::SetClientNetworkEntity(p);
 
 	if (gamestate != GS_TITLELEVEL)
 	{

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -62,6 +62,7 @@
 #include "fragglescript/t_script.h"
 #include "s_music.h"
 #include "model.h"
+#include "d_net.h"
 
 EXTERN_CVAR(Bool, save_formatted)
 
@@ -653,6 +654,15 @@ void FLevelLocals::SerializePlayers(FSerializer &arc, bool skipload)
 				ReadMultiplePlayers(arc, numPlayers, numPlayersNow, skipload);
 			}
 			arc.EndArray();
+
+			if (!skipload)
+			{
+				for (unsigned int i = 0u; i < MAXPLAYERS; ++i)
+				{
+					if (PlayerInGame(i) && Players[i]->mo != nullptr)
+						NetworkEntityManager::SetClientNetworkEntity(Players[i]);
+				}
+			}
 		}
 		if (!skipload && numPlayersNow > numPlayers)
 		{

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -793,6 +793,7 @@ public:
 	virtual void PostSerialize() override;
 	virtual void PostBeginPlay() override;		// Called immediately before the actor's first tick
 	virtual void Tick() override;
+	void EnableNetworking(const bool enable) override;
 
 	static AActor *StaticSpawn (FLevelLocals *Level, PClassActor *type, const DVector3 &pos, replace_t allowreplacement, bool SpawningMapThing = false);
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -100,6 +100,7 @@
 #include "a_dynlight.h"
 #include "fragglescript/t_fs.h"
 #include "shadowinlines.h"
+#include "d_net.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -177,6 +178,23 @@ IMPLEMENT_POINTERS_START(AActor)
 	IMPLEMENT_POINTER(modelData)
 	IMPLEMENT_POINTER(boneComponentData)
 IMPLEMENT_POINTERS_END
+
+//==========================================================================
+//
+// Make sure Actors can never have their networking disabled.
+//
+//==========================================================================
+
+void AActor::EnableNetworking(const bool enable)
+{
+	if (!enable)
+	{
+		ThrowAbortException(X_OTHER, "Cannot disable networking on Actors. Consider a Thinker instead.");
+		return;
+	}
+
+	Super::EnableNetworking(true);
+}
 
 //==========================================================================
 //
@@ -4793,6 +4811,7 @@ AActor *AActor::StaticSpawn(FLevelLocals *Level, PClassActor *type, const DVecto
 	AActor *actor;
 
 	actor = static_cast<AActor *>(Level->CreateThinker(type));
+	actor->EnableNetworking(true);
 
 	ConstructActor(actor, pos, SpawningMapThing);
 	return actor;

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -137,6 +137,9 @@ extend class Object
 	native static void MarkSound(Sound snd);
 	native static uint BAM(double angle);
 	native static void SetMusicVolume(float vol);
+	native clearscope static Object GetNetworkEntity(uint id);
+	native play void EnableNetworking(bool enable);
+	native clearscope uint GetNetworkID() const;
 }
 
 class Thinker : Object native play


### PR DESCRIPTION
This assigns a unique ID to any object set to be networkable. What this means for GZDoom's current networking is that they can be sent over the net by ID and then fetched on the other side in cases where code needs to modify a specific non-Inventory Actor through e.g. netevents (this can also technically obsolete the `InventoryID` field as its network ID can be used instead). It has the current structure:
* ID 0 is reserved for a potential world object in the future. This means any object with an ID of 0 is invalid.
* IDs 1-MAXPLAYERS are reserved for the clients' Actors. This isn't too relevant right now but in the future can be used as a way to quickly iterate through players and assign them slots (meaning the `players` array will likely become obsoleted, but this structure already has tons of issues with it that will need to be solved).
* Everything else is first come first serve. A system is set up to reuse any free IDs instead of allocating more space for new ones.

At the moment these are stored in an array with their ID being the index. This isn't totally necessary but should the networking ever be reworked to use a proper client/server system, this will be necessary for knowing what entities to track the deltas of and send over in the world snapshot (it also allows for quick access in the current system). As such, rules are based with this in mind. Actors are always networked and this cannot be disabled. For Thinkers/Objects, these are more likely to be server-side only so they're currently opt-in rather than opt-out and can only be made networkable through the play scope. The API was built with all of this in mind to allow minimal updating should this need to be changed for a proper networked system. Note that most of this API is intentionally kept hidden in the internals (ZScript should have little to no control over this realistically, but the function to enable networking is needed since there's no way to define an Object's defaults from ZScript at the moment).

This does mean that's it's now fully impossible to have a "client-side" Actor since it will mess with the networking IDs, but this was never safe and in the future a proper renderable client-side Object should be used instead, similar to particles.