### PR TITLE
Fix mouse cursor randomly becoming invisible outside gzdoom

### DIFF
--- a/src/common/platform/win32/i_input.cpp
+++ b/src/common/platform/win32/i_input.cpp
@@ -110,6 +110,8 @@ EXTERN_CVAR (Bool, use_mouse)
 static int WheelDelta;
 extern bool CursorState;
 
+void SetCursorState(bool visible);
+
 extern BOOL paused;
 static bool noidle = false;
 
@@ -415,7 +417,7 @@ LRESULT CALLBACK WndProc (HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	case WM_SETCURSOR:
 		if (!CursorState)
 		{
-			SetCursor(NULL); // turn off window cursor
+			SetCursorState(false); // turn off window cursor
 			return TRUE;	// Prevent Windows from setting cursor to window class cursor
 		}
 		else

--- a/src/common/platform/win32/i_mouse.cpp
+++ b/src/common/platform/win32/i_mouse.cpp
@@ -297,6 +297,12 @@ void I_CheckNativeMouse(bool preferNative, bool eventhandlerresult)
 			{
 				BlockMouseMove = 3;
 				Mouse->Ungrab();
+
+				if(!mouse_shown)
+				{
+					ShowCursor(true);
+					mouse_shown = true;
+				}
 			}
 			else
 			{

--- a/src/common/platform/win32/i_mouse.cpp
+++ b/src/common/platform/win32/i_mouse.cpp
@@ -131,7 +131,7 @@ enum EMouseMode
 
 // PRIVATE FUNCTION PROTOTYPES ---------------------------------------------
 
-static void SetCursorState(bool visible);
+void SetCursorState(bool visible);
 static FMouse *CreateWin32Mouse();
 static FMouse *CreateDInputMouse();
 static FMouse *CreateRawMouse();
@@ -191,7 +191,7 @@ CUSTOM_CVAR (Int, in_mouse, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL)
 
 static bool mouse_shown = true;
 
-static void SetCursorState(bool visible)
+void SetCursorState(bool visible)
 {
 	CursorState = visible || !m_hidepointer;
 	if (GetForegroundWindow() == mainwindow.GetHandle())


### PR DESCRIPTION
SetCursor was being used directly for WM_SETCURSOR, so it wheneverly broke the cursor un-hiding