### PR TITLE
Fixes for client network IDs

### DIFF
--- a/src/common/objects/dobject.cpp
+++ b/src/common/objects/dobject.cpp
@@ -637,10 +637,11 @@ void NetworkEntityManager::InitializeNetworkEntities()
 }
 
 // Clients need special handling since they always go in slots 1 - MAXPLAYERS.
-void NetworkEntityManager::SetClientNetworkEntity(DObject* mo, const uint32_t id)
+void NetworkEntityManager::SetClientNetworkEntity(DObject* mo, const unsigned int playNum)
 {
 	// If resurrecting, we need to swap the corpse's position with the new pawn's
 	// position so it's no longer considered the client's body.
+	const uint32_t id = ClientNetIDStart + playNum;
 	DObject* const oldBody = s_netEntities[id];
 	if (oldBody != nullptr)
 	{

--- a/src/common/objects/dobject.h
+++ b/src/common/objects/dobject.h
@@ -502,7 +502,7 @@ public:
 	inline static uint32_t NetIDStart;// = MAXPLAYERS + 1u;
 
 	static void InitializeNetworkEntities();
-	static void SetClientNetworkEntity(DObject* mo, const uint32_t id);
+	static void SetClientNetworkEntity(DObject* mo, const unsigned int playNum);
 	static void AddNetworkEntity(DObject* const ent);
 	static void RemoveNetworkEntity(DObject* const ent);
 	static DObject* GetNetworkEntity(const uint32_t id);

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -5384,6 +5384,10 @@ int MorphPointerSubstitution(AActor* from, AActor* to)
 	{
 		to->player = from->player;
 		from->player = nullptr;
+
+		// Swap the new body into the right network slot if it's a client (this doesn't
+		// really matter for regular Actors since they grab any ID they can get anyway).
+		NetworkEntityManager::SetClientNetworkEntity(to, to->player - players);
 	}
 
 	if (from->alternative != nullptr)


### PR DESCRIPTION
Fixed an off-by-one error on client IDs (these need to start at 1 as 0 is an invalid network ID). Morphing will now swap the client body's ID so it remains in the first 1 - MAXPLAYERS slots.