### PR TITLE
Fix for Morph virtual

### DIFF
--- a/src/common/objects/dobjtype.cpp
+++ b/src/common/objects/dobjtype.cpp
@@ -669,6 +669,8 @@ PClass *PClass::FindClassTentative(FName name)
 //
 //==========================================================================
 
+bool ShouldAllowGameSpecificVirtual(FName name, unsigned index, PType* arg, PType* varg);
+
 int PClass::FindVirtualIndex(FName name, PFunction::Variant *variant, PFunction *parentfunc, bool exactReturnType, bool ignorePointerReadOnly)
 {
 	auto proto = variant->Proto;
@@ -700,7 +702,7 @@ int PClass::FindVirtualIndex(FName name, PFunction::Variant *variant, PFunction 
 							break;
 						}
 					}
-					else
+					else if(!ShouldAllowGameSpecificVirtual(name, a, proto->ArgumentTypes[a], vproto->ArgumentTypes[a]))
 					{
 						fail = true;
 						break;

--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -463,6 +463,7 @@ xx(WBobSpeed)
 xx(WBobFire)
 xx(PlayerClass)
 xx(MonsterClass)
+xx(Morph)
 xx(MorphedMonster)
 xx(Wi_NoAutostartMap)
 

--- a/src/scripting/backend/codegen_doom.cpp
+++ b/src/scripting/backend/codegen_doom.cpp
@@ -57,6 +57,19 @@ PFunction* FindBuiltinFunction(FName funcname);
 //
 //==========================================================================
 
+bool ShouldAllowGameSpecificVirtual(FName name, unsigned index, PType* arg, PType* varg)
+{
+	return (name == NAME_Morph && index == 3u && arg->isClassPointer() && varg->isClassPointer()
+			&& PType::toClassPointer(varg)->ClassRestriction->TypeName == NAME_Actor
+			&& PType::toClassPointer(arg)->ClassRestriction->TypeName == NAME_MorphedMonster);
+}
+
+//==========================================================================
+//
+//
+//
+//==========================================================================
+
 bool isActor(PContainerType *type)
 {
 	auto cls = PType::toClass(type);


### PR DESCRIPTION
Allows `class<MorphedMonster>` to be used as an argument type in place of `class<Actor>` within the third argument for backwards compatibility.