### PR TITLE
View fixes when predicting

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3662,10 +3662,6 @@ void AActor::SetViewAngle(DAngle ang, int fflags)
 
 double AActor::GetFOV(double ticFrac)
 {
-	// [B] Disable interpolation when playing online, otherwise it gets vomit inducing
-	if (netgame)
-		return player ? player->FOV : CameraFOV;
-
 	double fov;
 	if (player)
 	{


### PR DESCRIPTION
View interpolation paths are now reset properly when predicting, fixing portals. Teleporters disabling view interpolation is now handled before every movement instead of only once at the start of predicting. Enabled FoV interpolation when playing online.