### PR TITLE
Interpolation fix for clientside prediction

### DIFF
--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1481,6 +1481,8 @@ void P_PredictPlayer (player_t *player)
 			R_RebuildViewInterpolation(player);
 
 		player->cmd = localcmds[i % LOCALCMDTICS];
+		player->mo->ClearInterpolation();
+		player->mo->ClearFOVInterpolation();
 		P_PlayerThink (player);
 		player->mo->Tick ();
 


### PR DESCRIPTION
This is a minor fix for interpolation when playing online as predicted movement was not properly having its prev data reset like a real tick would be. This resulted in jittery player sprites in third person.

Note that this isn't a complete fix for this behavior. I still suspect that an extra predicted movement step is occurring on real ticks since the automap both reveals some hidden behavior (this should not be jittery in the slightest when playing via localhost) and when playing on high latency the movement always seems to be slightly out of sync with where the player actually is (which is revealed by no longer moving and letting the position fully reset so it updates in the main viewport).