### PR TITLE
Allow pointer substitution when morphing for internal pointers only

### DIFF
--- a/src/common/objects/dobject.cpp
+++ b/src/common/objects/dobject.cpp
@@ -467,6 +467,35 @@ size_t DObject::PointerSubstitution (DObject *old, DObject *notOld)
 	return changed;
 }
 
+size_t DObject::SafePointerSubstitution(DObject* old, DObject* notOld)
+{
+	const PClass* info = GetClass();
+	size_t changed = 0;
+	do
+	{
+		if (!info->bRuntimeClass)
+		{
+			const size_t* offsets = info->Pointers;
+			if (offsets != nullptr)
+			{
+				while (*offsets != ~(size_t)0)
+				{
+					if (*(DObject**)((uint8_t*)this + *offsets) == old)
+					{
+						*(DObject**)((uint8_t*)this + *offsets) = notOld;
+						changed++;
+					}
+					offsets++;
+				}
+			}
+		}
+
+		info = info->ParentClass;
+	} while (info != nullptr);
+
+	return changed;
+}
+
 //==========================================================================
 //
 //

--- a/src/common/objects/dobject.h
+++ b/src/common/objects/dobject.h
@@ -247,6 +247,8 @@ public:
 
 	// This is only needed for swapping out PlayerPawns and absolutely nothing else!
 	virtual size_t PointerSubstitution (DObject *old, DObject *notOld);
+	// Unlike the above, this will only swap pointers defined by non-runtime classes.
+	size_t SafePointerSubstitution(DObject* old, DObject* notOld);
 
 	PClass *GetClass() const
 	{


### PR DESCRIPTION
Since internal pointers can't be more type-specific than AActor, any of them will be inherently safe to swap around in the case of morphing. This fixes some lingering internal issues where things like ACS script callers weren't being correctly updated, leading to potential crashes.