### PR TITLE
build: fix build failure on ILP32

### DIFF
--- a/src/common/platform/posix/sdl/sdlglvideo.cpp
+++ b/src/common/platform/posix/sdl/sdlglvideo.cpp
@@ -400,7 +400,7 @@ DFrameBuffer *SDLVideo::CreateFrameBuffer ()
 				builder.RequireExtension(names[i]);
 			auto instance = builder.Create();
 
-			VkSurfaceKHR surfacehandle = nullptr;
+			VkSurfaceKHR surfacehandle = {};
 			if (!I_CreateVulkanSurface(instance->Instance, &surfacehandle))
 				VulkanError("I_CreateVulkanSurface failed");
 

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -71,7 +71,10 @@ enum EParticleFlags
 class DVisualThinker;
 struct particle_t
 {
-	subsector_t* subsector; //+8 = 8
+	union {
+		subsector_t* subsector;
+		uint64_t _pad0; //+8 = 8
+	};
     DVector3 Pos; //+24 = 32
     FVector3 Vel; //+12 = 44
     FVector3 Acc; //+12 = 56
@@ -84,7 +87,7 @@ struct particle_t
     float Roll, RollVel, RollAcc; //+12 = 100
     uint16_t    tnext, snext, tprev; //+6 = 106
 	uint16_t flags; //+2 = 108
-	// uint32_t padding; //+4 = 112
+	uint32_t padding; //+4 = 112
 	FStandaloneAnimation animData; //+16 = 128
 };
 


### PR DESCRIPTION
On ILP32, particle_t is just size 120 and the static assertion below the struct declaration had failed.