### PR TITLE
ApplyAirControl - virtualize aircontrol effect

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -1251,6 +1251,12 @@ class PlayerPawn : Actor
 		return forward, side;
 	}
 
+	virtual void ApplyAirControl(out double movefactor, out double bobfactor)
+	{
+		movefactor *= level.aircontrol;
+		bobfactor *= level.aircontrol;
+	}
+
 	//----------------------------------------------------------------------------
 	//
 	// PROC P_MovePlayer
@@ -1294,8 +1300,8 @@ class PlayerPawn : Actor
 			if (!player.onground && !bNoGravity && !waterlevel)
 			{
 				// [RH] allow very limited movement if not on ground.
-				movefactor *= level.aircontrol;
-				bobfactor*= level.aircontrol;
+				// [AA] but also allow authors to override it.
+				ApplyAirControl(movefactor, bobfactor);
 			}
 
 			fm = cmd.forwardmove;


### PR DESCRIPTION
Application of air control moved to a new virtual `ApplyAirControl` for easier control by authors using custom player pawns.