### PR TITLE
Pre(Un)morph fix

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -5345,6 +5345,42 @@ int MorphPointerSubstitution(AActor* from, AActor* to)
 		return false;
 	}
 
+	// [MC] Had to move this here since ObtainInventory was also moved as well. Should be called
+	// before any transference of items since that's what was intended when introduced.
+	if (!from->alternative) // Morphing into
+	{
+		{
+			IFVIRTUALPTR(from, AActor, PreMorph)
+			{
+				VMValue params[] = { from, to, false };
+				VMCall(func, params, 3, nullptr, 0);
+			}
+		}
+		{
+			IFVIRTUALPTR(to, AActor, PreMorph)
+			{
+				VMValue params[] = { to, from, true };
+				VMCall(func, params, 3, nullptr, 0);
+			}
+		}
+	}
+	else // Unmorphing back
+	{
+		{
+			IFVIRTUALPTR(from, AActor, PreUnmorph)
+			{
+				VMValue params[] = { from, to, false };
+				VMCall(func, params, 3, nullptr, 0);
+			}
+		}
+		{
+			IFVIRTUALPTR(to, AActor, PreUnmorph)
+			{
+				VMValue params[] = { to, from, true };
+				VMCall(func, params, 3, nullptr, 0);
+			}
+		}
+	}
 	// Since the check is good, move the inventory items over. This should always be done when
 	// morphing to emulate Heretic/Hexen's behavior since those stored the inventory in their
 	// player structs.

--- a/wadsrc/static/zscript/actors/morph.zs
+++ b/wadsrc/static/zscript/actors/morph.zs
@@ -99,6 +99,7 @@ extend class Actor
 	}
 
 	// [MC] Called when an actor morphs, on both the previous form (!current) and present form (current).
+	// Due to recent changes, these are now called internally instead of within the virtuals.
 	virtual void PreMorph(Actor mo, bool current) {}
 	virtual void PostMorph(Actor mo, bool current) {}
 	virtual void PreUnmorph(Actor mo, bool current) {}

--- a/wadsrc/static/zscript/actors/player/player_morph.zs
+++ b/wadsrc/static/zscript/actors/player/player_morph.zs
@@ -129,9 +129,6 @@ extend class PlayerPawn
 			return false;
 		}
 
-		PreMorph(morphed, false);
-		morphed.PreMorph(self, true);
-
 		morphed.EndAllPowerupEffects();
 
 		if ((style & MRF_TRANSFERTRANSLATION) && !morphed.bDontTranslate)
@@ -258,9 +255,6 @@ extend class PlayerPawn
 
 		if (!MorphInto(alt))
 			return false;
-
-		PreUnmorph(alt, false);		// This body's about to be left.
-		alt.PreUnmorph(self, true);	// This one's about to become current.
 
 		alt.EndAllPowerupEffects();
 


### PR DESCRIPTION
Fixed Pre(Un)Morph being called out of order.

This had broken several mods that relied on the inventory being in place before the switch, which was the intended way to begin with.

Fixes #2600 