### PR TITLE
Improvements towards waiting and desync messages when playing online

### DIFF
--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -1233,76 +1233,63 @@ void DBaseStatusBar::DrawTopStuff (EHudState state)
 
 void DBaseStatusBar::DrawConsistancy () const
 {
-	static bool firsttime = true;
-	int i;
-	char conbuff[64], *buff_p;
-
 	if (!netgame)
 		return;
 
-	buff_p = NULL;
-	for (i = 0; i < MAXPLAYERS; i++)
+	bool desync = false;
+	FString text = "Out of sync with:";
+	for (int i = 0; i < MAXPLAYERS; i++)
 	{
 		if (playeringame[i] && players[i].inconsistant)
 		{
-			if (buff_p == NULL)
-			{
-				strcpy (conbuff, "Out of sync with:");
-				buff_p = conbuff + 17;
-			}
-			*buff_p++ = ' ';
-			*buff_p++ = '1' + i;
-			*buff_p = 0;
+			desync = true;
+			text.AppendFormat(" %s (%d)", players[i].userinfo.GetName(10u), i + 1);
 		}
 	}
 
-	if (buff_p != NULL)
+	if (desync)
 	{
-		if (firsttime)
+		auto lines = V_BreakLines(SmallFont, twod->GetWidth() / CleanXfac - 40, text.GetChars());
+		const int height = SmallFont->GetHeight() * CleanYfac;
+		double y = 0.0;
+		for (auto& line : lines)
 		{
-			firsttime = false;
-			if (debugfile)
-			{
-				fprintf (debugfile, "%s as of tic %d (%d)\n", conbuff,
-					players[1-consoleplayer].inconsistant,
-					players[1-consoleplayer].inconsistant/ticdup);
-			}
+			DrawText(twod, SmallFont, CR_GREEN,
+				(twod->GetWidth() - SmallFont->StringWidth(line.Text) * CleanXfac) * 0.5,
+				y, line.Text.GetChars(), DTA_CleanNoMove, true, TAG_DONE);
+			y += height;
 		}
-		DrawText(twod, SmallFont, CR_GREEN,
-			(twod->GetWidth() - SmallFont->StringWidth (conbuff)*CleanXfac) / 2,
-			0, conbuff, DTA_CleanNoMove, true, TAG_DONE);
 	}
 }
 
 void DBaseStatusBar::DrawWaiting () const
 {
-	int i;
-	char conbuff[64], *buff_p;
-
 	if (!netgame)
 		return;
 
-	buff_p = NULL;
-	for (i = 0; i < MAXPLAYERS; i++)
+	FString text = "Waiting for:";
+	bool isWaiting = false;
+	for (int i = 0; i < MAXPLAYERS; i++)
 	{
 		if (playeringame[i] && players[i].waiting)
 		{
-			if (buff_p == NULL)
-			{
-				strcpy (conbuff, "Waiting for:");
-				buff_p = conbuff + 12;
-			}
-			*buff_p++ = ' ';
-			*buff_p++ = '1' + i;
-			*buff_p = 0;
+			isWaiting = true;
+			text.AppendFormat(" %s (%d)", players[i].userinfo.GetName(10u), i + 1);
 		}
 	}
 
-	if (buff_p != NULL)
+	if (isWaiting)
 	{
-		DrawText(twod, SmallFont, CR_ORANGE,
-			(twod->GetWidth() - SmallFont->StringWidth (conbuff)*CleanXfac) / 2,
-			SmallFont->GetHeight()*CleanYfac, conbuff, DTA_CleanNoMove, true, TAG_DONE);
+		auto lines = V_BreakLines(SmallFont, twod->GetWidth() / CleanXfac - 40, text.GetChars());
+		const int height = SmallFont->GetHeight() * CleanYfac;
+		double y = 0.0;
+		for (auto& line : lines)
+		{
+			DrawText(twod, SmallFont, CR_ORANGE,
+				(twod->GetWidth() - SmallFont->StringWidth(line.Text) * CleanXfac) * 0.5,
+				y, line.Text.GetChars(), DTA_CleanNoMove, true, TAG_DONE);
+			y += height;
+		}
 	}
 }
 

--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -204,9 +204,25 @@ struct userinfo_t : TMap<FName,FBaseCVar *>
 	{
 		return *static_cast<FFloatCVar *>(*CheckKey(NAME_Autoaim));
 	}
-	const char *GetName() const
+	const char *GetName(unsigned int charLimit = 0u) const
 	{
-		return *static_cast<FStringCVar *>(*CheckKey(NAME_Name));
+		const char* name = *static_cast<FStringCVar*>(*CheckKey(NAME_Name));
+		if (charLimit)
+		{
+			FString temp = name;
+			if (temp.CharacterCount() > charLimit)
+			{
+				int next = 0;
+				for (unsigned int i = 0u; i < charLimit; ++i)
+					temp.GetNextCharacter(next);
+
+				temp.Truncate(next);
+				temp += "...";
+				name = temp.GetChars();
+			}
+		}
+
+		return name;
 	}
 	int GetTeam() const
 	{

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -721,7 +721,8 @@ DEFINE_ACTION_FUNCTION(_PlayerInfo, Resurrect)
 DEFINE_ACTION_FUNCTION(_PlayerInfo, GetUserName)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(player_t);
-	ACTION_RETURN_STRING(self->userinfo.GetName());
+	PARAM_UINT(charLimit);
+	ACTION_RETURN_STRING(self->userinfo.GetName(charLimit));
 }
 
 DEFINE_ACTION_FUNCTION(_PlayerInfo, GetNeverSwitch)

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2857,7 +2857,7 @@ struct PlayerInfo native play	// self is what internally is known as player_t
 	native void SetSubtitleNumber (int text, Sound sound_id = 0);
 	native bool Resurrect();
 
-	native clearscope String GetUserName() const;
+	native clearscope String GetUserName(uint charLimit = 0u) const;
 	native clearscope Color GetColor() const;
 	native clearscope Color GetDisplayColor() const;
 	native clearscope int GetColorSet() const;


### PR DESCRIPTION
These will now display usernames alongside node number making it easier to tell who's desyncing from/waiting for who. This also adds a character limit parameter for getting a client's username that will automatically truncate and add `...` at the end to avoid large names from taking up the entire screen. This should probably be used later for things like the scoreboard and chat messages as well.