### PR TITLE
Narrow Launcher check box clickable areas (address issue #2558)

### DIFF
--- a/src/launcher/settingspage.cpp
+++ b/src/launcher/settingspage.cpp
@@ -161,7 +161,7 @@ void SettingsPage::OnLanguageChanged(int i)
 
 void SettingsPage::OnGeometryChanged()
 {
-	double panelWidth = 200.0;
+	double panelWidth = 160.0;
 	double y = 0.0;
 	double w = GetWidth();
 	double h = GetHeight();


### PR DESCRIPTION
Fix issue #2558 by narrowing the Launcher check box clickable areas on their right edges. They extend too far to the extent that clicking on some check boxes will actually change the values of the boxes to their immediate left.

160 is chosen to not only eliminate this overlap, but provide a few extra pixels of buffer space in case of mis-clicks five or so pixels to the left of the intended check box (so that they don't accidentally change the boxes to the left).