### PR TITLE
Add missing GC write barrier

### DIFF
--- a/src/common/objects/dobject.cpp
+++ b/src/common/objects/dobject.cpp
@@ -332,6 +332,7 @@ void DObject::Destroy ()
 	}
 	OnDestroy();
 	ObjectFlags = (ObjectFlags & ~OF_Fixed) | OF_EuthanizeMe;
+	GC::WriteBarrier(this);
 }
 
 DEFINE_ACTION_FUNCTION(DObject, Destroy)


### PR DESCRIPTION
_Took me 4 days to figure out..._

May or may not solve: https://github.com/ZDoom/gzdoom/issues/2487

During propagation phase of GC, it's possible to end up with references to deallocated memory:
![image](https://github.com/ZDoom/gzdoom/assets/29225776/8fb0350f-393c-4c5d-ab27-d050d79aad41)
