### PR TITLE
- implement anamorphesis proof-of-concept

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -80,6 +80,8 @@ EXTERN_CVAR(Float, r_actorspriteshadowfadeheight)
 CVAR(Bool, gl_usecolorblending, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, gl_sprite_blend, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 CVAR(Int, gl_spriteclip, 1, CVAR_ARCHIVE)
+CVAR(Bool, r_debug_nolimitanamorphoses, false, 0)
+CVAR(Float, r_spriteclipanamorphicminbias, 0.6, CVAR_ARCHIVE)
 CVAR(Float, gl_sclipthreshold, 10.0, CVAR_ARCHIVE)
 CVAR(Float, gl_sclipfactor, 1.8f, CVAR_ARCHIVE)
 CVAR(Int, gl_particles_style, 2, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // 0 = square, 1 = round, 2 = smooth
@@ -1061,6 +1063,56 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	depth = (float)((x - vp.Pos.X) * vp.TanCos + (y - vp.Pos.Y) * vp.TanSin);
 	if (isSpriteShadow) depth += 1.f/65536.f; // always sort shadows behind the sprite.
 
+	if (gl_spriteclip == -1 && (thing->renderflags & RF_SPRITETYPEMASK) == RF_FACESPRITE) // perform anamorphosis
+	{
+		float minbias = r_spriteclipanamorphicminbias;
+		minbias = clamp(minbias, 0.3f, 1.0f);
+
+		float btm = thing->Sector->floorplane.ZatPoint(thing) - thing->Floorclip;
+		float top = thing->Sector->ceilingplane.ZatPoint(thingpos);
+
+		float vbtm = thing->Sector->floorplane.ZatPoint(vp.Pos);
+		float vtop = thing->Sector->ceilingplane.ZatPoint(vp.Pos);
+
+		float vpx = vp.Pos.X;
+		float vpy = vp.Pos.Y;
+		float vpz = vp.Pos.Z;
+
+		float tpx = thingpos.X;
+		float tpy = thingpos.Y;
+		float tpz = thingpos.Z;
+
+		if (!(r_debug_nolimitanamorphoses))
+		{
+			// this should help prevent clipping through walls ...
+			float objradiusbias = 1.f - thing->radius / sqrt((vpx - tpx) * (vpx - tpx) + (vpy - tpy) * (vpy - tpy));
+			minbias = max(minbias, objradiusbias);
+		}
+
+		float bintersect, tintersect;
+		if (z2 < vpz && vbtm < vpz)
+			bintersect = min((btm - vpz) / (z2 - vpz), (vbtm - vpz) / (z2 - vpz));
+		else
+			bintersect = 1.0;
+
+		if (z1 > vpz && vtop > vpz)
+			tintersect = min((top - vpz) / (z1 - vpz), (vtop - vpz) / (z1 - vpz));
+		else
+			tintersect = 1.0;
+
+		if (thing->waterlevel >= 1 && thing->waterlevel <= 2)
+			bintersect = tintersect = 1.0f;
+
+		float spbias = clamp(min(bintersect, tintersect), minbias, 1.0f);
+		float vpbias = 1.0 - spbias;
+		x1 = x1 * spbias + vpx * vpbias;
+		y1 = y1 * spbias + vpy * vpbias;
+		z1 = z1 * spbias + vpz * vpbias;
+		x2 = x2 * spbias + vpx * vpbias;
+		y2 = y2 * spbias + vpy * vpbias;
+		z2 = z2 * spbias + vpz * vpbias;		
+	}
+
 	// light calculation
 
 	bool enhancedvision = false;
@@ -1279,6 +1331,7 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	{
 		lightlist = nullptr;
 	}
+
 	PutSprite(di, hw_styleflags != STYLEHW_Solid);
 	rendered_sprites++;
 }

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2384,6 +2384,7 @@ OptionValue "SpriteclipModes"
 	1, "$OPTVAL_SMART"
 	2, "$OPTVAL_ALWAYS"
 	3, "$OPTVAL_SMARTER"
+	-1, "$OPTVAL_ANAMORPHIC"
 }
 
 OptionValue "EnhancedStealth"


### PR DESCRIPTION
Anamorphosis: the idea that something looks like it is something else from a certain angle.

This PR does exactly that, but with sprites, albeit a very simplistic distortion. It shrinks sprites towards the viewer in order to give the illusion that they are able to be drawn below the floor.

There are very obvious and clear limitations with this. Right now the sprite moves to a maximum of its physical clipping range, in an effort to prevent it from being drawn through walls.

There probably could be even more improvements to this, like slicing up the sprite, but I really don't have time to figure out how to do that or the maths needed for it.