### PR TITLE
Stopgap fix for GetEntryReader EMFILE

### DIFF
--- a/src/common/filesystem/source/files.cpp
+++ b/src/common/filesystem/source/files.cpp
@@ -38,7 +38,10 @@
 #include <algorithm>
 #include <assert.h>
 #include <string.h>
+#include "printf.h"
 #include "files_internal.h"
+
+#include <cerrno>
 
 namespace FileSys {
 	
@@ -53,7 +56,9 @@ FILE *myfopen(const char *filename, const char *flags)
 #else
 	auto widename = toWide(filename);
 	auto wideflags = toWide(flags);
-	return _wfopen(widename.c_str(), wideflags.c_str());
+	FILE * f = _wfopen(widename.c_str(), wideflags.c_str());
+	if(!f && errno == EMFILE) I_FatalError("Too many file descriptors open");
+	return f;
 #endif
 }
 

--- a/src/common/platform/win32/i_main.cpp
+++ b/src/common/platform/win32/i_main.cpp
@@ -41,6 +41,8 @@
 #include <commctrl.h>
 #include <richedit.h>
 
+#include <cstdio>
+
 #include <processenv.h>
 #include <shellapi.h>
 #include <VersionHelpers.h>
@@ -147,6 +149,8 @@ int DoMain (HINSTANCE hInstance)
 	RECT cRect;
 	TIMECAPS tc;
 	DEVMODE displaysettings;
+
+	_setmaxstdio(8192);
 
 	// Do not use the multibyte __argv here because we want UTF-8 arguments
 	// and those can only be done by converting the Unicode variants.

--- a/src/playsim/fragglescript/t_prepro.cpp
+++ b/src/playsim/fragglescript/t_prepro.cpp
@@ -418,7 +418,8 @@ void DFsScript::ParseInclude(FLevelLocals *Level, char *lumpname)
     }
 	
 	int lumplen=fileSystem.FileLength(lumpnum);
-	TArray<char> lump(lumplen + 10);
+	TArray<char> lump;
+	lump.Resize(lumplen + 10);
 	fileSystem.ReadFile(lumpnum,lump.Data());
 	
 	lump[lumplen]=0;


### PR DESCRIPTION
Doesn't address the root of the issue, but makes it less likely to happen by raising the max file handle limit from 512 to 8192