### PR TITLE
fix bad assert in GetStateLabelIndex.

### DIFF
--- a/src/p_states.cpp
+++ b/src/p_states.cpp
@@ -506,8 +506,10 @@ int FStateDefinitions::GetStateLabelIndex (FName statename)
 	{
 		return -1;
 	}
-	assert((size_t)std->State <= StateArray.Size() + 1);
-	return (int)((ptrdiff_t)std->State - 1);
+	if ((size_t)std->State <= StateArray.Size() + 1)
+		return (int)((ptrdiff_t)std->State - 1);
+	else
+		return -1;
 }
 
 //==========================================================================


### PR DESCRIPTION
This function only gets used for validating 'nodelay', but in debug mode this assert always gets triggered if the nodelay flag is put on a later state - at this point the spawn state's address has already been resolved. This PR treats all such occurences as invalid which allows the calling code to print its warning