### PR TITLE
Fixed subnormal float viewpos values breaking rendering

### DIFF
--- a/src/common/utility/vectors.h
+++ b/src/common/utility/vectors.h
@@ -1019,6 +1019,45 @@ struct TVector4
 	}
 };
 
+inline void ZeroSubnormalsF(double& num)
+{
+	if (fabs(num) < FLT_MIN) num = 0;
+}
+
+inline void ZeroSubnormals(double& num)
+{
+	if (fabs(num) < DBL_MIN) num = 0;
+}
+
+inline void ZeroSubnormals(float& num)
+{
+	if (fabsf(num) < FLT_MIN) num = 0;
+}
+
+template<typename T>
+inline void ZeroSubnormals(TVector2<T>& vec)
+{
+	ZeroSubnormals(vec.X);
+	ZeroSubnormals(vec.Y);
+}
+
+template<typename T>
+inline void ZeroSubnormals(TVector3<T>& vec)
+{
+	ZeroSubnormals(vec.X);
+	ZeroSubnormals(vec.Y);
+	ZeroSubnormals(vec.Z);
+}
+
+template<typename T>
+inline void ZeroSubnormals(TVector4<T>& vec)
+{
+	ZeroSubnormals(vec.X);
+	ZeroSubnormals(vec.Y);
+	ZeroSubnormals(vec.Z);
+	ZeroSubnormals(vec.W);
+}
+
 template<class vec_t>
 struct TMatrix3x3
 {

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -774,6 +774,9 @@ public:
 
 	void Set(DVector3 &off, int f = -1)
 	{
+		ZeroSubnormalsF(off.X);
+		ZeroSubnormalsF(off.Y);
+		ZeroSubnormalsF(off.Z);
 		Offset = off;
 
 		if (f > -1)


### PR DESCRIPTION
Fixes #2648. While you should always remember to properly 0 your floats that are intended to be zeroed (use an epsilon!), this is a quick fix to make sure bad values can't be passed back in the first place. It's likely the messy math of the previous render setup code accidentally fixed these potential oversights hence why they showed up after the rewrite. A fuller solution is probably needed in the future that prevents them in their entirety from existing in the backend since this issue could potentially rear its head with view angles as well.

A standard set of functions for fixing subnormals has been included for posterity.