### PR TITLE
Added safety barriers to pointer substitution

### DIFF
--- a/src/common/objects/dobject.h
+++ b/src/common/objects/dobject.h
@@ -246,7 +246,7 @@ public:
 	inline int* IntArray(FName field);
 
 	// This is only needed for swapping out PlayerPawns and absolutely nothing else!
-	virtual size_t PointerSubstitution (DObject *old, DObject *notOld);
+	virtual size_t PointerSubstitution (DObject *old, DObject *notOld, bool nullOnFail);
 
 	PClass *GetClass() const
 	{

--- a/src/common/objects/dobjtype.h
+++ b/src/common/objects/dobjtype.h
@@ -27,6 +27,9 @@ class PClassType;
 struct FNamespaceManager;
 class PSymbol;
 class PField;
+class PObjectPointer;
+class PDynArray;
+class PMap;
 
 enum
 {
@@ -53,10 +56,15 @@ public:
 
 	// Per-class information -------------------------------------
 	PClass				*ParentClass = nullptr;	// the class this class derives from
-	const size_t		*Pointers = nullptr;		// object pointers defined by this class *only*
-	const size_t		*FlatPointers = nullptr;	// object pointers defined by this class and all its superclasses; not initialized by default
-	const size_t		*ArrayPointers = nullptr;	// dynamic arrays containing object pointers.
-	const std::pair<size_t,PType *>	*MapPointers = nullptr;	// maps containing object pointers.
+	const size_t * Pointers = nullptr;			// native object pointers defined by this class *only*
+
+	mutable size_t FlatPointersSize = 0;
+	mutable const std::pair<size_t, PObjectPointer*> * FlatPointers = nullptr;	// object pointers defined by this class and all its superclasses; not initialized by default.
+	mutable size_t ArrayPointersSize = 0;
+	mutable const std::pair<size_t, PDynArray *> * ArrayPointers = nullptr;	// dynamic arrays containing object pointers.
+	mutable size_t MapPointersSize = 0;
+	mutable const std::pair<size_t, PMap *>	* MapPointers = nullptr;	// maps containing object pointers.
+
 	uint8_t				*Defaults = nullptr;
 	uint8_t				*Meta = nullptr;			// Per-class static script data
 	unsigned			 Size = sizeof(DObject);
@@ -86,9 +94,11 @@ public:
 	PClass *CreateDerivedClass(FName name, unsigned int size, bool *newlycreated = nullptr, int fileno = 0);
 
 	void InitializeActorInfo();
-	void BuildFlatPointers();
-	void BuildArrayPointers();
-	void BuildMapPointers();
+
+	void BuildFlatPointers() const;
+	void BuildArrayPointers() const;
+	void BuildMapPointers() const;
+
 	void DestroySpecials(void *addr);
 	void DestroyMeta(void *addr);
 	const PClass *NativeClass() const;

--- a/src/common/scripting/core/types.cpp
+++ b/src/common/scripting/core/types.cpp
@@ -196,15 +196,15 @@ void PType::SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset> 
 //
 //==========================================================================
 
-void PType::SetPointer(void *base, unsigned offset, TArray<size_t> *stroffs)
+void PType::SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *stroffs)
 {
 }
 
-void PType::SetPointerArray(void *base, unsigned offset, TArray<size_t> *stroffs)
+void PType::SetPointerArray(void *base, unsigned offset, TArray<std::pair<size_t, PDynArray *>> *stroffs)
 {
 }
 
-void PType::SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t,PType *>> *ptrofs)
+void PType::SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t, PMap *>> *ptrofs)
 {
 }
 
@@ -1575,10 +1575,10 @@ PObjectPointer::PObjectPointer(PClass *cls, bool isconst)
 //
 //==========================================================================
 
-void PObjectPointer::SetPointer(void *base, unsigned offset, TArray<size_t> *special)
+void PObjectPointer::SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *special)
 {
 	// Add to the list of pointers for this class.
-	special->Push(offset);
+	special->Push({offset, this});
 }
 
 //==========================================================================
@@ -1706,7 +1706,7 @@ bool PClassPointer::isCompatible(PType *type)
 //
 //==========================================================================
 
-void PClassPointer::SetPointer(void *base, unsigned offset, TArray<size_t> *special)
+void PClassPointer::SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *special)
 {
 }
 
@@ -1908,7 +1908,7 @@ void PArray::SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset>
 //
 //==========================================================================
 
-void PArray::SetPointer(void *base, unsigned offset, TArray<size_t> *special)
+void PArray::SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *special)
 {
 	for (unsigned i = 0; i < ElementCount; ++i)
 	{
@@ -1922,7 +1922,7 @@ void PArray::SetPointer(void *base, unsigned offset, TArray<size_t> *special)
 //
 //==========================================================================
 
-void PArray::SetPointerArray(void *base, unsigned offset, TArray<size_t> *special)
+void PArray::SetPointerArray(void *base, unsigned offset, TArray<std::pair<size_t, PDynArray *>> *special)
 {
 	if (ElementType->isStruct() || ElementType->isDynArray())
 	{
@@ -1939,7 +1939,7 @@ void PArray::SetPointerArray(void *base, unsigned offset, TArray<size_t> *specia
 //
 //==========================================================================
 
-void PArray::SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t,PType *>> *special)
+void PArray::SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t, PMap *>> *special)
 {
 	if(ElementType->isStruct() || ElementType->isMap())
 	{
@@ -2254,12 +2254,12 @@ void PDynArray::SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffs
 //
 //==========================================================================
 
-void PDynArray::SetPointerArray(void *base, unsigned offset, TArray<size_t> *special)
+void PDynArray::SetPointerArray(void *base, unsigned offset, TArray<std::pair<size_t, PDynArray *>> *special)
 {
 	if (ElementType->isObjectPointer())
 	{
 		// Add to the list of pointer arrays for this class.
-		special->Push(offset);
+		special->Push({offset, this});
 	}
 }
 
@@ -2524,12 +2524,12 @@ void PMap::SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset> *
 //
 //==========================================================================
 
-void PMap::SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t,PType *>> *special)
+void PMap::SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t, PMap *>> *special)
 {
 	if (ValueType->isObjectPointer())
 	{
 		// Add to the list of pointer arrays for this class.
-		special->Push(std::make_pair(offset,KeyType));
+		special->Push(std::make_pair(offset, this));
 	}
 }
 
@@ -3264,7 +3264,7 @@ void PStruct::SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset
 //
 //==========================================================================
 
-void PStruct::SetPointer(void *base, unsigned offset, TArray<size_t> *special)
+void PStruct::SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *special)
 {
 	auto it = Symbols.GetIterator();
 	PSymbolTable::MapType::Pair *pair;
@@ -3284,7 +3284,7 @@ void PStruct::SetPointer(void *base, unsigned offset, TArray<size_t> *special)
 //
 //==========================================================================
 
-void PStruct::SetPointerArray(void *base, unsigned offset, TArray<size_t> *special)
+void PStruct::SetPointerArray(void *base, unsigned offset, TArray<std::pair<size_t, PDynArray *>> *special)
 {
 	auto it = Symbols.GetIterator();
 	PSymbolTable::MapType::Pair *pair;
@@ -3304,7 +3304,7 @@ void PStruct::SetPointerArray(void *base, unsigned offset, TArray<size_t> *speci
 //
 //==========================================================================
 
-void PStruct::SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t,PType *>> *special)
+void PStruct::SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t, PMap *>> *special)
 {
 	auto it = Symbols.GetIterator();
 	PSymbolTable::MapType::Pair *pair;

--- a/src/common/scripting/core/types.h
+++ b/src/common/scripting/core/types.h
@@ -68,8 +68,11 @@ class PPointer;
 class PClassPointer;
 class PFunctionPointer;
 class PArray;
+class PDynArray;
+class PMap;
 class PStruct;
 class PClassType;
+class PObjectPointer;
 
 struct ZCC_ExprConstant;
 class PType : public PTypeBase
@@ -129,9 +132,9 @@ public:
 	// initialization when the object is created and destruction when the
 	// object is destroyed.
 	virtual void SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset> *special=NULL);
-	virtual void SetPointer(void *base, unsigned offset, TArray<size_t> *ptrofs = NULL);
-	virtual void SetPointerArray(void *base, unsigned offset, TArray<size_t> *ptrofs = NULL);
-	virtual void SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t,PType *>> *ptrofs = NULL);
+	virtual void SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *ptrofs = NULL);
+	virtual void SetPointerArray(void *base, unsigned offset, TArray<std::pair<size_t, PDynArray *>> *ptrofs = NULL);
+	virtual void SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t, PMap *>> *ptrofs = NULL);
 
 	// Initialize the value, if needed (e.g. strings)
 	virtual void InitializeValue(void *addr, const void *def) const;
@@ -455,7 +458,7 @@ public:
 
 	void WriteValue(FSerializer &ar, const char *key, const void *addr) const override;
 	bool ReadValue(FSerializer &ar, const char *key, void *addr) const override;
-	void SetPointer(void *base, unsigned offset, TArray<size_t> *special = NULL) override;
+	void SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *special = NULL) override;
 	PClass *PointedClass() const;
 };
 
@@ -471,7 +474,7 @@ public:
 	void WriteValue(FSerializer &ar, const char *key, const void *addr) const override;
 	bool ReadValue(FSerializer &ar, const char *key, void *addr) const override;
 
-	void SetPointer(void *base, unsigned offset, TArray<size_t> *special = NULL) override;
+	void SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *special = NULL) override;
 	 bool IsMatch(intptr_t id1, intptr_t id2) const override;
 	 void GetTypeIDs(intptr_t &id1, intptr_t &id2) const override;
 };
@@ -503,9 +506,9 @@ public:
 	bool ReadValue(FSerializer &ar, const char *key,void *addr) const override;
 
 	void SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset> *special) override;
-	void SetPointer(void *base, unsigned offset, TArray<size_t> *special) override;
-	void SetPointerArray(void *base, unsigned offset, TArray<size_t> *ptrofs = NULL) override;
-	void SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t,PType *>> *ptrofs = NULL) override;
+	void SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *special) override;
+	void SetPointerArray(void *base, unsigned offset, TArray<std::pair<size_t, PDynArray *>> *ptrofs = NULL) override;
+	void SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t, PMap *>> *ptrofs = NULL) override;
 };
 
 class PStaticArray : public PArray
@@ -535,7 +538,7 @@ public:
 	void SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset> *specials) override;
 	void InitializeValue(void *addr, const void *def) const override;
 	void DestroyValue(void *addr) const override;
-	void SetPointerArray(void *base, unsigned offset, TArray<size_t> *ptrofs = NULL) override;
+	void SetPointerArray(void *base, unsigned offset, TArray<std::pair<size_t, PDynArray *>> *ptrofs = NULL) override;
 };
 
 class PMap : public PCompoundType
@@ -579,7 +582,7 @@ public:
 	void SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset> *specials) override;
 	void InitializeValue(void *addr, const void *def) const override;
 	void DestroyValue(void *addr) const override;
-	void SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t,PType *>> *ptrofs) override;
+	void SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t, PMap *>> *ptrofs) override;
 };
 
 
@@ -653,9 +656,9 @@ public:
 	void WriteValue(FSerializer &ar, const char *key,const void *addr) const override;
 	bool ReadValue(FSerializer &ar, const char *key,void *addr) const override;
 	void SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset> *specials) override;
-	void SetPointer(void *base, unsigned offset, TArray<size_t> *specials) override;
-	void SetPointerArray(void *base, unsigned offset, TArray<size_t> *special) override;
-	void SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t,PType *>> *ptrofs) override;
+	void SetPointer(void *base, unsigned offset, TArray<std::pair<size_t, PObjectPointer *>> *specials) override;
+	void SetPointerArray(void *base, unsigned offset, TArray<std::pair<size_t, PDynArray *>> *special) override;
+	void SetPointerMap(void *base, unsigned offset, TArray<std::pair<size_t, PMap *>> *ptrofs) override;
 };
 
 class PPrototype : public PCompoundType

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1712,7 +1712,7 @@ int FLevelLocals::FinishTravel ()
 		pawn->flags2 &= ~MF2_BLASTED;
 		if (oldpawn != nullptr)
 		{
-			PlayerPointerSubstitution (oldpawn, pawn);
+			PlayerPointerSubstitution (oldpawn, pawn, true);
 			oldpawn->Destroy();
 		}
 		if (pawndup != NULL)

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1744,7 +1744,7 @@ struct FTranslatedLineTarget
 	bool unlinked;	// found by a trace that went through an unlinked portal.
 };
 
-void PlayerPointerSubstitution(AActor* oldPlayer, AActor* newPlayer);
+void PlayerPointerSubstitution(AActor* oldPlayer, AActor* newPlayer, bool removeOld);
 int MorphPointerSubstitution(AActor* from, AActor* to);
 
 #define S_FREETARGMOBJ	1

--- a/src/playsim/fragglescript/t_script.cpp
+++ b/src/playsim/fragglescript/t_script.cpp
@@ -549,9 +549,9 @@ size_t DFraggleThinker::PropagateMark()
 //
 //==========================================================================
 
-size_t DFraggleThinker::PointerSubstitution (DObject *old, DObject *notOld)
+size_t DFraggleThinker::PointerSubstitution (DObject *old, DObject *notOld, bool nullOnFail)
 {
-	size_t changed = Super::PointerSubstitution(old, notOld);
+	size_t changed = Super::PointerSubstitution(old, notOld, nullOnFail);
 	for(unsigned i=0;i<SpawnedThings.Size();i++)
 	{
 		if (SpawnedThings[i] == static_cast<AActor*>(old)) 

--- a/src/playsim/fragglescript/t_script.h
+++ b/src/playsim/fragglescript/t_script.h
@@ -701,7 +701,7 @@ public:
 	void Tick();
 	void InitFunctions();
 	size_t PropagateMark();
-	size_t PointerSubstitution (DObject *old, DObject *notOld);
+	size_t PointerSubstitution (DObject *old, DObject *notOld, bool nullOnFail);
 	bool wait_finished(DRunningScript *script);
 	void AddRunningScript(DRunningScript *runscr);
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -5209,15 +5209,14 @@ extern bool demonew;
 
 //==========================================================================
 //
-// This function is dangerous and only designed for swapping player pawns
+// This function is only designed for swapping player pawns
 // over to their new ones upon changing levels or respawning. It SHOULD NOT be
 // used for anything else! Do not export this functionality as it's
-// meant strictly for internal usage. Only swap pointers if the thing being swapped
-// to is a type of the thing being swapped from.
+// meant strictly for internal usage.
 //
 //==========================================================================
 
-void PlayerPointerSubstitution(AActor* oldPlayer, AActor* newPlayer)
+void PlayerPointerSubstitution(AActor* oldPlayer, AActor* newPlayer, bool removeOld)
 {
 	if (oldPlayer == nullptr || newPlayer == nullptr || oldPlayer == newPlayer
 		|| !oldPlayer->IsKindOf(NAME_PlayerPawn) || !newPlayer->IsKindOf(NAME_PlayerPawn))
@@ -5254,20 +5253,16 @@ void PlayerPointerSubstitution(AActor* oldPlayer, AActor* newPlayer)
 			sec.SoundTarget = newPlayer;
 	}
 
-	// Update all the remaining object pointers. This is dangerous but needed to ensure
-	// everything functions correctly when respawning or changing levels.
+	// Update all the remaining object pointers.
 	for (DObject* probe = GC::Root; probe != nullptr; probe = probe->ObjNext)
-		probe->PointerSubstitution(oldPlayer, newPlayer);
+		probe->PointerSubstitution(oldPlayer, newPlayer, removeOld);
 }
 
 //==========================================================================
 //
-// This function is much safer than PlayerPointerSubstition as it only truly
-// swaps a few safe pointers. This has some extra barriers to it to allow
+// This has some extra barriers compared to PlayerPointerSubstitution to allow
 // Actors to freely morph into other Actors which is its main usage.
-// Previously this used raw pointer substitutions but that's far too
-// volatile to use with modder-provided information. It also allows morphing
-// to be more extendable from ZScript.
+// It also allows morphing to be more extendable from ZScript.
 //
 //==========================================================================
 
@@ -5312,30 +5307,6 @@ int MorphPointerSubstitution(AActor* from, AActor* to)
 		VMCall(func, params, 2, nullptr, 0);
 	}
 
-	// Only change some gameplay-related pointers that we know we can safely swap to whatever
-	// new Actor class is present.
-	AActor* mo = nullptr;
-	auto it = from->Level->GetThinkerIterator<AActor>();
-	while ((mo = it.Next()) != nullptr)
-	{
-		if (mo->target == from)
-			mo->target = to;
-		if (mo->tracer == from)
-			mo->tracer = to;
-		if (mo->master == from)
-			mo->master = to;
-		if (mo->goal == from)
-			mo->goal = to;
-		if (mo->lastenemy == from)
-			mo->lastenemy = to;
-		if (mo->LastHeard == from)
-			mo->LastHeard = to;
-		if (mo->LastLookActor == from)
-			mo->LastLookActor = to;
-		if (mo->Poisoner == from)
-			mo->Poisoner = to;
-	}
-
 	// Go through player infos.
 	for (int i = 0; i < MAXPLAYERS; ++i)
 	{
@@ -5364,6 +5335,10 @@ int MorphPointerSubstitution(AActor* from, AActor* to)
 		if (sec.SoundTarget == from)
 			sec.SoundTarget = to;
 	}
+
+	// Replace any object pointers that are safe to swap around.
+	for (DObject* probe = GC::Root; probe != nullptr; probe = probe->ObjNext)
+		probe->PointerSubstitution(from, to, false);
 
 	// Remaining maintenance related to morphing.
 	if (from->player != nullptr)
@@ -5657,7 +5632,7 @@ AActor *FLevelLocals::SpawnPlayer (FPlayerStart *mthing, int playernum, int flag
 				if (sec.SoundTarget == oldactor) sec.SoundTarget = nullptr;
 			}
 
-			PlayerPointerSubstitution (oldactor, p->mo);
+			PlayerPointerSubstitution (oldactor, p->mo, false);
 
 			localEventManager->PlayerRespawned(PlayerNum(p));
 			Behaviors.StartTypedScripts (SCRIPT_Respawn, p->mo, true);


### PR DESCRIPTION
Adds typing information for object pointers so that, when substituting with a new object, it can safely do so. Pointers that are unsafe to swap are left untouched except in the case of players swapping levels, where they're nulled instead. ZSMaps were previously missed when pointer substituting and has now been fixed.

This also serves as a final fix for morphing logic by reimplementing old morph pointer substitution behavior without running the risk of abuse.