### PR TITLE
Pathing player check fix

### DIFF
--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -2245,14 +2245,18 @@ bool AActor::CanPathfind()
 			return true;
 
 		// Can't pathfind while feared.
-		if (!(flags4 & MF4_FRIGHTENED))
-		{
-			if (!target)	
-				return true;
+		if (flags4 & MF4_FRIGHTENED)
+			return false;
 
-			if (!target->flags8 & MF8_FRIGHTENING)
-				return (!target->player || !(target->player->cheats & CF_FRIGHTENING));
+		if (target)
+		{
+			if (target->flags8 & MF8_FRIGHTENING)
+				return false;
+
+			if (target->player && target->player->cheats & CF_FRIGHTENING)
+				return false;
 		}
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
 Fixed: Fear checks were incorrect when accounting for player being present or not.

Fixes #2451 