### PR TITLE
Add crash log file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 /build_vc2019-64
 /build_vc2019-32
 /build__
+gzdoom-crash.log


### PR DESCRIPTION
This prevents accidentally committing this file if you run into a crash while working on something.
