### PR TITLE
validate voxel file size before reading it

### DIFF
--- a/src/common/models/voxels.cpp
+++ b/src/common/models/voxels.cpp
@@ -164,6 +164,7 @@ FVoxel *R_LoadKVX(int lumpnum)
 	auto lump =  fileSystem.ReadFile(lumpnum);	// FileData adds an extra 0 byte to the end.
 	auto rawvoxel = lump.bytes();
 	int voxelsize = (int)(lump.size());
+	if (voxelsize <= 768 + 4) return nullptr;
 
 	// Oh, KVX, why couldn't you have a proper header? We'll just go through
 	// and collect each MIP level, doing lots of range checking, and if the


### PR DESCRIPTION
Old code read from the loaded data without ever checking if the file is too small.
This rejects everything below 772 bytes which is one 32 bit index plus the palette.

Fixes #2488