### PR TITLE
Add another soundfonts search directory for *nix

### DIFF
--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -180,6 +180,7 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey("Path", "/usr/share/doom/fm_banks", true);
 		SetValueForKey("Path", "/usr/share/games/doom/soundfonts", true);
 		SetValueForKey("Path", "/usr/share/games/doom/fm_banks", true);
+		SetValueForKey("Path", "/usr/share/soundfonts", true);
 #endif
 	}
 


### PR DESCRIPTION
This adds another soundfont search directory for the convenience of the user.