### PR TITLE
Added real-time client camera tracking for texture cams

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -500,6 +500,7 @@ enum ActorRenderFlag2
 	RF2_BILLBOARDNOFACECAMERA	= 0x0008,	// Sprite billboard face camera angle (override gl_billboard_faces_camera)
 	RF2_FLIPSPRITEOFFSETX		= 0x0010,
 	RF2_FLIPSPRITEOFFSETY		= 0x0020,
+	RF2_CAMFOLLOWSPLAYER		= 0x0040,	// Matches the cam's base position and angles to the main viewpoint.
 };
 
 // This translucency value produces the closest match to Heretic's TINTTAB.

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -383,6 +383,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(RF2, BILLBOARDNOFACECAMERA, AActor, renderflags2),
 	DEFINE_FLAG(RF2, FLIPSPRITEOFFSETX, AActor, renderflags2),
 	DEFINE_FLAG(RF2, FLIPSPRITEOFFSETY, AActor, renderflags2),
+	DEFINE_FLAG(RF2, CAMFOLLOWSPLAYER, AActor, renderflags2),
 
 	// Bounce flags
 	DEFINE_FLAG2(BOUNCE_Walls, BOUNCEONWALLS, AActor, BounceFlags),


### PR DESCRIPTION
In certain cases you want a camera that perfectly mimics the main client's view point, but right now that isn't possible thanks to cameras always interpolating. Even with abuse of `const` functions in GZDoom this can't be made perfect. This PR adds a flag, `+CAMFOLLOWSPLAYER`, to handle this directly for any camera Actors being drawn on the screen e.g. player mirrors, weapon scopes, etc. As a bonus, this also fixes the issue where the camera will appear to warp across the map when walking through a portal. This only affects the base angles/position so the view properties will still offset from it.

The following demos compare what it looks like in real-time vs what happens when you slow the game down to 0.05 timescale.

Current GZDoom (broken):

https://github.com/ZDoom/gzdoom/assets/59555366/3b296675-580a-484c-a237-f6ec0daf3178

With the fix implemented:

https://github.com/ZDoom/gzdoom/assets/59555366/19f465cf-47d6-4078-80fd-56f9eeccd970

Note that even with this fix implemented, this will still lag behind by a single frame, but that's a single _render_ frame vs an entire game tick, not to mention it now correctly takes into account anything modifying the player's view such as mouse input.
