### PR TITLE
`NOTCONSUMABLE` inventory flag

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -71,6 +71,7 @@ class Inventory : Actor
 	flagdef Unclearable: ItemFlags, 24;
 	flagdef NeverLocal: ItemFlags, 25;
 	flagdef IsKeyItem: ItemFlags, 26;
+	flagdef NotConsumable: ItemFlags, 27;
 
 	flagdef ForceRespawnInSurvival: none, 0;
 	flagdef PickupFlash: none, 6;

--- a/wadsrc/static/zscript/actors/inventory_util.zs
+++ b/wadsrc/static/zscript/actors/inventory_util.zs
@@ -267,7 +267,7 @@ extend class Actor
 			return false;
 		}
 
-		if (sv_infiniteinventory)
+		if (sv_infiniteinventory || item.bNotConsumable)
 		{
 			return true;
 		}


### PR DESCRIPTION
An item with this flag isn't consumed upon a successful use.

In my mod, I have powerups which are meant to be used infinitely but require the player to have enough "energy" to be successfully used/activated. So I propose this flag.