### PR TITLE
Various fixes for spawn farthest deathmatch option

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1606,10 +1606,20 @@ void FLevelLocals::DeathMatchSpawnPlayer (int playernum)
 	if (selections < 1)
 		I_Error ("No deathmatch starts");
 
+	bool hasSpawned = false;
+	for (int i = 0; i < MAXPLAYERS; ++i)
+	{
+		if (PlayerInGame(i) && Players[i]->mo != nullptr && Players[i]->health > 0)
+		{
+			hasSpawned = true;
+			break;
+		}
+	}
+
 	// At level start, none of the players have mobjs attached to them,
 	// so we always use the random deathmatch spawn. During the game,
 	// though, we use whatever dmflags specifies.
-	if ((dmflags & DF_SPAWN_FARTHEST) && players[playernum].mo)
+	if ((dmflags & DF_SPAWN_FARTHEST) && hasSpawned)
 		spot = SelectFarthestDeathmatchSpot (selections);
 	else
 		spot = SelectRandomDeathmatchSpot (playernum, selections);


### PR DESCRIPTION
This option normally tries to spawn players as far from each other as possible but has a few oversights. Mainly, the first spawn of the match won't take sequential player spawning into account (every player will get a random spawn which leads to things like telefragging). Another bug was fixed where if every other player was dead when trying to respawn, it would fail to pick a valid spawn spot (it now opts to pick a random one in this case). This isn't super common in larger games but in a duel is much more likely to happen.

At some point I'd like to add better telefrag prevention support but that will require some deeper additions to the DM spawn system to achieve.