### PR TITLE
Support negative fadestep for particles

### DIFF
--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -1691,7 +1691,8 @@ DEFINE_ACTION_FUNCTION(AActor, A_SpawnParticleEx)
 	PARAM_FLOAT	(rollacc)
 
 	startalpha = clamp(startalpha, 0., 1.);
-	if (fadestep > 0) fadestep = clamp(fadestep, 0., 1.);
+	fadestep = clamp(fadestep, -1.0, 1.0);
+
 	size = fabs(size);
 	if (lifetime != 0)
 	{

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -306,10 +306,9 @@ void P_ThinkParticles (FLevelLocals *Level)
 			continue;
 		}
 		
-		auto oldtrans = particle->alpha;
 		particle->alpha -= particle->fadestep;
 		particle->size += particle->sizestep;
-		if (particle->alpha <= 0 || oldtrans < particle->alpha || --particle->ttl <= 0 || (particle->size <= 0))
+		if (particle->alpha <= 0 || --particle->ttl <= 0 || (particle->size <= 0))
 		{ // The particle has expired, so free it
 			*particle = {};
 			if (prev)
@@ -375,7 +374,7 @@ void P_SpawnParticle(FLevelLocals *Level, const DVector3 &pos, const DVector3 &v
 		particle->Acc = FVector3(accel);
 		particle->color = ParticleColor(color);
 		particle->alpha = float(startalpha);
-		if (fadestep < 0) particle->fadestep = FADEFROMTTL(lifetime);
+		if (fadestep <= -1.0) particle->fadestep = FADEFROMTTL(lifetime);
 		else particle->fadestep = float(fadestep);
 		particle->ttl = lifetime;
 		particle->size = size;


### PR DESCRIPTION
Keeps `-1` fadestep working as described on ZDoom wiki, but anything more than `-1` and less than `0` will make the particle fade in.