### PR TITLE
Added WorldHitscanFired and WorldHitscanPreFired

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -719,7 +719,7 @@ bool EventManager::WorldHitscanPreFired(AActor* actor, DAngle angle, double dist
 	return ret;
 }
 
-void EventManager::WorldHitscanFired(AActor* actor, DVector3 AttackPos, DVector3 DamagePosition, AActor* Inflictor, int flags)
+void EventManager::WorldHitscanFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags)
 {
 	// don't call anything if actor was destroyed on PostBeginPlay/BeginPlay/whatever.
 	if (actor->ObjectFlags & OF_EuthanizeMe)
@@ -1795,7 +1795,7 @@ bool DStaticEventHandler::WorldHitscanPreFired(AActor* actor, DAngle angle, doub
 	return false;
 }
 
-void DStaticEventHandler::WorldHitscanFired(AActor* actor, DVector3 AttackPos, DVector3 DamagePosition, AActor* Inflictor, int flags)
+void DStaticEventHandler::WorldHitscanFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags)
 {
 	IFVIRTUAL(DStaticEventHandler, WorldHitscanFired)
 	{

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -701,6 +701,36 @@ void EventManager::WorldThingDied(AActor* actor, AActor* inflictor)
 		handler->WorldThingDied(actor, inflictor);
 }
 
+bool EventManager::WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside)
+{
+	// don't call anything if actor was destroyed on PostBeginPlay/BeginPlay/whatever.
+	if (actor->ObjectFlags & OF_EuthanizeMe)
+		return false;
+
+	bool ret = false;
+	if (ShouldCallStatic(true)) ret = staticEventManager.WorldHitscanPreFired(actor, angle, distance, pitch, damage, damageType, pufftype, flags, sz, offsetforward, offsetside);
+
+	if (!ret)
+	{
+		for (DStaticEventHandler* handler = FirstEventHandler; handler && ret == false; handler = handler->next)
+			ret = handler->WorldHitscanPreFired(actor, angle, distance, pitch, damage, damageType, pufftype, flags, sz, offsetforward, offsetside);
+	}
+	
+	return ret;
+}
+
+void EventManager::WorldHitscanFired(AActor* actor, DVector3 AttackPos, DVector3 DamagePosition, AActor* Inflictor, int flags)
+{
+	// don't call anything if actor was destroyed on PostBeginPlay/BeginPlay/whatever.
+	if (actor->ObjectFlags & OF_EuthanizeMe)
+		return;
+
+	if (ShouldCallStatic(true)) staticEventManager.WorldHitscanFired(actor, AttackPos, DamagePosition, Inflictor, flags);
+
+	for (DStaticEventHandler* handler = FirstEventHandler; handler; handler = handler->next)
+		handler->WorldHitscanFired(actor, AttackPos, DamagePosition, Inflictor, flags);
+}
+
 void EventManager::WorldThingGround(AActor* actor, FState* st)
 {
 	// don't call anything if actor was destroyed on PostBeginPlay/BeginPlay/whatever.
@@ -1026,6 +1056,14 @@ DEFINE_FIELD_X(WorldEvent, FWorldEvent, DamagePosition);
 DEFINE_FIELD_X(WorldEvent, FWorldEvent, DamageIsRadius);
 DEFINE_FIELD_X(WorldEvent, FWorldEvent, NewDamage);
 DEFINE_FIELD_X(WorldEvent, FWorldEvent, CrushedState);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, AttackPos);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, AttackAngle);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, AttackPitch);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, AttackDistance);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, AttackOffsetForward);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, AttackOffsetSide);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, AttackZ);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, AttackPuffType);
 
 DEFINE_FIELD_X(PlayerEvent, FPlayerEvent, PlayerNumber);
 DEFINE_FIELD_X(PlayerEvent, FPlayerEvent, IsReturn);
@@ -1729,6 +1767,51 @@ void DStaticEventHandler::WorldThingDied(AActor* actor, AActor* inflictor)
 	}
 }
 
+bool DStaticEventHandler::WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside)
+{
+	IFVIRTUAL(DStaticEventHandler, WorldHitscanPreFired)
+	{
+		// don't create excessive DObjects if not going to be processed anyway
+		if (isEmpty(func)) return false;
+		FWorldEvent e = owner->SetupWorldEvent();
+		e.Thing = actor;
+		e.AttackAngle = angle;
+		e.AttackPitch = pitch;
+		e.AttackDistance = distance;
+		e.Damage = damage;
+		e.DamageType = damageType;
+		e.AttackPuffType = pufftype;
+		e.AttackOffsetForward = offsetforward;
+		e.AttackOffsetSide = offsetside;
+		e.AttackZ = sz;
+		e.DamageFlags = flags;
+		int processed;
+		VMReturn results[1] = { &processed };
+		VMValue params[2] = { (DStaticEventHandler*)this, &e };
+		VMCall(func, params, 2, results, 1);
+		return !!processed;
+	}
+
+	return false;
+}
+
+void DStaticEventHandler::WorldHitscanFired(AActor* actor, DVector3 AttackPos, DVector3 DamagePosition, AActor* Inflictor, int flags)
+{
+	IFVIRTUAL(DStaticEventHandler, WorldHitscanFired)
+	{
+		// don't create excessive DObjects if not going to be processed anyway
+		if (isEmpty(func)) return;
+		FWorldEvent e = owner->SetupWorldEvent();
+		e.Thing = actor;
+		e.AttackPos = AttackPos;
+		e.DamagePosition = DamagePosition;
+		e.Inflictor = Inflictor;
+		e.DamageFlags = flags;
+		VMValue params[2] = { (DStaticEventHandler*)this, &e };
+		VMCall(func, params, 2, nullptr, 0);
+	}
+}
+
 void DStaticEventHandler::WorldThingGround(AActor* actor, FState* st)
 {
 	IFVIRTUAL(DStaticEventHandler, WorldThingGround)
@@ -1742,7 +1825,6 @@ void DStaticEventHandler::WorldThingGround(AActor* actor, FState* st)
 		VMCall(func, params, 2, nullptr, 0);
 	}
 }
-
 
 void DStaticEventHandler::WorldThingRevived(AActor* actor)
 {

--- a/src/events.h
+++ b/src/events.h
@@ -311,6 +311,8 @@ public:
 	void WorldThingRevived(AActor* actor);
 	void WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
 	void WorldThingDestroyed(AActor* actor);
+	bool WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside);
+	void WorldHitscanFired(AActor* actor, DVector3 AttackPos, DVector3 DamagePosition, AActor* Inflictor, int flags);
 	void WorldLinePreActivated(line_t* line, AActor* actor, int activationType, bool* shouldactivate);
 	void WorldLineActivated(line_t* line, AActor* actor, int activationType);
 	int WorldSectorDamaged(sector_t* sector, AActor* source, int damage, FName damagetype, int part, DVector3 position, bool isradius);
@@ -393,6 +395,14 @@ struct FWorldEvent
 	bool DamageIsRadius; // radius damage yes/no
 	int NewDamage = 0; // sector/line damaged. allows modifying damage
 	FState* CrushedState = nullptr; // custom crush state set in thingground
+	DVector3 AttackPos; //hitscan point of origin
+	DAngle AttackAngle;
+	DAngle AttackPitch;
+	double AttackDistance = 0;
+	double AttackOffsetForward = 0;
+	double AttackOffsetSide = 0;
+	double AttackZ = 0;
+	PClassActor* AttackPuffType = nullptr;
 };
 
 struct FPlayerEvent
@@ -467,6 +477,10 @@ struct EventManager
 	void WorldThingSpawned(AActor* actor);
 	// called after AActor::Die of each actor.
 	void WorldThingDied(AActor* actor, AActor* inflictor);
+	// called when a hitscan attack is fired (can be overridden to block it)
+	bool WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside);
+	// called when a hitscan attack has been fired
+	void WorldHitscanFired(AActor* actor, DVector3 AttackPos, DVector3 DamagePosition, AActor* Inflictor, int flags);
 	// called inside AActor::Grind just before the corpse is destroyed
 	void WorldThingGround(AActor* actor, FState* st);
 	// called after AActor::Revive.

--- a/src/events.h
+++ b/src/events.h
@@ -312,7 +312,7 @@ public:
 	void WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
 	void WorldThingDestroyed(AActor* actor);
 	bool WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside);
-	void WorldHitscanFired(AActor* actor, DVector3 AttackPos, DVector3 DamagePosition, AActor* Inflictor, int flags);
+	void WorldHitscanFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags);
 	void WorldLinePreActivated(line_t* line, AActor* actor, int activationType, bool* shouldactivate);
 	void WorldLineActivated(line_t* line, AActor* actor, int activationType);
 	int WorldSectorDamaged(sector_t* sector, AActor* source, int damage, FName damagetype, int part, DVector3 position, bool isradius);
@@ -480,7 +480,7 @@ struct EventManager
 	// called when a hitscan attack is fired (can be overridden to block it)
 	bool WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside);
 	// called when a hitscan attack has been fired
-	void WorldHitscanFired(AActor* actor, DVector3 AttackPos, DVector3 DamagePosition, AActor* Inflictor, int flags);
+	void WorldHitscanFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags);
 	// called inside AActor::Grind just before the corpse is destroyed
 	void WorldThingGround(AActor* actor, FState* st);
 	// called after AActor::Revive.

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -81,6 +81,7 @@
 #include "r_utility.h"
 #include "p_blockmap.h"
 #include "p_3dmidtex.h"
+#include "events.h"
 #include "vm.h"
 #include "d_main.h"
 
@@ -4620,6 +4621,12 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 	DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, FTranslatedLineTarget*victim, int *actualdamage, 
 	double sz, double offsetforward, double offsetside)
 {
+	if (t1->Level->localEventManager->WorldHitscanPreFired(t1, angle, distance, pitch, damage, damageType, pufftype, flags, sz, offsetforward, offsetside))
+	{
+		return nullptr;
+	}
+
+
 	bool nointeract = !!(flags & LAF_NOINTERACT);
 	DVector3 direction;
 	double shootz;
@@ -4633,6 +4640,7 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 	bool spawnSky = false;
 	if (flags & LAF_NORANDOMPUFFZ)
 		puffFlags |= PF_NORANDOMZ;
+
 
 	if (victim != NULL)
 	{
@@ -4724,6 +4732,7 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 	// LAF_ABSOFFSET: Ignore the angle.
 
 	DVector3 tempos;
+	DVector3 puffpos;
 
 	if (flags & LAF_ABSPOSITION)
 	{
@@ -4759,7 +4768,8 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 
 		if (nointeract || (puffDefaults && puffDefaults->flags3 & MF3_ALWAYSPUFF))
 		{ // Spawn the puff anyway
-			puff = P_SpawnPuff(t1, pufftype, trace.HitPos, trace.SrcAngleFromTarget, trace.SrcAngleFromTarget, 2, puffFlags);
+			puffpos = trace.HitPos;
+			puff = P_SpawnPuff(t1, pufftype, puffpos, trace.SrcAngleFromTarget, trace.SrcAngleFromTarget, 2, puffFlags);
 
 			if (nointeract)
 			{
@@ -4789,7 +4799,8 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 			if (nointeract || trace.HitType != TRACE_HitWall || ((trace.Line->special != Line_Horizon) || spawnSky))
 			{
 				DVector2 pos = t1->Level->GetPortalOffsetPosition(trace.HitPos.X, trace.HitPos.Y, -trace.HitVector.X * 4, -trace.HitVector.Y * 4);
-				puff = P_SpawnPuff(t1, pufftype, DVector3(pos, trace.HitPos.Z - trace.HitVector.Z * 4), trace.SrcAngleFromTarget,
+				puffpos = DVector3(pos, trace.HitPos.Z - trace.HitVector.Z * 4);
+				puff = P_SpawnPuff(t1, pufftype, puffpos, trace.SrcAngleFromTarget,
 					trace.SrcAngleFromTarget - DAngle::fromDeg(90), 0, puffFlags);
 				puff->radius = 1/65536.;
 
@@ -4836,6 +4847,7 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 		{
 			// Hit a thing, so it could be either a puff or blood
 			DVector3 bleedpos = trace.HitPos;
+			puffpos = bleedpos;
 			// position a bit closer for puffs/blood if using compatibility mode.
 			if (trace.Actor->Level->i_compatflags & COMPATF_HITSCAN)
 			{
@@ -4928,6 +4940,9 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 			SpawnDeepSplash(t1, trace, puff);
 		}
 	}
+
+	t1->Level->localEventManager->WorldHitscanFired(t1, tempos, puffpos, puff, flags);
+
 	if (killPuff && puff != NULL)
 	{
 		puff->Destroy();
@@ -5378,16 +5393,30 @@ static ETraceStatus ProcessRailHit(FTraceResults &res, void *userdata)
 //==========================================================================
 void P_RailAttack(FRailParams *p)
 {
-	DVector3 start;
-	FTraceResults trace;
+	AActor *source = p->source;
 
 	PClassActor *puffclass = p->puff;
 	if (puffclass == NULL)
 	{
 		puffclass = PClass::FindActor(NAME_BulletPuff);
 	}
+	assert(puffclass != NULL);		// Because we set it to a default above
+	AActor *puffDefaults = GetDefaultByType(puffclass->GetReplacement(source->Level)); //Contains all the flags such as FOILINVUL, etc.
+	FName damagetype = (puffDefaults == NULL || puffDefaults->DamageType == NAME_None) ? FName(NAME_Railgun) : puffDefaults->DamageType;
 
-	AActor *source = p->source;
+	int flags;
+
+	// disabled because not complete yet.
+	flags = (puffDefaults->flags6 & MF6_NOTRIGGER) ? TRACE_ReportPortals : TRACE_PCross | TRACE_Impact | TRACE_ReportPortals;
+
+	if (source->Level->localEventManager->WorldHitscanPreFired(source, source->Angles.Yaw + p->angleoffset, p->distance, source->Angles.Pitch + p->pitchoffset, p->damage, damagetype, puffclass, flags, p->offset_z, 0, p->offset_xy))
+	{
+		return;
+	}
+
+	DVector3 start;
+	FTraceResults trace;
+
 	DAngle pitch = source->Angles.Pitch + p->pitchoffset;
 	DAngle angle = source->Angles.Yaw + p->angleoffset;
 
@@ -5416,13 +5445,6 @@ void P_RailAttack(FRailParams *p)
 	start.Y = xy.Y;
 	start.Z = shootz;
 
-	int flags;
-
-	assert(puffclass != NULL);		// Because we set it to a default above
-	AActor *puffDefaults = GetDefaultByType(puffclass->GetReplacement(source->Level)); //Contains all the flags such as FOILINVUL, etc.
-
-	// disabled because not complete yet.
-	flags = (puffDefaults->flags6 & MF6_NOTRIGGER) ? TRACE_ReportPortals : TRACE_PCross | TRACE_Impact | TRACE_ReportPortals;
 	rail_data.StopAtInvul = (puffDefaults->flags3 & MF3_FOILINVUL) ? false : true;
 	rail_data.MThruSpecies = ((puffDefaults->flags6 & MF6_MTHRUSPECIES)) ? true : false;
 	
@@ -5459,8 +5481,7 @@ void P_RailAttack(FRailParams *p)
 
 	// Hurt anything the trace hit
 	unsigned int i;
-	FName damagetype = (puffDefaults == NULL || puffDefaults->DamageType == NAME_None) ? FName(NAME_Railgun) : puffDefaults->DamageType;
-
+	
 	for (i = 0; i < rail_data.RailHits.Size(); i++)
 	{
 		bool spawnpuff;
@@ -5548,6 +5569,9 @@ void P_RailAttack(FRailParams *p)
 			}
 		}
 	}
+
+	source->Level->localEventManager->WorldHitscanFired(source, start, trace.HitPos, thepuff, flags);
+
 	if (thepuff != NULL)
 	{
 		if (trace.Crossed3DWater || trace.CrossedWater)

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -97,6 +97,14 @@ struct WorldEvent native play version("2.4")
     native readonly bool DamageIsRadius;
     native int NewDamage;
     native readonly State CrushedState;
+	native readonly double AttackAngle;
+	native readonly double AttackPitch;
+	native readonly double AttackDistance;
+	native readonly vector3 AttackPos;
+	native readonly double AttackOffsetForward;
+	native readonly double AttackOffsetSide;
+	native readonly double AttackZ;
+	native readonly class<Actor> AttackPuffType;
 }
 
 struct PlayerEvent native play version("2.4")
@@ -155,6 +163,8 @@ class StaticEventHandler : Object native play version("2.4")
     virtual void WorldThingRevived(WorldEvent e) {}
     virtual void WorldThingDamaged(WorldEvent e) {}
     virtual void WorldThingDestroyed(WorldEvent e) {}
+	virtual bool WorldHitscanPreFired(WorldEvent e) { return false; }
+    virtual void WorldHitscanFired(WorldEvent e) {}
     virtual void WorldLinePreActivated(WorldEvent e) {}
     virtual void WorldLineActivated(WorldEvent e) {}
     virtual void WorldSectorDamaged(WorldEvent e) {}


### PR DESCRIPTION
This adds `WorldHitscanFired` and `WorldHitscanPreFired` events to `P_LineAttack` and `P_RailAttack`. The former is called after a hitscan has been fired and provides information about it; the latter before it and allows stopping it. The idea is to allow mod authors universally detect hitscans, and potentially replace them with projectiles, which hasn't been possible so far. 

~~THE PROBLEM is that in its current form, despite compiling properly, it leads to a mysterious crash on startup, presumably tripping up the file system. This is caused by WorldHitscanPrefired specifically; the other features were tested and work fine, but as soon as I added WorldHitscanPrefired, the crashes started happening. Unfortunately, I cannot nail down the issue myself.~~

UPD: I can't believe my inattention; the whole problem was that WorldHitscanPreFired was defined without a return value in zscript, and apparently that causes a CTD on startup rather than a build error.

Test file. This replaces hitscans with plasma balls and reports on received values.
[WorldHitscan.zip](https://github.com/user-attachments/files/17549712/WorldHitscan.zip)
