### PR TITLE
SetSkin and GetSkinCount added to PlayerInfo class

### DIFF
--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -514,6 +514,23 @@ DEFINE_ACTION_FUNCTION(_PlayerInfo, SetFOV)
 	return 0;
 }
 
+DEFINE_ACTION_FUNCTION(_PlayerInfo, SetSkin)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(player_t);
+	PARAM_INT(skinIndex);
+	if (skinIndex >= 0 && skinIndex < Skins.size())
+	{
+		// commented code - cvar_set calls this automatically, along with saving the skin selection.
+		//self->userinfo.SkinNumChanged(skinIndex);
+		cvar_set("skin", Skins[skinIndex].Name.GetChars());
+		ACTION_RETURN_INT(self->userinfo.GetSkin());
+	}
+	else
+	{
+		ACTION_RETURN_INT(-1);
+	}
+}
+
 //===========================================================================
 //
 // EnumColorsets
@@ -764,6 +781,12 @@ DEFINE_ACTION_FUNCTION(_PlayerInfo, GetSkin)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(player_t);
 	ACTION_RETURN_INT(self->userinfo.GetSkin());
+}
+
+DEFINE_ACTION_FUNCTION(_PlayerInfo, GetSkinCount)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(player_t);
+	ACTION_RETURN_INT(Skins.size());
 }
 
 DEFINE_ACTION_FUNCTION(_PlayerInfo, GetGender)

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2866,6 +2866,7 @@ struct PlayerInfo native play	// self is what internally is known as player_t
 	native clearscope int GetColorSet() const;
 	native clearscope int GetPlayerClassNum() const;
 	native clearscope int GetSkin() const;
+	native clearscope int GetSkinCount() const;
 	native clearscope bool GetNeverSwitch() const;
 	native clearscope int GetGender() const;
 	native clearscope int GetTeam() const;
@@ -2877,6 +2878,7 @@ struct PlayerInfo native play	// self is what internally is known as player_t
 	native bool GetFViewBob() const;
 	native double GetStillBob() const;
 	native void SetFOV(float fov);
+	native int SetSkin(int skinIndex);
 	native clearscope bool GetClassicFlight() const;
 	native void SendPitchLimits();
 	native clearscope bool HasWeaponsInSlot(int slot) const;


### PR DESCRIPTION
This pull request adds the ability to set the client player's skin through ZScript.  Specifically it adds the following functions:

```
PlayerInfo.SetSkin(int skinId)

PlayerInfo.GetSkinCount()
```

The impetus behind this is to allow a map to contain a "changing room" of sorts, providing an alternative to the "Player Settings" menu.

Note - This is confirmed to work on multiplayer.

Note - I wasn't sure if PlayerInfo was the right place for these methods, but I saw SetFOV() in there, so it seemed appropriate.

Here's an example ZCODE using this functionality:

```
version "4.11.3"

class SkinAccessor
{
	static int GetSkinIndex()
	{
		return Players[consolePlayer].GetSkin();
	}

	static int GetSkinCount()
	{
		return Players[consolePlayer].GetSkinCount();
	}

	play static int SetSkinIndex(int playerNumber, int newValue)
	{
		if (playerNumber != consolePlayer) return -1;
		return Players[consolePlayer].SetSkin(newValue);
	}
}
```

Also, I've attached a working example.  A PK3 and MOD file to add to Doom2 or FreeDoom2.

[setskin_test.zip](https://github.com/ZDoom/gzdoom/files/15467026/setskin_test.zip)
