### PR TITLE
Add RADF_CIRCULARTHRUST and matching XF_/RTF_ flags

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1534,9 +1534,13 @@ public:
 	{
 		return Z() + Height;
 	}
+	double CenterOffset() const
+	{
+		return Height / 2;
+	}
 	double Center() const
 	{
-		return Z() + Height/2;
+		return Z() + CenterOffset();
 	}
 	void SetZ(double newz, bool moving = true)
 	{
@@ -1611,6 +1615,11 @@ public:
 	{
 		Vel.X += speed * angle.Cos();
 		Vel.Y += speed * angle.Sin();
+	}
+
+	void Thrust(const DVector3& vel)
+	{
+		Vel += vel;
 	}
 
 	void Vel3DFromAngle(DAngle angle, DAngle pitch, double speed)

--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -408,7 +408,8 @@ enum
 	RADF_OLDRADIUSDAMAGE = 32,
 	RADF_THRUSTLESS = 64,
 	RADF_NOALLIES = 128,
-	RADF_CIRCULAR = 256
+	RADF_CIRCULAR = 256,
+	RADF_CIRCULARTHRUST = 512,
 };
 int P_GetRadiusDamage(AActor *self, AActor *thing, int damage, double distance, double fulldmgdistance, bool oldradiusdmg, bool circular);
 int	P_RadiusAttack (AActor *spot, AActor *source, int damage, double distance, 

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -6226,24 +6226,44 @@ int P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, double 
 							if (!(thing->flags7 & MF7_DONTTHRUST))
 							{
 								thrust = points * 0.5 / (double)thing->Mass;
+
 								if (bombsource == thing)
 								{
 									thrust *= selfthrustscale;
 								}
-								vz = (thing->Center() - bombspot->Z()) * thrust;
-								if (bombsource != thing)
+
+								if (flags & RADF_CIRCULARTHRUST)
 								{
-									vz *= 0.5;
+									auto dir = bombspot->Vec3To(thing);
+									dir.Z += thing->CenterOffset() - bombspot->CenterOffset();
+
+									if (!dir.isZero())
+									{
+										dir.MakeUnit();
+										thing->Thrust(dir * thrust);
+									}
 								}
 								else
 								{
-									vz *= 0.8;
-								}
-								thing->Thrust(bombspot->AngleTo(thing), thrust);
-								if (!(flags & RADF_NODAMAGE) || (flags & RADF_THRUSTZ))
-								{
-									if (!(thing->Level->i_compatflags2 & COMPATF2_EXPLODE1) || (flags & RADF_THRUSTZ))
-										thing->Vel.Z += vz;	// this really doesn't work well
+									thing->Thrust(bombspot->AngleTo(thing), thrust);
+
+									if (!(flags & RADF_NODAMAGE) || (flags & RADF_THRUSTZ))
+									{
+										if (!(thing->Level->i_compatflags2 & COMPATF2_EXPLODE1) || (flags & RADF_THRUSTZ))
+										{
+											vz = (thing->Center() - bombspot->Z()) * thrust;
+											if (bombsource != thing)
+											{
+												vz *= 0.5;
+											}
+											else
+											{
+												vz *= 0.8;
+											}
+										
+											thing->Vel.Z += vz;	// this really doesn't work well
+										}
+									}
 								}
 							}
 						}

--- a/wadsrc/static/zscript/actors/attacks.zs
+++ b/wadsrc/static/zscript/actors/attacks.zs
@@ -609,6 +609,7 @@ extend class Actor
 		if (flags & XF_THRUSTLESS) pflags |= RADF_THRUSTLESS;
 		if (flags & XF_NOALLIES) pflags |= RADF_NOALLIES;
 		if (flags & XF_CIRCULAR) pflags |= RADF_CIRCULAR;
+		if (flags & XF_CIRCULARTHRUST) pflags |= RADF_CIRCULARTHRUST;
 
 		int count = RadiusAttack (target, damage, distance, damagetype, pflags, fulldamagedistance);
 		if (!(flags & XF_NOSPLASH)) CheckSplash(distance);

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -267,6 +267,7 @@ enum EExplodeFlags
 	XF_THRUSTLESS = 64,
 	XF_NOALLIES = 128,
 	XF_CIRCULAR = 256,
+	XF_CIRCULARTHRUST = 512,
 };
 
 // Flags for A_RadiusThrust
@@ -276,6 +277,7 @@ enum ERadiusThrustFlags
 	RTF_NOIMPACTDAMAGE = 2,
 	RTF_NOTMISSILE = 4,
 	RTF_THRUSTZ = 16,
+	RTF_CIRCULARTHRUST = 512,
 };
 
 // Flags for A_RadiusDamageSelf
@@ -1251,7 +1253,8 @@ enum RadiusDamageFlags
 	RADF_OLDRADIUSDAMAGE = 32,
 	RADF_THRUSTLESS = 64,
 	RADF_NOALLIES = 128,
-	RADF_CIRCULAR = 256
+	RADF_CIRCULAR = 256,
+	RADF_CIRCULARTHRUST = 512,
 };
 
 enum IntermissionSequenceType


### PR DESCRIPTION
The original THRUSTZ variant ends up throwing enemies sky-high due to its strange math.

This adds something like: `vel += bomb.Vec3To(target).Unit() * thrust;` from one center towards other actor's center.

when RADF_CIRCULARTHRUST is active, RADF_THRUSTZ is ignored.