### PR TITLE
- slow down frame updates for the start screen for slower GPU's, sinc…

### DIFF
--- a/src/common/startscreen/startscreen.cpp
+++ b/src/common/startscreen/startscreen.cpp
@@ -654,9 +654,11 @@ void FStartScreen::NetProgress(int count)
 
 void FStartScreen::Render(bool force)
 {
+	static uint64_t minwaittime = 30;
+
 	auto nowtime = I_msTime();
 	// Do not refresh too often. This function gets called a lot more frequently than the screen can update.
-	if (nowtime - screen->FrameTime > 30 || force)
+	if (nowtime - screen->FrameTime > minwaittime || force)
 	{
 		screen->FrameTime = nowtime;
 		screen->BeginFrame();
@@ -689,6 +691,9 @@ void FStartScreen::Render(bool force)
 		screen->Update();
 		twod->OnFrameDone();
 	}
+	auto newtime = I_msTime();
+	if (newtime - nowtime > minwaittime) // slow down drawing the start screen if we're on a slow GPU!
+		minwaittime = (newtime - nowtime);
 }
 
 FImageSource* CreateStartScreenTexture(FBitmap& srcdata);

--- a/src/common/startscreen/startscreen.cpp
+++ b/src/common/startscreen/startscreen.cpp
@@ -692,8 +692,8 @@ void FStartScreen::Render(bool force)
 		twod->OnFrameDone();
 	}
 	auto newtime = I_msTime();
-	if (newtime - nowtime > minwaittime) // slow down drawing the start screen if we're on a slow GPU!
-		minwaittime = (newtime - nowtime);
+	if ((newtime - nowtime) * 2.0 > minwaittime) // slow down drawing the start screen if we're on a slow GPU!
+		minwaittime = (newtime - nowtime) * 2.0;
 }
 
 FImageSource* CreateStartScreenTexture(FBitmap& srcdata);


### PR DESCRIPTION
…e this can increase loading time significantly

I noticed this when using underpowered PC's to test GZDoom, but then I had a complaint from a mapper today and I had him test with "-nostartup" to see if his game loaded faster and sure enough the start screen was causing him problems. So this is an attempt to address that.

My preferred solution (that I already attempted and failed) was making the screen drawing asynchronous, however that did not work because it could only draw a single frame before it crashed. If there's any chance of recovering my efforts from that though, the attempt is here: https://github.com/madame-rachelle/gzdoom/tree/async_startscreen