### PR TITLE
Reworked view offsetting

### DIFF
--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -125,11 +125,11 @@ enum
 
 struct FQuakeJiggers
 {
-	DVector3 Intensity;
-	DVector3 RelIntensity;
-	DVector3 Offset;
-	DVector3 RelOffset;
-	double RollIntensity, RollWave;
+	DVector3 Intensity = {};
+	DVector3 RelIntensity = {};
+	DVector3 Offset = {};
+	DVector3 RelOffset = {};
+	double RollIntensity = 0.0, RollWave = 0.0;
 };
 
 class DEarthquake : public DThinker

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -770,7 +770,7 @@ public:
 			Flags = f;
 	}
 
-	bool isZero()
+	bool isZero() const
 	{
 		return Offset.isZero();
 	}

--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -393,11 +393,8 @@ bool	P_CheckMissileSpawn(AActor *missile, double maxdist);
 
 void	P_PlaySpawnSound(AActor *missile, AActor *spawner);
 
-// [RH] Position the chasecam
-void	P_AimCamera (AActor *t1, DVector3 &, DAngle &, sector_t *&sec, bool &unlinked);
-
-// [MC] Aiming for ViewPos
-void	P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &, sector_t *&sec, bool &unlinked, FRenderViewpoint *view);
+// [RH] Position the cam's view offsets.
+void	R_OffsetView(FRenderViewpoint& viewPoint, const DVector3& dir, const double distance);
 
 
 // [RH] Means of death

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -800,7 +800,7 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	// Some added checks if the camera actor is not supposed to be seen. It can happen that some portal setup has this actor in view in which case it may not be skipped here
 	if (viewmaster == camera && !vp.showviewer)
 	{
-		if (vp.noviewer || (viewmaster->player && viewmaster->player->crossingPortal)) return;
+		if (vp.bForceNoViewer || (viewmaster->player && viewmaster->player->crossingPortal)) return;
 		DVector3 vieworigin = viewmaster->Pos();
 		if (thruportal == 1) vieworigin += di->Level->Displacements.getOffset(viewmaster->Sector->PortalGroup, sector->PortalGroup);
 		if (fabs(vieworigin.X - vp.ActorPos.X) < 2 && fabs(vieworigin.Y - vp.ActorPos.Y) < 2) return;

--- a/src/rendering/r_utility.h
+++ b/src/rendering/r_utility.h
@@ -43,9 +43,8 @@ struct FRenderViewpoint
 	
 	int				extralight;		// extralight to be added to this viewpoint
 	bool			showviewer;		// show the camera actor?
-	bool			NoPortalPath;	// Disable portal interpolation path for actor viewpos.
-	bool			noviewer;		// Force camera sprite off for first person.
-	void SetViewAngle(const FViewWindow &viewwindow);
+	bool			bForceNoViewer; // Never show the camera Actor.
+	void SetViewAngle(const FViewWindow& viewWindow);
 
 };
 
@@ -118,7 +117,7 @@ void R_ClearInterpolationPath();
 void R_AddInterpolationPoint(const DVector3a &vec);
 void R_SetViewSize (int blocks);
 void R_SetFOV (FRenderViewpoint &viewpoint, DAngle fov);
-void R_SetupFrame (FRenderViewpoint &viewpoint, FViewWindow &viewwindow, AActor * camera);
+void R_SetupFrame(FRenderViewpoint& viewPoint, const FViewWindow& viewWindow, AActor* const camera);
 void R_SetViewAngle (FRenderViewpoint &viewpoint, const FViewWindow &viewwindow);
 
 // Called by startup code.


### PR DESCRIPTION
Rather than being handled before calculating interpolation, view offsets are now added after the base position and angles are calculated in full. This allows them to trivially update in real-time with the player's mouse and gives proper portal support. The result is that the chase cam no longer forces interpolation and any remaining bugs with view offsets should be squashed. Behavior was centralized into a singular tracer that all view offsets now use to prevent clipping out of the map (including from things like earthquakes). This also fixes any issues with the camera appearing to momentarily clip into the void when near walls (especially common with corners in chase cam mode).