### PR TITLE
Allow for Basic and Hexen Armor replacing

### DIFF
--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -436,7 +436,7 @@ static bool DoSubstitution (FString &out, const char *in)
 		{
 			if (strnicmp(a, "armor", 5) == 0)
 			{
-				auto armor = player->mo->FindInventory(NAME_BasicArmor);
+				auto armor = player->mo->FindInventory(NAME_BasicArmor, true);
 				out.AppendFormat("%d", armor != NULL ? armor->IntVar(NAME_Amount) : 0);
 			}
 		}

--- a/src/g_statusbar/sbarinfo.cpp
+++ b/src/g_statusbar/sbarinfo.cpp
@@ -1036,7 +1036,7 @@ public:
 		ammocount2 = ammo2 != nullptr ? ammo2->IntVar(NAME_Amount) : 0;
 
 		//prepare ammo counts
-		armor = CPlayer->mo->FindInventory(NAME_BasicArmor);
+		armor = CPlayer->mo->FindInventory(NAME_BasicArmor, true);
 	}
 
 	void _Draw (EHudState state)

--- a/src/g_statusbar/sbarinfo_commands.cpp
+++ b/src/g_statusbar/sbarinfo_commands.cpp
@@ -276,7 +276,7 @@ class CommandDrawImage : public SBarInfoCommandFlowControl
 			{
 				int armorType = type - HEXENARMOR_ARMOR;
 			
-				auto harmor = statusBar->CPlayer->mo->FindInventory(NAME_HexenArmor);
+				auto harmor = statusBar->CPlayer->mo->FindInventory(NAME_HexenArmor, true);
 				if (harmor != NULL)
 				{
 					double *Slots = (double*)harmor->ScriptVar(NAME_Slots, nullptr);
@@ -596,7 +596,7 @@ class CommandDrawSwitchableImage : public CommandDrawImage
 			}
 			else if(condition == ARMORTYPE)
 			{
-				auto armor = statusBar->CPlayer->mo->FindInventory(NAME_BasicArmor);
+				auto armor = statusBar->CPlayer->mo->FindInventory(NAME_BasicArmor, true);
 				if(armor != NULL)
 				{
 					auto n = armor->NameVar(NAME_ArmorType).GetIndex();
@@ -1413,7 +1413,7 @@ class CommandDrawNumber : public CommandDrawString
 				case SAVEPERCENT:
 				{
 					double add = 0;
-					auto harmor = statusBar->CPlayer->mo->FindInventory(NAME_HexenArmor);
+					auto harmor = statusBar->CPlayer->mo->FindInventory(NAME_HexenArmor, true);
 					if(harmor != NULL)
 					{
 						double *Slots = (double*)harmor->ScriptVar(NAME_Slots, nullptr);
@@ -2775,7 +2775,7 @@ class CommandDrawBar : public SBarInfoCommand
 				case SAVEPERCENT:
 				{
 					double add = 0;
-					auto harmor = statusBar->CPlayer->mo->FindInventory(NAME_HexenArmor);
+					auto harmor = statusBar->CPlayer->mo->FindInventory(NAME_HexenArmor, true);
 					if (harmor != NULL)
 					{
 						double *Slots = (double*)harmor->ScriptVar(NAME_Slots, nullptr);

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -5500,7 +5500,7 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, int32_t *args, int &
 			else
 			{
 				FName p(Level->Behaviors.LookupString(args[0]));
-				auto armor = Level->Players[args[1]]->mo->FindInventory(NAME_BasicArmor);
+				auto armor = Level->Players[args[1]]->mo->FindInventory(NAME_BasicArmor, true);
 				if (armor && armor->NameVar(NAME_ArmorType) == p) return armor->IntVar(NAME_Amount);
 			}
 			return 0;
@@ -5511,7 +5511,7 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, int32_t *args, int &
 		{
 			if (activator == NULL || activator->player == NULL) return 0;
 
-			auto equippedarmor = activator->FindInventory(NAME_BasicArmor);
+			auto equippedarmor = activator->FindInventory(NAME_BasicArmor, true);
 
 			if (equippedarmor && equippedarmor->IntVar(NAME_Amount) != 0)
 			{
@@ -8892,7 +8892,7 @@ scriptwait:
 		case PCD_PLAYERARMORPOINTS:
 			if (activator)
 			{
-				auto armor = activator->FindInventory(NAME_BasicArmor);
+				auto armor = activator->FindInventory(NAME_BasicArmor, true);
 				PushToStack (armor ? armor->IntVar(NAME_Amount) : 0);
 			}
 			else

--- a/wadsrc/static/zscript/actors/checks.zs
+++ b/wadsrc/static/zscript/actors/checks.zs
@@ -110,7 +110,7 @@ extend class Actor
 
 	bool CheckArmorType(name Type, int amount = 1)
 	{
-		let myarmor = BasicArmor(FindInventory("BasicArmor"));
+		let myarmor = BasicArmor(FindInventory("BasicArmor", true));
 		return myarmor != null && myarmor.ArmorType == type && myarmor.Amount >= amount;
 	}
 

--- a/wadsrc/static/zscript/actors/hexen/boostarmor.zs
+++ b/wadsrc/static/zscript/actors/hexen/boostarmor.zs
@@ -32,7 +32,7 @@ class ArtiBoostArmor : Inventory
 
 			for (int i = 0; i < 4; ++i)
 			{
-				armor = HexenArmor(Spawn("HexenArmor"));
+				armor = HexenArmor(Spawn(GetArmorReplacement("HexenArmor")));
 				armor.bDropped = true;
 				armor.health = i;
 				armor.Amount = 1;

--- a/wadsrc/static/zscript/actors/hexen/healingradius.zs
+++ b/wadsrc/static/zscript/actors/hexen/healingradius.zs
@@ -51,7 +51,7 @@ class ArtiHealingRadius : Inventory
 				case 'Armor':
 					for (int j = 0; j < 4; ++j)
 					{
-						HexenArmor armor = HexenArmor(Spawn("HexenArmor"));
+						HexenArmor armor = HexenArmor(Spawn(GetArmorReplacement("HexenArmor")));
 						armor.health = j;
 						armor.Amount = 1;
 						if (!armor.CallTryPickup (mo))

--- a/wadsrc/static/zscript/actors/inventory/armor.zs
+++ b/wadsrc/static/zscript/actors/inventory/armor.zs
@@ -106,7 +106,7 @@ class BasicArmor : Armor
 	{
 		// BasicArmor that is in use is stored in the inventory as BasicArmor.
 		// BasicArmor that is in reserve is not.
-		let copy = BasicArmor(Spawn("BasicArmor"));
+		let copy = BasicArmor(Spawn(GetArmorReplacement("BasicArmor")));
 		copy.SavePercent = SavePercent != 0 ? SavePercent : 0.33335;	// slightly more than 1/3 to avoid roundoff errors.
 		copy.Amount = Amount;
 		copy.MaxAmount = MaxAmount;
@@ -127,7 +127,7 @@ class BasicArmor : Armor
 
 	override bool HandlePickup (Inventory item)
 	{
-		if (item.GetClass() == "BasicArmor")
+		if (item is "BasicArmor")
 		{
 			// You shouldn't be picking up BasicArmor anyway.
 			return true;
@@ -271,13 +271,13 @@ class BasicArmorBonus : Armor
 
 	override bool Use (bool pickup)
 	{
-		let armor = BasicArmor(Owner.FindInventory("BasicArmor"));
+		let armor = BasicArmor(Owner.FindInventory("BasicArmor", true));
 		bool result = false;
 
 		// This should really never happen but let's be prepared for a broken inventory.
 		if (armor == null)
 		{
-			armor = BasicArmor(Spawn("BasicArmor"));
+			armor = BasicArmor(Spawn(GetArmorReplacement("BasicArmor")));
 			armor.BecomeItem ();
 			armor.Amount = 0;
 			armor.MaxAmount = MaxSaveAmount;
@@ -391,12 +391,12 @@ class BasicArmorPickup : Armor
 	override bool Use (bool pickup)
 	{
 		int SaveAmount = GetSaveAmount();
-		let armor = BasicArmor(Owner.FindInventory("BasicArmor"));
+		let armor = BasicArmor(Owner.FindInventory("BasicArmor", true));
 
 		// This should really never happen but let's be prepared for a broken inventory.
 		if (armor == null)
 		{
-			armor = BasicArmor(Spawn("BasicArmor"));
+			armor = BasicArmor(Spawn(GetArmorReplacement("BasicArmor")));
 			armor.BecomeItem ();
 			Owner.AddInventory (armor);
 		}
@@ -471,7 +471,7 @@ class HexenArmor : Armor
 		// Like BasicArmor, HexenArmor is used in the inventory but not the map.
 		// health is the slot this armor occupies.
 		// Amount is the quantity to give (0 = normal max).
-		let copy = HexenArmor(Spawn("HexenArmor"));
+		let copy = HexenArmor(Spawn(GetArmorReplacement("HexenArmor")));
 		copy.AddArmorToSlot (health, Amount);
 		GoAwayAndDie ();
 		return copy;

--- a/wadsrc/static/zscript/actors/inventory_util.zs
+++ b/wadsrc/static/zscript/actors/inventory_util.zs
@@ -855,8 +855,15 @@ extend class Actor
 		}
 	}
 
+	clearscope static class<Armor> GetArmorReplacement(class<Armor> type)
+	{
+		class<Armor> replacement = (class<Armor>)(GetReplacement(type));
+		// The replacement must be a type of the base type so it can
+		// suitably replace its functionality.
+		if (replacement is type)
+			return replacement;
 
-
-
+		return type;
+	}
 
 }

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -1897,8 +1897,8 @@ class PlayerPawn : Actor
 		// it provides player class based protection that should not affect
 		// any other protection item.
 		let myclass = GetClass();
-		GiveInventoryType('HexenArmor');
-		let harmor = HexenArmor(FindInventory('HexenArmor'));
+		GiveInventoryType(GetArmorReplacement("HexenArmor"));
+		let harmor = HexenArmor(FindInventory('HexenArmor', true));
 
 		harmor.Slots[4] = self.HexenArmor[0];
 		for (int i = 0; i < 4; ++i)
@@ -1909,7 +1909,7 @@ class PlayerPawn : Actor
 		// BasicArmor must come right after that. It should not affect any
 		// other protection item as well but needs to process the damage
 		// before the HexenArmor does.
-		GiveInventoryType('BasicArmor');
+		GiveInventoryType(GetArmorReplacement("BasicArmor"));
 
 		// Now add the items from the DECORATE definition
 		let di = GetDropItems();

--- a/wadsrc/static/zscript/actors/player/player_cheat.zs
+++ b/wadsrc/static/zscript/actors/player/player_cheat.zs
@@ -139,7 +139,7 @@ extend class PlayerPawn
 			{
 				for (i = 0; i < 4; ++i)
 				{
-					let armoritem = Inventory(Spawn("HexenArmor"));
+					let armoritem = Inventory(Spawn(GetArmorReplacement("HexenArmor")));
 					armoritem.health = i;
 					armoritem.Amount = 0;
 					if (!armoritem.CallTryPickup (self))

--- a/wadsrc/static/zscript/actors/player/player_morph.zs
+++ b/wadsrc/static/zscript/actors/player/player_morph.zs
@@ -352,7 +352,7 @@ extend class PlayerPawn
 		}
 
 		// Reset the base AC of the player's Hexen armor back to its default.
-		let hexArmor = HexenArmor(alt.FindInventory("HexenArmor"));
+		let hexArmor = HexenArmor(alt.FindInventory("HexenArmor", true));
 		if (hexArmor)
 			hexArmor.Slots[4] = alt.HexenArmor[0];
 

--- a/wadsrc/static/zscript/scriptutil/scriptutil.zs
+++ b/wadsrc/static/zscript/scriptutil/scriptutil.zs
@@ -61,7 +61,7 @@ class ScriptUtil play
 		}
 		if (type == 'Armor')
 		{
-			type = "BasicArmor";
+			type = Actor.GetArmorReplacement("BasicArmor").GetClassName();
 		}
 		if (amount <= 0)
 		{

--- a/wadsrc/static/zscript/ui/statusbar/alt_hud.zs
+++ b/wadsrc/static/zscript/ui/statusbar/alt_hud.zs
@@ -930,7 +930,7 @@ class AltHud ui
 		int armory = hud_swaphealtharmor ? hudheight-45 : hudheight-20;
 		int healthy = hud_swaphealtharmor ? hudheight-20 : hudheight-45;
 		DrawHealth(CPlayer, 5, healthy);
-		DrawArmor(BasicArmor(CPlayer.mo.FindInventory('BasicArmor')), HexenArmor(CPlayer.mo.FindInventory('HexenArmor')), 5, armory);
+		DrawArmor(BasicArmor(CPlayer.mo.FindInventory('BasicArmor', true)), HexenArmor(CPlayer.mo.FindInventory('HexenArmor', true)), 5, armory);
 
 		int y = DrawKeys(CPlayer, hudwidth-4, hudheight-10);
 		y = DrawAmmo(CPlayer, hudwidth-5, y);

--- a/wadsrc/static/zscript/ui/statusbar/doom_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/doom_sbar.zs
@@ -146,7 +146,7 @@ class DoomStatusBar : BaseStatusBar
 		DrawImage(berserk? "PSTRA0" : "MEDIA0", (20, -2));
 		DrawString(mHUDFont, FormatNumber(CPlayer.health, 3), (44, -20));
 		
-		let armor = CPlayer.mo.FindInventory("BasicArmor");
+		let armor = CPlayer.mo.FindInventory("BasicArmor", true);
 		if (armor != null && armor.Amount > 0)
 		{
 			DrawInventoryIcon(armor, (20, -22));

--- a/wadsrc/static/zscript/ui/statusbar/heretic_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/heretic_sbar.zs
@@ -148,7 +148,7 @@ class HereticStatusBar : BaseStatusBar
 		DrawString(mBigFont, FormatNumber(mHealthInterpolator.GetValue()), (41, -21), DI_TEXT_ALIGN_RIGHT);
 
 		//armor
-		let armor = CPlayer.mo.FindInventory("BasicArmor");
+		let armor = CPlayer.mo.FindInventory("BasicArmor", true);
 		if (armor != null && armor.Amount > 0)
 		{
 			DrawInventoryIcon(armor, (58, -24));

--- a/wadsrc/static/zscript/ui/statusbar/statusbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/statusbar.zs
@@ -430,7 +430,7 @@ class BaseStatusBar : StatusBarCore native
 	
 	int GetArmorAmount()
 	{
-		let armor = CPlayer.mo.FindInventory("BasicArmor");
+		let armor = CPlayer.mo.FindInventory("BasicArmor", true);
 		return armor? armor.Amount : 0;
 	}
 	
@@ -451,13 +451,13 @@ class BaseStatusBar : StatusBarCore native
 	int GetArmorSavePercent()
 	{
 		double add = 0;
-		let harmor = HexenArmor(CPlayer.mo.FindInventory("HexenArmor"));
+		let harmor = HexenArmor(CPlayer.mo.FindInventory("HexenArmor", true));
 		if(harmor != NULL)
 		{
 			add = harmor.Slots[0] + harmor.Slots[1] + harmor.Slots[2] + harmor.Slots[3] + harmor.Slots[4];
 		}
 		//Hexen counts basic armor also so we should too.
-		let armor = BasicArmor(CPlayer.mo.FindInventory("BasicArmor"));
+		let armor = BasicArmor(CPlayer.mo.FindInventory("BasicArmor", true));
 		if(armor != NULL && armor.Amount > 0)
 		{
 			add += armor.SavePercent * 100;
@@ -771,7 +771,7 @@ class BaseStatusBar : StatusBarCore native
 
 	void DrawHexenArmor(int armortype, String image, Vector2 pos, int flags = 0, double alpha = 1.0, Vector2 boxsize = (-1, -1), Vector2 scale = (1.,1.))
 	{
-		let harmor = HexenArmor(statusBar.CPlayer.mo.FindInventory("HexenArmor"));
+		let harmor = HexenArmor(statusBar.CPlayer.mo.FindInventory("HexenArmor", true));
 		if (harmor != NULL)
 		{
 			let slotval = harmor.Slots[armorType];

--- a/wadsrc/static/zscript/ui/statusbar/strife_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/strife_sbar.zs
@@ -287,7 +287,7 @@ class StrifeStatusBar : BaseStatusBar
 		DrawHealthBar (points, 49, 175);
 
 		// Armor
-		item = CPlayer.mo.FindInventory('BasicArmor');
+		item = CPlayer.mo.FindInventory('BasicArmor', true);
 		if (item != NULL && item.Amount > 0)
 		{
 			DrawInventoryIcon(item, (2, 177), DI_ITEM_OFFSETS);
@@ -333,7 +333,7 @@ class StrifeStatusBar : BaseStatusBar
 		DrawImage("I_MDKT", (14, -17));
 
 		// Draw armor
-		let armor = CPlayer.mo.FindInventory('BasicArmor');
+		let armor = CPlayer.mo.FindInventory('BasicArmor', true);
 		if (armor != NULL && armor.Amount != 0)
 		{
 			DrawString(mYelFont, FormatNumber(armor.Amount, 3), (35, -10));


### PR DESCRIPTION
These two have been largely untouchable for a while which makes setting up custom armor handling an absolute nightmare. Now they can be safely replaced as their replacements are verified that they're of the same type as their parents (e.g. something replacing `BasicArmor` must inherit from `BasicArmor`). If not, it falls back to the default classes.