### PR TITLE
Fixed unmorphed Actors still ticking

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3810,8 +3810,11 @@ void AActor::Tick ()
 
 	// Check for Actor unmorphing, but only on the thing that is the morphed Actor.
 	// Players do their own special checking for this.
-	if (alternative != nullptr && !(flags & MF_UNMORPHED) && player == nullptr)
+	if (alternative != nullptr && player == nullptr)
 	{
+		if (flags & MF_UNMORPHED)
+			return;
+
 		int res = false;
 		IFVIRTUAL(AActor, CheckUnmorph)
 		{


### PR DESCRIPTION
Caused unmorphed monsters to still roam around and attack.