### PR TITLE
Fixes for SCALEDNOLERP

### DIFF
--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -458,8 +458,7 @@ public:
 	bool Resurrect();
 
 	// Scaled angle adjustment info. Not for direct manipulation.
-	DRotator angleTargets;
-	DRotator angleAppliedAmounts;
+	DRotator angleOffsetTargets;
 };
 
 // Bookkeeping on players - state.

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3495,22 +3495,16 @@ void AActor::SetPitch(DAngle p, int fflags)
 	{
 		if (player != nullptr)
 		{
-			const bool mustLerp = !P_NoInterpolation(player, this);
-
-			if ((fflags & SPF_INTERPOLATE) || ((fflags & SPF_SCALEDNOLERP) && mustLerp))
+			if (fflags & SPF_SCALEDNOLERP)
 			{
-				Angles.Pitch = p;
-				player->cheats |= CF_INTERPVIEW;
-			}
-			else if ((fflags & SPF_SCALEDNOLERP) && !mustLerp)
-			{
-				player->angleTargets.Pitch = deltaangle(Angles.Pitch, p);
-				player->angleAppliedAmounts.Pitch = nullAngle;
+				player->angleOffsetTargets.Pitch = deltaangle(Angles.Pitch, p);
 				player->cheats |= CF_SCALEDNOLERP;
 			}
 			else
 			{
 				Angles.Pitch = p;
+				if (fflags & SPF_INTERPOLATE)
+					player->cheats |= CF_INTERPVIEW;
 			}
 		}
 		else
@@ -3527,22 +3521,16 @@ void AActor::SetAngle(DAngle ang, int fflags)
 	{
 		if (player != nullptr)
 		{
-			const bool mustLerp = !P_NoInterpolation(player, this);
-
-			if ((fflags & SPF_INTERPOLATE) || ((fflags & SPF_SCALEDNOLERP) && mustLerp))
+			if (fflags & SPF_SCALEDNOLERP)
 			{
-				Angles.Yaw = ang;
-				player->cheats |= CF_INTERPVIEW;
-			}
-			else if ((fflags & SPF_SCALEDNOLERP) && !mustLerp)
-			{
-				player->angleTargets.Yaw = deltaangle(Angles.Yaw, ang);
-				player->angleAppliedAmounts.Yaw = nullAngle;
+				player->angleOffsetTargets.Yaw = deltaangle(Angles.Yaw, ang);
 				player->cheats |= CF_SCALEDNOLERP;
 			}
 			else
 			{
 				Angles.Yaw = ang;
+				if (fflags & SPF_INTERPOLATE)
+					player->cheats |= CF_INTERPVIEW;
 			}
 		}
 		else
@@ -3559,22 +3547,16 @@ void AActor::SetRoll(DAngle r, int fflags)
 	{
 		if (player != nullptr)
 		{
-			const bool mustLerp = !P_NoInterpolation(player, this);
-
-			if ((fflags & SPF_INTERPOLATE) || ((fflags & SPF_SCALEDNOLERP) && mustLerp))
+			if (fflags & SPF_SCALEDNOLERP)
 			{
-				Angles.Roll = r;
-				player->cheats |= CF_INTERPVIEW;
-			}
-			else if ((fflags & SPF_SCALEDNOLERP) && !mustLerp)
-			{
-				player->angleTargets.Roll = deltaangle(Angles.Roll, r);
-				player->angleAppliedAmounts.Roll = nullAngle;
+				player->angleOffsetTargets.Roll = deltaangle(Angles.Roll, r);
 				player->cheats |= CF_SCALEDNOLERP;
 			}
 			else
 			{
 				Angles.Roll = r;
+				if (fflags & SPF_INTERPOLATE)
+					player->cheats |= CF_INTERPVIEW;
 			}
 		}
 		else

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1239,6 +1239,17 @@ void P_PlayerThink (player_t *player)
 		I_Error ("No player %td start\n", player - players + 1);
 	}
 
+	for (unsigned int i = 0u; i < 3u; ++i)
+	{
+		if (fabs(player->angleOffsetTargets[i].Degrees()) >= EQUAL_EPSILON)
+		{
+			player->mo->Angles[i] += player->angleOffsetTargets[i];
+			player->mo->PrevAngles[i] = player->mo->Angles[i];
+		}
+
+		player->angleOffsetTargets[i] = nullAngle;
+	}
+
 	if (player->SubtitleCounter > 0)
 	{
 		player->SubtitleCounter--;


### PR DESCRIPTION
No longer relies on last input fraction to determine offset on frame (now uses TicFrac), making consistency much better. This also fixes other viewports being rendered breaking it as multiple calls to InputFrac happened in those frames giving small values (the main viewport was being rendered last). No longer modifies Actor angle in real-time, instead changing it on the next tick. Angle setting functions no longer use client-side info to determine branching (guaranteed desyncs happening with this).

As a side note, this _should_ now make it safe in multiplayer since the synchronizing of angles is forced within the playsim, but NoInterpolation is still disabled online. That will require further testing later to fix.