### PR TITLE
Fix for certain client-side items not behaving as expected

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -414,7 +414,10 @@ class Inventory : Actor
 	{
 		Inventory copy;
 
-		Amount = MIN(Amount, MaxAmount);
+		// Clamping this on local copy creation presents too many possible
+		// pitfalls (e.g. Health items).
+		if (!IsCreatingLocalCopy())
+			Amount = MIN(Amount, MaxAmount);
 		if (GoAway ())
 		{
 			copy = Inventory(Spawn (GetClass()));
@@ -1046,7 +1049,7 @@ class Inventory : Actor
 
 	protected bool GoAway ()
 	{
-		if (bCreatingCopy)
+		if (IsCreatingLocalCopy())
 			return true;
 
 		// Dropped items never stick around
@@ -1129,6 +1132,11 @@ class Inventory : Actor
 		bCreatingCopy = false;
 
 		return item;
+	}
+
+	protected clearscope bool IsCreatingLocalCopy() const
+	{
+		return bCreatingCopy;
 	}
 	
 	//===========================================================================


### PR DESCRIPTION
It seems clamping the `Amount` in `CreateCopy()` presents issues with `Health` items in particular since their `MaxAmount` serves an entirely different purpose. I have no idea if this behavior is intended as it not only bricks the copy but the original item itself. The existing respawn behavior got around this problem by outright replacing all the `TryPickup()` code. This could possibly be a problem for anyone trying to legitimately use this function but thankfully `CreateLocalCopy()` should now cover this edge case and changing it directly could have way too many possible side effects.