### PR TITLE
Player spawn fix in co-op new games

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1478,7 +1478,7 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 		for (int i = 0; i<MAXPLAYERS; i++)
 		{
 			if (PlayerInGame(i) && Players[i]->mo != nullptr)
-				P_PlayerStartStomp(Players[i]->mo);
+				P_PlayerStartStomp(Players[i]->mo, !deathmatch);
 		}
 	}
 

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -504,6 +504,18 @@ void P_SetupLevel(FLevelLocals *Level, int position, bool newGame)
 			}
 		}
 	}
+	else if (newGame)
+	{
+		for (i = 0; i < MAXPLAYERS; ++i)
+		{
+			// Didn't have a player spawn available so spawn it now.
+			if (Level->PlayerInGame(i) && Level->Players[i]->playerstate == PST_ENTER && Level->Players[i]->mo == nullptr)
+			{
+				FPlayerStart* mthing = Level->PickPlayerStart(i);
+				Level->SpawnPlayer(mthing, i, (Level->flags2 & LEVEL2_PRERAISEWEAPON) ? SPF_WEAPONFULLYUP : 0);
+			}
+		}
+	}
 
 	// [SP] move unfriendly players around
 	// horribly hacky - yes, this needs rewritten.


### PR DESCRIPTION
If there aren't enough player spawns present in co-op, the game will instead fail to spawn extra players, waiting for the ticker to automatically capture the fact they have PST_ENTER. This presents a problem in WorldLoaded() where it becomes unreliable whether or not a player has truly spawned. This also means those extra players had slightly different spawn behavior compared to regular pawns.