### PR TITLE
Fixed incorrect automap arrow position in multiplayer

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -2880,7 +2880,8 @@ void DAutomap::drawPlayers ()
 
 		if (p->mo != nullptr)
 		{
-			DVector3 pos = p->mo->PosRelative(MapPortalGroup);
+			DVector2 pos = p->mo->InterpolatedPosition(r_viewpoint.TicFrac).XY();
+			pos += Level->Displacements.getOffset(Level->PointInSector(pos)->PortalGroup, MapPortalGroup);
 			pt.x = pos.X;
 			pt.y = pos.Y;
 


### PR DESCRIPTION
This caused the player arrows to update at only 35Hz and for the console player's arrow it would lag behind when following.