### PR TITLE
Reworked client network state handling

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1402,6 +1402,8 @@ void FLevelLocals::PlayerReborn (int player)
 	chasecam = p->cheats & CF_CHASECAM;
 	Bot = p->Bot;			//Added by MC:
 	const bool settings_controller = p->settings_controller;
+	const int clientState = p->ClientState;
+	const int clientTic = p->ClientTic;
 
 	// Reset player structure to its defaults
 	p->~player_t();
@@ -1421,6 +1423,8 @@ void FLevelLocals::PlayerReborn (int player)
 	p->cheats |= chasecam;
 	p->Bot = Bot;			//Added by MC:
 	p->settings_controller = settings_controller;
+	p->ClientState = clientState;
+	p->ClientTic = clientTic;
 
 	p->oldbuttons = ~0, p->attackdown = true; p->usedown = true;	// don't do anything immediately
 	p->original_oldbuttons = ~0;

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -494,6 +494,8 @@ void G_NewInit ()
 		p->settings_controller = settings_controller;
 		p->cheats |= chasecam;
 		p->playerstate = PST_DEAD;
+		p->ClientState = CS_NONE;
+		p->ClientTic = 0;
 		p->userinfo.TransferFrom(saved_ui);
 		playeringame[i] = false;
 	}

--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -120,7 +120,7 @@ typedef enum
 	CF_FRIGHTENING		= 1 << 10,		// [RH] Scare monsters away
 	CF_INSTANTWEAPSWITCH= 1 << 11,		// [RH] Switch weapons instantly
 	CF_TOTALLYFROZEN	= 1 << 12,		// [RH] All players can do is press +use
-	CF_PREDICTING		= 1 << 13,		// [RH] Player movement is being predicted
+	CF_PREDICTING		= 1 << 13,		// Deprecated. See CS_PREDICTING.
 	CF_INTERPVIEW		= 1 << 14,		// [RH] view was changed outside of input, so interpolate one frame
 	CF_INTERPVIEWANGLES	= 1 << 15,		// [MR] flag for interpolating view angles without interpolating the entire frame
 	CF_NOFOVINTERP		= 1 << 16,		// [B] Disable FOV interpolation when instantly zooming
@@ -132,6 +132,18 @@ typedef enum
 	CF_BUDDHA			= 1 << 27,		// [SP] Buddha mode - take damage, but don't die
 	CF_NOCLIP2			= 1 << 30,		// [RH] More Quake-like noclip
 } cheat_t;
+
+typedef enum
+{
+	CS_NONE = 0,
+	CS_PREDICTING = 1,			// Client is currently predicting movement (unconfirmed position).
+	CS_LATEST_TICK = 1 << 1,	// Client is on the latest tick taking prediction into account.
+	CS_RUBBERBANDING = 1 << 2,	// Client's misprediction is being corrected.
+	//CS_CONNECTING		= 1 << 3,	// Client is joining the game.
+	//CS_DISCONNECTING	= 1 << 4,	// Client is leaving the game.
+
+	CS_PREDICTION_STATE = CS_PREDICTING | CS_LATEST_TICK | CS_RUBBERBANDING,
+} clientstate_t;
 
 enum
 {
@@ -305,6 +317,8 @@ public:
 
 	AActor *mo = nullptr;
 	uint8_t		playerstate = 0;
+	int			ClientState = CS_NONE;	// What networking state is the client currently in? This is intentionally unserialized.
+	int			ClientTic = 0;			// Gets the current simulated tick. Unserialized like above.
 	ticcmd_t	cmd = {};
 	usercmd_t	original_cmd;
 	uint32_t		original_oldbuttons;
@@ -491,7 +505,7 @@ inline bool AActor::IsNoClip2() const
 }
 
 bool P_IsPlayerTotallyFrozen(const player_t *player);
-
+int IsPredicting(AActor* self);
 bool P_NoInterpolation(player_t const *player, AActor const *actor);
 
 #endif // __D_PLAYER_H__

--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -505,7 +505,12 @@ inline bool AActor::IsNoClip2() const
 }
 
 bool P_IsPlayerTotallyFrozen(const player_t *player);
-int IsPredicting(AActor* self);
+
 bool P_NoInterpolation(player_t const *player, AActor const *actor);
+
+inline int IsPredicting(AActor* self)
+{
+	return self->player != nullptr && self->player->mo == self && (self->player->ClientState & CS_PREDICTING);
+}
 
 #endif // __D_PLAYER_H__

--- a/src/playsim/p_3dfloors.cpp
+++ b/src/playsim/p_3dfloors.cpp
@@ -244,7 +244,7 @@ void P_PlayerOnSpecial3DFloor(player_t* player)
 //==========================================================================
 bool P_CheckFor3DFloorHit(AActor * mo, double z, bool trigger)
 {
-	if ((mo->player && (mo->player->cheats & CF_PREDICTING))) return false;
+	if (IsPredicting(mo)) return false;
 
 	for (auto rover : mo->Sector->e->XFloor.ffloors)
 	{
@@ -272,7 +272,7 @@ bool P_CheckFor3DFloorHit(AActor * mo, double z, bool trigger)
 //==========================================================================
 bool P_CheckFor3DCeilingHit(AActor * mo, double z, bool trigger)
 {
-	if ((mo->player && (mo->player->cheats & CF_PREDICTING))) return false;
+	if (IsPredicting(mo)) return false;
 
 	for (auto rover : mo->Sector->e->XFloor.ffloors)
 	{

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -555,7 +555,7 @@ bool	P_TeleportMove(AActor* thing, const DVector3 &pos, bool telefrag, bool modi
 		if ((StompAlwaysFrags && !(th->flags6 & MF6_NOTELEFRAG)) || (th->flags7 & MF7_ALWAYSTELEFRAG))
 		{
 			// Don't actually damage if predicting a teleport
-			if (thing->player == NULL || !(thing->player->cheats & CF_PREDICTING))
+			if (!IsPredicting(thing))
 				P_DamageMobj(th, thing, thing, TELEFRAG_DAMAGE, NAME_Telefrag, DMG_THRUSTLESS);
 			continue;
 		}
@@ -1502,7 +1502,7 @@ bool PIT_CheckThing(FMultiBlockThingsIterator &it, FMultiBlockThingsIterator::Ch
 	}
 
 
-	if (tm.thing->player == NULL || !(tm.thing->player->cheats & CF_PREDICTING))
+	if (!IsPredicting(tm.thing))
 	{
 		// touchy object is alive, toucher is solid
 		if (thing->flags6 & MF6_TOUCHY && tm.thing->flags & MF_SOLID && thing->health > 0 &&
@@ -1545,7 +1545,7 @@ bool PIT_CheckThing(FMultiBlockThingsIterator &it, FMultiBlockThingsIterator::Ch
 	}
 
 	// [ED850] Player Prediction ends here. There is nothing else they could/should do.
-	if (tm.thing->player != NULL && (tm.thing->player->cheats & CF_PREDICTING))
+	if (IsPredicting(tm.thing))
 	{
 		solid = (thing->flags & MF_SOLID) &&
 			!(thing->flags & MF_NOCLIP) &&
@@ -2068,7 +2068,7 @@ AActor *P_CheckOnmobj(AActor *thing)
 
 	// Make sure we don't double call a collision with it.
 	if (!good && onmobj != nullptr && onmobj != thing->BlockingMobj
-		&& (thing->player == nullptr || !(thing->player->cheats & CF_PREDICTING)))
+		&& !IsPredicting(thing))
 	{
 		P_CollidedWith(thing, onmobj);
 	}
@@ -2317,7 +2317,7 @@ bool P_TryMove(AActor *thing, const DVector2 &pos,
 		AActor *BlockingMobj = thing->BlockingMobj;
 		// This gets called regardless of whether or not the following checks allow the thing to pass. This is because a player
 		// could step on top of an enemy but we still want it to register as a collision.
-		if (BlockingMobj != nullptr && (thing->player == nullptr || !(thing->player->cheats & CF_PREDICTING)))
+		if (BlockingMobj != nullptr && !IsPredicting(thing))
 			P_CollidedWith(thing, BlockingMobj);
 
 		// Solid wall or thing
@@ -2598,7 +2598,7 @@ bool P_TryMove(AActor *thing, const DVector2 &pos,
 				thing->SetXYZ(thingpos.X, thingpos.Y, pos.Z);
 				if (!P_CheckPosition(thing, pos.XY(), true))	// check if some actor blocks us on the other side. (No line checks, because of the mess that'd create.)
 				{
-					if (thing->BlockingMobj != nullptr && (thing->player == nullptr || !(thing->player->cheats && CF_PREDICTING)))
+					if (thing->BlockingMobj != nullptr && !IsPredicting(thing))
 						P_CollidedWith(thing, thing->BlockingMobj);
 
 					thing->SetXYZ(oldthingpos);
@@ -2690,7 +2690,7 @@ bool P_TryMove(AActor *thing, const DVector2 &pos,
 			oldside = P_PointOnLineSide(spec.Oldrefpos, ld);
 			if (side != oldside && ld->special && !(thing->flags6 & MF6_NOTRIGGER))
 			{
-				if (thing->player && (thing->player->cheats & CF_PREDICTING))
+				if (IsPredicting(thing))
 				{
 					P_PredictLine(ld, thing, oldside, SPAC_Cross);
 				}
@@ -2721,7 +2721,7 @@ bool P_TryMove(AActor *thing, const DVector2 &pos,
 	}
 
 	// [RH] Don't activate anything if just predicting
-	if (thing->player && (thing->player->cheats & CF_PREDICTING))
+	if (IsPredicting(thing))
 	{
 		thing->flags6 &= ~MF6_INTRYMOVE;
 		return true;
@@ -2783,7 +2783,7 @@ pushline:
 	thing->SetZ(oldz);
 
 	// [RH] Don't activate anything if just predicting
-	if (thing->player && (thing->player->cheats & CF_PREDICTING))
+	if (IsPredicting(thing))
 	{
 		return false;
 	}
@@ -2994,7 +2994,7 @@ void FSlide::HitSlideLine(line_t* ld)
 		{
 			tmmove.X = -tmmove.X / 2;
 			tmmove.Y /= 2; // absorb half the velocity
-			if (slidemo->player && slidemo->health > 0 && !(slidemo->player->cheats & CF_PREDICTING))
+			if (slidemo->player && slidemo->health > 0 && !IsPredicting(slidemo))
 			{
 				S_Sound(slidemo, CHAN_VOICE, 0, "*grunt", 1, ATTN_IDLE); // oooff!//   ^
 			}
@@ -3010,7 +3010,7 @@ void FSlide::HitSlideLine(line_t* ld)
 		{
 			tmmove.X /= 2; // absorb half the velocity
 			tmmove.Y = -tmmove.Y / 2;
-			if (slidemo->player && slidemo->health > 0 && !(slidemo->player->cheats & CF_PREDICTING))
+			if (slidemo->player && slidemo->health > 0 && !IsPredicting(slidemo))
 			{
 				S_Sound(slidemo, CHAN_VOICE, 0, "*grunt", 1, ATTN_IDLE); // oooff!
 			}
@@ -3042,7 +3042,7 @@ void FSlide::HitSlideLine(line_t* ld)
 	{
 		moveangle = ::deltaangle(deltaangle, lineangle);
 		movelen /= 2; // absorb
-		if (slidemo->player && slidemo->health > 0 && !(slidemo->player->cheats & CF_PREDICTING))
+		if (slidemo->player && slidemo->health > 0 && !IsPredicting(slidemo))
 		{
 			S_Sound(slidemo, CHAN_VOICE, 0, "*grunt", 1, ATTN_IDLE); // oooff!
 		}

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -521,7 +521,7 @@ inline int GetTics(AActor* actor, FState * newstate)
 
 bool AActor::SetState (FState *newstate, bool nofunction)
 {
-	if (debugfile && player && (player->cheats & CF_PREDICTING))
+	if (debugfile && IsPredicting(this))
 		fprintf (debugfile, "for pl %d: SetState while predicting!\n", Level->PlayerNum(player));
 	
 	auto oldstate = state;
@@ -2396,7 +2396,7 @@ static double P_XYMovement (AActor *mo, DVector2 scroll)
 		// if in a walking frame, stop moving
 		// killough 10/98:
 		// Don't affect main player when voodoo dolls stop:
-		if (player && player->mo == mo && !(player->cheats & CF_PREDICTING))
+		if (player && player->mo == mo && !(player->ClientState & CS_PREDICTING))
 		{
 			PlayIdle (player->mo);
 		}
@@ -2566,7 +2566,7 @@ static void P_ZMovement (AActor *mo, double oldfloorz)
 //
 	if (mo->Z() <= mo->floorz)
 	{	// Hit the floor
-		if ((!mo->player || !(mo->player->cheats & CF_PREDICTING)) &&
+		if (!IsPredicting(mo) &&
 			mo->Sector->SecActTarget != NULL &&
 			mo->Sector->floorplane.ZatPoint(mo) == mo->floorz)
 		{ // [RH] Let the sector do something to the actor
@@ -2675,7 +2675,7 @@ static void P_ZMovement (AActor *mo, double oldfloorz)
 
 	if (mo->Top() > mo->ceilingz)
 	{ // hit the ceiling
-		if ((!mo->player || !(mo->player->cheats & CF_PREDICTING)) &&
+		if (!IsPredicting(mo) &&
 			mo->Sector->SecActTarget != NULL &&
 			mo->Sector->ceilingplane.ZatPoint(mo) == mo->ceilingz)
 		{ // [RH] Let the sector do something to the actor
@@ -2727,7 +2727,7 @@ static void P_ZMovement (AActor *mo, double oldfloorz)
 
 void P_CheckFakeFloorTriggers (AActor *mo, double oldz, bool oldz_has_viewheight)
 {
-	if (mo->player && (mo->player->cheats & CF_PREDICTING))
+	if (IsPredicting(mo))
 	{
 		return;
 	}
@@ -2821,7 +2821,7 @@ static void PlayerLandedOnThing (AActor *mo, AActor *onmobj)
 		mo->player->deltaviewheight = mo->Vel.Z / 8.;
 	}
 
-	if (mo->player->cheats & CF_PREDICTING)
+	if (IsPredicting(mo))
 		return;
 
 	P_FallingDamage (mo);
@@ -3873,7 +3873,7 @@ void AActor::Tick ()
 	{
 		if (player)
 			player->crossingPortal = false;
-		if (!player || !(player->cheats & CF_PREDICTING))
+		if (!IsPredicting(this))
 		{
 			// Handle powerup effects here so that the order is controlled
 			// by the order in the inventory, not the order in the thinker table
@@ -4214,9 +4214,9 @@ void AActor::Tick ()
 			return;
 		}
 		// [ZZ] trigger hit floor/hit ceiling actions from XY movement
-		if (BlockingFloor && BlockingFloor != oldBlockingFloor && (!player || !(player->cheats & CF_PREDICTING)) && BlockingFloor->SecActTarget)
+		if (BlockingFloor && BlockingFloor != oldBlockingFloor && !IsPredicting(this) && BlockingFloor->SecActTarget)
 			BlockingFloor->TriggerSectorActions(this, SECSPAC_HitFloor);
-		if (BlockingCeiling && BlockingCeiling != oldBlockingCeiling && (!player || !(player->cheats & CF_PREDICTING)) && BlockingCeiling->SecActTarget)
+		if (BlockingCeiling && BlockingCeiling != oldBlockingCeiling && !IsPredicting(this) && BlockingCeiling->SecActTarget)
 			BlockingCeiling->TriggerSectorActions(this, SECSPAC_HitCeiling);
 		if (Vel.X == 0 && Vel.Y == 0) // Actors at rest
 		{
@@ -4273,7 +4273,7 @@ void AActor::Tick ()
 						|| ((onmo->activationtype & THINGSPEC_MissileTrigger) && (flags & MF_MISSILE))
 						) && (Level->maptime > onmo->lastbump)) // Leave the bumper enough time to go away
 					{
-						if (player == NULL || !(player->cheats & CF_PREDICTING))
+						if (!IsPredicting(this))
 						{
 							if (P_ActivateThingSpecial(onmo, this))
 								onmo->lastbump = Level->maptime + TICRATE;
@@ -4318,7 +4318,7 @@ void AActor::Tick ()
 		UpdateWaterLevel ();
 
 		// [RH] Don't advance if predicting a player
-		if (player && (player->cheats & CF_PREDICTING))
+		if (IsPredicting(this))
 		{
 			return;
 		}
@@ -6498,7 +6498,7 @@ int P_GetThingFloorType (AActor *thing)
 
 bool P_HitWater (AActor * thing, sector_t * sec, const DVector3 &pos, bool checkabove, bool alert, bool force)
 {
-	if (thing->player && (thing->player->cheats & CF_PREDICTING))
+	if (IsPredicting(thing))
 		return false;
 
 	AActor *mo = NULL;

--- a/src/playsim/p_teleport.cpp
+++ b/src/playsim/p_teleport.cpp
@@ -87,7 +87,7 @@ DEFINE_ACTION_FUNCTION(AActor, SpawnTeleportFog)
 
 bool P_Teleport (AActor *thing, DVector3 pos, DAngle angle, int flags)
 {
-	bool predicting = (thing->player && (thing->player->cheats & CF_PREDICTING));
+	bool predicting = IsPredicting(thing);
 
 	DVector3 old;
 	double aboveFloor;
@@ -385,7 +385,7 @@ bool FLevelLocals::EV_Teleport (int tid, int tag, line_t *line, int side, AActor
 	{ // Teleport function called with an invalid actor
 		return false;
 	}
-	bool predicting = (thing->player && (thing->player->cheats & CF_PREDICTING));
+	bool predicting = IsPredicting(thing);
 	if (thing->flags2 & MF2_NOTELEPORT)
 	{
 		return false;

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1249,11 +1249,6 @@ static bool P_CanPredict(const player_t* player)
 		&& player->playerstate == PST_LIVE);
 }
 
-int IsPredicting(AActor* self)
-{
-	return self->player != nullptr && self->player->mo == self && (self->player->ClientState & CS_PREDICTING);
-}
-
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, IsPredicting, IsPredicting)
 {
 	PARAM_SELF_PROLOGUE(AActor);

--- a/wadsrc/static/zscript/actors/actions.zs
+++ b/wadsrc/static/zscript/actors/actions.zs
@@ -4,7 +4,7 @@ extend class Actor
 	private void CheckStopped()
 	{
 		let player = self.player;
-		if (player && player.mo == self && !(player.cheats & CF_PREDICTING) && Vel == (0, 0, 0))
+		if (player && player.mo == self && !(player.ClientState & CS_PREDICTING) && Vel == (0, 0, 0))
 		{
 			player.mo.PlayIdle();
 			player.Vel = (0, 0);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -508,6 +508,7 @@ class Actor : Thinker native
 	native ui void DisplayNameTag();
 	native clearscope void DisableLocalRendering(uint playerNum, bool disable);
 	native ui bool ShouldRenderLocally(); // Only clients get to check this, never the playsim.
+	native clearscope bool IsPredicting() const;
 
 	// Called when the Actor is being used within a PSprite. This happens before potentially changing PSprite
 	// state so that any custom actions based on things like player input can be done before moving to the next

--- a/wadsrc/static/zscript/actors/inventory/powerups.zs
+++ b/wadsrc/static/zscript/actors/inventory/powerups.zs
@@ -1181,7 +1181,7 @@ class PowerSpeed : Powerup
 		if (Owner == NULL || Owner.player == NULL)
 			return;
 
-		if (Owner.player.cheats & CF_PREDICTING)
+		if (Owner.IsPredicting())
 			return;
 
 		if (NoTrail)
@@ -1557,7 +1557,7 @@ class PowerTimeFreezer : Powerup
 		// [RH] Do not change LEVEL_FROZEN on odd tics, or the Revenant's tracer
 		// will get thrown off.
 		// [ED850] Don't change it if the player is predicted either.
-		if (Level.maptime & 1 || (Owner != null && Owner.player != null && Owner.player.cheats & CF_PREDICTING))
+		if (Level.maptime & 1 || (Owner != null && Owner.IsPredicting()))
 		{
 			return;
 		}

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -154,7 +154,7 @@ class PlayerPawn : Actor
 			if (health > 0) Height = FullHeight;
 		}
 
-		if (player && bWeaponLevel2Ended && !(player.cheats & CF_PREDICTING))
+		if (player && bWeaponLevel2Ended && !IsPredicting())
 		{
 			bWeaponLevel2Ended = false;
 			if (player.ReadyWeapon != NULL && player.ReadyWeapon.bPowered_Up)
@@ -1348,7 +1348,7 @@ class PlayerPawn : Actor
 				Thrust(sidemove, a);
 			}
 
-			if (!(player.cheats & CF_PREDICTING) && (forwardmove != 0 || sidemove != 0))
+			if (!IsPredicting() && (forwardmove != 0 || sidemove != 0))
 			{
 				PlayRunning ();
 			}
@@ -1459,7 +1459,7 @@ class PlayerPawn : Actor
 				Vel.Z += jumpvelz;
 				bOnMobj = false;
 				player.jumpTics = -1;
-				if (!(player.cheats & CF_PREDICTING)) A_StartSound("*jump", CHAN_BODY);
+				if (!IsPredicting()) A_StartSound("*jump", CHAN_BODY);
 			}
 		}
 	}
@@ -1493,13 +1493,13 @@ class PlayerPawn : Actor
 				{
 					bFly = true;
 					bNoGravity = true;
-					if ((Vel.Z <= -39) && !(player.cheats & CF_PREDICTING))
+					if ((Vel.Z <= -39) && !IsPredicting())
 					{ // Stop falling scream
 						A_StopSound(CHAN_VOICE);
 					}
 				}
 			}
-			else if (cmd.upmove > 0 && !(player.cheats & CF_PREDICTING))
+			else if (cmd.upmove > 0 && !IsPredicting())
 			{
 				let fly = FindInventory("ArtiFly");
 				if (fly != NULL)
@@ -1682,7 +1682,7 @@ class PlayerPawn : Actor
 				player.jumpTics = 0;
 			}
 		}
-		if (Alternative && !(player.cheats & CF_PREDICTING))
+		if (Alternative && !IsPredicting())
 		{
 			MorphPlayerThink ();
 		}
@@ -1691,7 +1691,7 @@ class PlayerPawn : Actor
 		HandleMovement();
 		CalcHeight ();
 
-		if (!(player.cheats & CF_PREDICTING))
+		if (!IsPredicting())
 		{
 			CheckEnvironment();
 			// Note that after this point the PlayerPawn may have changed due to getting unmorphed or getting its skull popped so 'self' is no longer safe to use.
@@ -2765,6 +2765,8 @@ struct PlayerInfo native play	// self is what internally is known as player_t
 	
 	native PlayerPawn mo;
 	native uint8 playerstate;
+	native readonly int ClientTic;
+	native readonly int ClientState;
 	native readonly uint buttons;
 	native uint original_oldbuttons;
 	native Class<PlayerPawn> cls;

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1157,7 +1157,7 @@ enum EPlayerCheats
 	CF_FRIGHTENING		= 1 << 10,		// [RH] Scare monsters away
 	CF_INSTANTWEAPSWITCH= 1 << 11,		// [RH] Switch weapons instantly
 	CF_TOTALLYFROZEN	= 1 << 12,		// [RH] All players can do is press +use
-	CF_PREDICTING		= 1 << 13,		// [RH] Player movement is being predicted
+	CF_PREDICTING		= 1 << 13,		// Deprecated. See CS_PREDICTING.
 	CF_INTERPVIEW		= 1 << 14,		// [RH] view was changed outside of input, so interpolate one frame
 	CF_INTERPVIEWANGLES	= 1 << 15,		// [MR] flag for interpolating view angles without interpolating the entire frame
 	CF_NOFOVINTERP		= 1 << 16,		// [B] Disable FOV interpolation when instantly zooming
@@ -1178,6 +1178,18 @@ enum EPlayerCheats
 	CF_PROSPERITY		= 0,
 	CF_DOUBLEFIRINGSPEED= 0,
 	CF_INFINITEAMMO		= 0,
+};
+
+enum EClientState
+{
+	CS_NONE = 0,
+	CS_PREDICTING = 1,			// Client is currently predicting movement (unconfirmed position).
+	CS_LATEST_TICK = 1 << 1,	// Client is on the latest tick taking prediction into account.
+	CS_RUBBERBANDING = 1 << 2,	// Client's misprediction is being corrected.
+	//CS_CONNECTING		= 1 << 3,	// Client is joining the game.
+	//CS_DISCONNECTING	= 1 << 4,	// Client is leaving the game.
+
+	CS_PREDICTION_STATE = CS_PREDICTING | CS_LATEST_TICK | CS_RUBBERBANDING,
 };
 
 enum EWeaponState


### PR DESCRIPTION
Currently working with client-side prediction is a bit too limiting due to the nature of only having the info that the client is predicting and nothing else. Not only this, but handling the prediction state via `cheats` is volatile as it allows players to unset it (likely unintentionally) while predicting which will break the game state immediately.

Prediction is now locked behind `ClientState` which is readonly. This will be used for getting a client's network status (both the consoleplayer and others) and currently supports `CS_PREDICTING`, `CS_LATEST_TICK`, and `CS_RUBBERBANDING`. `CS_LATEST_TICK` is of particular interest because it can allow effects and sounds to be executed on the player's last "real" tick rather than constantly being repredicted. This allows for things like sounds on landing to be played at the last predicted tick without rapid firing when being played back.

`ClientTic` has also been added which can be compared against `gametic` to see how far ahead the player is currently predicting on a given tick. Note that `gametic` becomes one tick ahead when predicting since its value is incremented after all game logic but before prediction starts.

These fields should mainly be used for client-side prediction as they won't give the same values across clients (similar to `consoleplayer`), but things like `CS_LATEST_TICK` and `ClientTic` are still set for all clients so logic can execute correctly on their end. For instance, a non-consoleplayer client will only update on a real tick, but their flag will always be set to `CS_LATEST_TICK` so a landing sound would still play at the correct time if checking against it.