### PR TITLE
Added ShouldShareItem() virtual

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inv_misc.zs
+++ b/wadsrc/static/zscript/actors/inventory/inv_misc.zs
@@ -43,6 +43,11 @@ class Key : Inventory
 	static native clearscope Color GetMapColorForKey(Key key);
 	static native clearscope int GetKeyTypeCount();
 	static native clearscope class<Key> GetKeyType(int index);
+
+	override bool ShouldShareItem(Actor giver)
+	{
+		return sv_coopsharekeys;
+	}
 	
 	override bool HandlePickup (Inventory item)
 	{
@@ -112,6 +117,11 @@ class PuzzleItem : Inventory
 		Inventory.PickupSound "misc/i_pkup";
 		PuzzleItem.FailMessage("$TXT_USEPUZZLEFAILED");
 		PuzzleItem.FailSound "*puzzfail";
+	}
+
+	override bool ShouldShareItem(Actor giver)
+	{
+		return sv_coopsharekeys;
 	}
 	
 	override bool HandlePickup (Inventory item)

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -261,6 +261,11 @@ class Inventory : Actor
 		}
 	}
 
+	virtual bool ShouldShareItem(Actor giver)
+	{
+		return false;
+	}
+
 	protected void ShareItemWithPlayers(Actor giver)
 	{
 		if (bSharingItem)
@@ -695,7 +700,7 @@ class Inventory : Actor
 			toucher.HasReceived(self);
 
 			// If the item can be shared, make sure every player gets a copy.
-			if (multiplayer && !deathmatch && sv_coopsharekeys && bIsKeyItem)
+			if (multiplayer && !deathmatch && ShouldShareItem(toucher))
 				ShareItemWithPlayers(toucher);
 		}
 		return res, toucher;


### PR DESCRIPTION
Allows for easier customizing of whether or not an item should be shared with players upon pickup in co-op (e.g. it allows it to be expanded to weapons with custom cvars or removed from specific key items).