### PR TITLE
TArray: static_assert that T is trivially relocatable

### DIFF
--- a/src/common/utility/tarray.h
+++ b/src/common/utility/tarray.h
@@ -32,18 +32,18 @@
 **---------------------------------------------------------------------------
 **
 ** NOTE: TArray takes advantage of the assumption that the contained type is
-** able to be trivially moved. The definition of trivially movable by the C++
-** standard is more strict than the actual set of types that can be moved with
-** memmove. For example, FString uses non-trivial constructors/destructor in
-** order to maintain the reference count, but can be "safely" by passed if the
+** able to be trivially relocated. This definition includes more than just
+** types that the C++ standard says are trivially copyable. For example,
+** FString uses non-trivial constructors/destructor in
+** order to maintain the reference count, but can be "safely" memcpyed if the
 ** opaque destructor call is avoided. Similarly types like TArray itself which
 ** only null the owning pointers when moving which can be skipped if the
 ** destructor is not called.
 **
-** It is possible that with LTO TArray could be made safe for non-trivial types,
-** but we don't wish to rely on LTO to reach expected performance. The set of
-** types which can not be contained by TArray as a result of this choice is
-** actually extremely small.
+** It is possible that with LTO TArray could be made safe for non-trivially
+** relocatable types, but we don't wish to rely on LTO to reach expected
+** performance. The set of types which cannot be contained by TArray as a
+** result of this choice is actually extremely small.
 **
 */
 
@@ -139,6 +139,10 @@ struct FArray
 template <class T, class TT=T>
 class TArray
 {
+#if defined(__clang__) && defined(__cpp_impl_trivially_relocatable)
+    static_assert(__is_trivially_relocatable(T), "T must be trivially relocatable");
+#endif
+
 public:
 
     typedef TIterator<T>                       iterator;


### PR DESCRIPTION
The trivial-relocatability assumption is used in `Grow` (where memcpy replaces move-construct plus destroy) and also in `Delete` (where destroy plus memmove replaces move-assign plus destroy). P1144R10 "std::is_trivially_relocatable" asks for the STL to directly support

    static_assert(std::is_trivially_relocatable_v<T>);

but for now it suffices to detect the Clang reference implementation using P1144's feature-test macro. On the reference implementation, the `__is_trivially_relocatable(T)` builtin always gives the right answer.

Most importantly, update the block comment to use the terminology "relocate" instead of "move."

attn @coelckers @kcat if you're still interested, 4.5 years after #928 :)