### PR TITLE
Bug fix: blur sphere currently does not affect enemy aim

### DIFF
--- a/src/playsim/shadowinlines.h
+++ b/src/playsim/shadowinlines.h
@@ -85,7 +85,12 @@ inline bool AffectedByShadows(AActor* self)
 
 inline AActor* CheckForShadows(AActor* self, AActor* other, DVector3 pos, double& penaltyFactor)
 {
-    return ((other && (other->flags & MF_SHADOW)) || (self->flags9 & MF9_DOSHADOWBLOCK)) ? P_CheckForShadowBlock(self, other, pos, penaltyFactor) : nullptr;
+	if ((other && (other->flags & MF_SHADOW)) || (self->flags9 & MF9_DOSHADOWBLOCK))
+	{
+		AActor* shadowBlock = P_CheckForShadowBlock(self, other, pos, penaltyFactor);
+		return shadowBlock ? shadowBlock : other;
+	}
+	return nullptr;
 }
 
 inline AActor* PerformShadowChecks(AActor* self, AActor* other, DVector3 pos, double& penaltyFactor)


### PR DESCRIPTION
Some new code was added to affect enemy aim if an invisible actor is between the enemy and its target.  However, this inadvertently caused the effect to stop working if the target itself is invisible and no invisible actor is between the enemy and target.

When calling CheckForShadows(), we are incorrectly returning a nullptr actor if nothing is between the monster and the player.  This results in the monster aiming as if you don't have invisibility.

Fall back to returning the target actor if it is shadowed but nothing is in between the two.

Fixes #2566 