### PR TITLE
Fixed weapon slots not resetting on unmorph

### DIFF
--- a/wadsrc/static/zscript/actors/player/player_morph.zs
+++ b/wadsrc/static/zscript/actors/player/player_morph.zs
@@ -323,6 +323,7 @@ extend class PlayerPawn
 		if (level2)
 			level2.Destroy();
 
+		WeaponSlots.SetupWeaponSlots(alt);
 		let morphWeap = p.ReadyWeapon;
 		if (premorphWeap)
 		{


### PR DESCRIPTION
Important for any morphed pawns that set custom weapon slots.