### PR TITLE
ExtraDepletionBehavior

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -923,7 +923,7 @@ class Inventory : Actor
 	//===========================================================================
 	virtual void DepleteBy(int by)
 	{
-		if (!amount || by >= amount)
+		if (amount < 1 || by >= amount)
 		{
 			DepleteOrDestroy();
 		}

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -916,6 +916,18 @@ class Inventory : Actor
 
 	//===========================================================================
 	//
+	// Inventory :: ExtraDepletionBehavior
+	//
+	// Allows for additional custom depletion behavior with TakeInventory and UseInventory
+	//
+	//===========================================================================
+	
+	virtual void ExtraDepletionBehavior (int takeAmount)
+	{
+	}
+
+	//===========================================================================
+	//
 	// Inventory :: DepleteOrDestroy
 	//
 	// If the item is depleted, just change its amount to 0, otherwise it's destroyed.

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -921,9 +921,9 @@ class Inventory : Actor
 	// Handles item depletion when using or taking items
 	//
 	//===========================================================================
-	virtual void DepleteBy(int by, bool usedItem)
+	virtual void DepleteBy(int by)
 	{
-		if (!amount || by >= amount || --Amount <= 0 && usedItem)
+		if (!amount || by >= amount)
 		{
 			DepleteOrDestroy();
 		}

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -916,14 +916,21 @@ class Inventory : Actor
 
 	//===========================================================================
 	//
-	// Inventory :: ExtraDepletionBehavior
+	// Inventory :: DepleteBy
 	//
-	// Allows for additional custom depletion behavior with TakeInventory and UseInventory
+	// Handles item depletion when using or taking items
 	//
 	//===========================================================================
-	
-	virtual void ExtraDepletionBehavior (int takeAmount)
+	virtual void DepleteBy(int by, bool usedItem)
 	{
+		if (!amount || by >= amount || --Amount <= 0 && usedItem)
+		{
+			DepleteOrDestroy();
+		}
+		else
+		{
+			amount -= by;
+		}
 	}
 
 	//===========================================================================

--- a/wadsrc/static/zscript/actors/inventory_util.zs
+++ b/wadsrc/static/zscript/actors/inventory_util.zs
@@ -146,7 +146,7 @@ extend class Actor
 
 		if (!fromdecorate)
 		{
-			item.DepleteBy(amount, false);
+			item.DepleteBy(amount);
 			// It won't be used in non-decorate context, so return false here
 			return false;
 		}
@@ -159,15 +159,17 @@ extend class Actor
 
 		// Do not take ammo if the "no take infinite/take as ammo depletion" flag is set
 		// and infinite ammo is on
+		// Alternatively do not take customInventory items if sv_infiniteinventory is true
 		if (notakeinfinite &&
-		(sv_infiniteammo || (player && FindInventory('PowerInfiniteAmmo', true))) && (item is 'Ammo'))
+		(sv_infiniteammo || (player && FindInventory('PowerInfiniteAmmo', true))) && (item is 'Ammo')
+		|| sv_infiniteinventory && item is 'CustomInventory')
 		{
 			// Nothing to do here, except maybe res = false;? Would it make sense?
 			result = false;
 		}
 		else
 		{
-			item.DepleteBy(amount, false);
+			item.DepleteBy(amount);
 		}
 
 		return result;
@@ -266,8 +268,10 @@ extend class Actor
 		{
 			return true;
 		}
-
-		item.DepleteBy(1, true); //useinventory can only really use one item at a time
+		else
+		{
+			item.DepleteBy(1); //useinventory can only really use one item at a time
+		}
 		return true;
 	}
 

--- a/wadsrc/static/zscript/actors/inventory_util.zs
+++ b/wadsrc/static/zscript/actors/inventory_util.zs
@@ -151,6 +151,7 @@ extend class Actor
 			{
 				item.DepleteOrDestroy();
 			}
+			item.ExtraDepletionBehavior(amount);
 			// It won't be used in non-decorate context, so return false here
 			return false;
 		}
@@ -173,7 +174,11 @@ extend class Actor
 		{
 			item.DepleteOrDestroy();
 		}
-		else item.Amount -= amount;
+		else
+		{ 
+			item.Amount -= amount; 
+			item.ExtraDepletionBehavior(amount); 
+		}
 
 		return result;
 	}
@@ -276,6 +281,7 @@ extend class Actor
 		{
 			item.DepleteOrDestroy ();
 		}
+		item.ExtraDepletionBehavior(1); //useinventory can only really use one item at a time
 		return true;
 	}
 

--- a/wadsrc/static/zscript/actors/inventory_util.zs
+++ b/wadsrc/static/zscript/actors/inventory_util.zs
@@ -151,7 +151,10 @@ extend class Actor
 			{
 				item.DepleteOrDestroy();
 			}
-			item.ExtraDepletionBehavior(amount);
+			else
+			{
+				item.ExtraDepletionBehavior(amount);
+			}
 			// It won't be used in non-decorate context, so return false here
 			return false;
 		}
@@ -281,7 +284,11 @@ extend class Actor
 		{
 			item.DepleteOrDestroy ();
 		}
-		item.ExtraDepletionBehavior(1); //useinventory can only really use one item at a time
+		//check to prevent address from zero crashes, anyway you should really be using DetachFromOwner for removing the whole item
+		if(item.Amount > 0)
+		{
+			item.ExtraDepletionBehavior(1); //useinventory can only really use one item at a time
+		}
 		return true;
 	}
 

--- a/wadsrc/static/zscript/actors/inventory_util.zs
+++ b/wadsrc/static/zscript/actors/inventory_util.zs
@@ -146,15 +146,7 @@ extend class Actor
 
 		if (!fromdecorate)
 		{
-			item.Amount -= amount;
-			if (item.Amount <= 0)
-			{
-				item.DepleteOrDestroy();
-			}
-			else
-			{
-				item.ExtraDepletionBehavior(amount);
-			}
+			item.DepleteBy(amount, false);
 			// It won't be used in non-decorate context, so return false here
 			return false;
 		}
@@ -173,14 +165,9 @@ extend class Actor
 			// Nothing to do here, except maybe res = false;? Would it make sense?
 			result = false;
 		}
-		else if (!amount || amount >= item.Amount)
-		{
-			item.DepleteOrDestroy();
-		}
 		else
-		{ 
-			item.Amount -= amount; 
-			item.ExtraDepletionBehavior(amount); 
+		{
+			item.DepleteBy(amount, false);
 		}
 
 		return result;
@@ -280,15 +267,7 @@ extend class Actor
 			return true;
 		}
 
-		if (--item.Amount <= 0)
-		{
-			item.DepleteOrDestroy ();
-		}
-		//check to prevent address from zero crashes, anyway you should really be using DetachFromOwner for removing the whole item
-		if(item.Amount > 0)
-		{
-			item.ExtraDepletionBehavior(1); //useinventory can only really use one item at a time
-		}
+		item.DepleteBy(1, true); //useinventory can only really use one item at a time
 		return true;
 	}
 

--- a/wadsrc/static/zscript/actors/inventory_util.zs
+++ b/wadsrc/static/zscript/actors/inventory_util.zs
@@ -159,10 +159,8 @@ extend class Actor
 
 		// Do not take ammo if the "no take infinite/take as ammo depletion" flag is set
 		// and infinite ammo is on
-		// Alternatively do not take customInventory items if sv_infiniteinventory is true
 		if (notakeinfinite &&
-		(sv_infiniteammo || (player && FindInventory('PowerInfiniteAmmo', true))) && (item is 'Ammo')
-		|| sv_infiniteinventory && item is 'CustomInventory')
+		(sv_infiniteammo || (player && FindInventory('PowerInfiniteAmmo', true))) && (item is 'Ammo'))
 		{
 			// Nothing to do here, except maybe res = false;? Would it make sense?
 			result = false;


### PR DESCRIPTION
ExtraDepletionBehavior is a dynamic way of expanding upon TakeInventory and UseInventory* with additional behaviour, whilst also preventing code bloat from custom inventory use and take functions.

Extremely useful for weight systems, requires at least 1 item in reserve to function (use DetachFromOwner for when the final item is dropped) 
	
*SetInventory should also be theoretically supported, at least on the takeinventory side