### PR TITLE
src: filesystem: move includes out of the FileSys namespace

### DIFF
--- a/src/common/filesystem/source/fs_findfile.cpp
+++ b/src/common/filesystem/source/fs_findfile.cpp
@@ -36,6 +36,18 @@
 #include <string.h>
 #include <vector>
 
+#ifndef _WIN32
+
+#include <limits.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fnmatch.h>
+#include <sys/stat.h>
+
+#include <dirent.h>
+
+#endif
+
 namespace FileSys {
 	
 enum
@@ -62,14 +74,6 @@ enum
 
 
 #ifndef _WIN32
-
-#include <limits.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <fnmatch.h>
-#include <sys/stat.h>
-
-#include <dirent.h>
 
 struct findstate_t
 {


### PR DESCRIPTION
The previous situation is unfortunately not sustainable; header pollution isn't consistent across all non-Windows platforms.  As a result, some of the earlier includes may pull functions/types into the global namespace too soon, and the later includes will have no visibility of them because they're in a different namespace.  Re-including the necessary one doesn't work because include guards will prevent their re-inclusion, and it's not a good idea to try and #undefine include guards now that we're in a new namespace.

This fixes the build on FreeBSD, and likely some other systems as well.