### PR TITLE
Fixed view position forcing camera interpolation

### DIFF
--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -397,7 +397,7 @@ void	P_PlaySpawnSound(AActor *missile, AActor *spawner);
 void	P_AimCamera (AActor *t1, DVector3 &, DAngle &, sector_t *&sec, bool &unlinked);
 
 // [MC] Aiming for ViewPos
-void	P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &, sector_t *&sec, bool &unlinked, DViewPosition *VP, FRenderViewpoint *view);
+void	P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &, sector_t *&sec, bool &unlinked, FRenderViewpoint *view);
 
 
 // [RH] Means of death

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5626,7 +5626,7 @@ static ETraceStatus VPos_CheckPortal(FTraceResults &res, void *userdata)
 }
 
 // [MC] Used for ViewPos. Uses code borrowed from P_AimCamera.
-void P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &campos, sector_t *&CameraSector, bool &unlinked, DViewPosition *VP, FRenderViewpoint *view)
+void P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &campos, sector_t *&CameraSector, bool &unlinked, FRenderViewpoint *view)
 {
 	FTraceResults trace;
 	ViewPosPortal pc;
@@ -5642,7 +5642,6 @@ void P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &campos, sector_t *&Cam
 		campos = trace.HitPos - trace.HitVector * 1 / 256.;
 	
 
-	if (pc.counter > 2) view->noviewer = true;
 	CameraSector = trace.Sector;
 	unlinked = trace.unlinked;
 }


### PR DESCRIPTION
Fixed absolute view position not working. Camera Actor is no longer visible when using view offsets. Note that there's a swinging effect when using relative view offsets since they don't use the up-to-date player view angles. This will require a more extensive rework in the future of how positional offsets are calculated. It was disabled entirely for the chase cam since it was more jarring in third person.