### PR TITLE
Fix am_cheat modes 4-6 using SecretWallColor instead of WallColor

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -2624,7 +2624,7 @@ void DAutomap::drawWalls (bool allmap)
 				}
 				else if (line.flags & ML_SECRET)
 				{ // secret door
-					if (am_cheat != 0 && line.backsector != nullptr)
+					if (am_cheat != 0 && am_cheat < 4 && line.backsector != nullptr)
 						drawMline(&l, AMColors.SecretWallColor);
 					else
 						drawMline(&l, AMColors.WallColor);


### PR DESCRIPTION
Waaaay back when `am_cheat 4` was added, the intent was to show the automap as if it were fully explored by the player (I'd dig up a source, but the search function on the new ZDoom forum software doesn't want to play ball). Current versions of GZDoom break this somewhat by drawing Secret-flagged lines with SecretWallColor when `am_cheat 4` is active, which also has the probably-unintended side effect of hiding these lines entirely when using one of the traditional color presets (since they don't define a SecretWallColor -- could be that's a separate bug?). Probably just an oversight when SecretWallColor was added.

This lil' PR restores the intended behavior, since it's extremely useful as a debug tool for doing automap cleanup work (i.e. you can preview the whole map as it will look for a non-cheating player, without having to noclip around everywhere). `am_cheat` modes 1 through 3 are untouched.
