### PR TITLE
Fixed ViewPos not properly backing up when predicting

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -179,6 +179,9 @@ class PlayerPawn : Actor
 
 	override void BeginPlay()
 	{
+		// Force create this since players can predict.
+		SetViewPos((0.0, 0.0, 0.0));
+
 		Super.BeginPlay ();
 		ChangeStatNum (STAT_PLAYER);
 		FullHeight = Height;


### PR DESCRIPTION
Pawns will now also force create the `ViewPos` object so that any calls to `SetViewPos()` while predicting won't spam create objects if it didn't exist during a real tick. In the future, _please_ do not use DObjects to store playsim data. Structs will be automatically backed up which makes them much easier to work with (alongside not needing a GC'd object anymore). `ViewPos` will likely need a structural rework in the future because of these problems.