### PR TITLE
Support the new Doom + Doom II update

### DIFF
--- a/src/win32/i_steam.cpp
+++ b/src/win32/i_steam.cpp
@@ -183,6 +183,7 @@ static bool QueryPathKey(HKEY key, const wchar_t *keypath, const wchar_t *valnam
 
 TArray<FString> I_GetGogPaths()
 {
+	// TODO Does the 2024 Update affect GOG version?
 	TArray<FString> result;
 	FString path;
 	std::wstring gamepath;
@@ -292,9 +293,13 @@ TArray<FString> I_GetSteamPath()
 		"hexen/base",
 		"hexen deathkings of the dark citadel/base",
 		"ultimate doom/base",
+		"ultimate doom/base/doom2",                          // 2024 Update
+		"ultimate doom/base/tnt",                            // 2024 Update
+		"ultimate doom/base/plutonia",                       // 2024 Update
 		"DOOM 3 BFG Edition/base/wads",
 		"Strife",
-		"Ultimate Doom/rerelease/DOOM_Data/StreamingAssets",
+		"Ultimate Doom/rerelease/DOOM_Data/StreamingAssets", // 2019 Unity port (previous-re-release branch in Doom + Doom II app)
+		"Ultimate Doom/rerelease",                           // 2024 KEX Port
 		"Doom 2/rerelease/DOOM II_Data/StreamingAssets",
 		"Doom 2/finaldoombase",
         "Master Levels of Doom/doom2"
@@ -350,6 +355,7 @@ TArray<FString> I_GetBethesdaPath()
 	TArray<FString> result;
 	static const char* const bethesda_dirs[] =
 	{
+		// TODO Does the 2024 Update affect Bethesda Launcher?
 		"DOOM_Classic_2019/base",
 		"DOOM_Classic_2019/rerelease/DOOM_Data/StreamingAssets",
 		"DOOM_II_Classic_2019/base",

--- a/wadsrc_extra/static/iwadinfo.txt
+++ b/wadsrc_extra/static/iwadinfo.txt
@@ -338,6 +338,24 @@ IWad
 
 IWad
 {
+	Name = "DOOM: KEX Edition"
+	Autoname = "doom.id.doom1.kex"
+	Game = "Doom"
+	Config = "Doom"
+	IWADName = "doom.wad", 2
+	Mapinfo = "mapinfo/ultdoom.txt"
+	Compatibility = "Shorttex", "nosectionmerge"
+	MustContain = "E1M1","E2M1","E2M2","E2M3","E2M4","E2M5","E2M6","E2M7","E2M8","E2M9",
+		          "E3M1","E3M2","E3M3","E3M4","E3M5","E3M6","E3M7","E3M8","E3M9",
+		          "DPHOOF","BFGGA0","HEADA1","CYBRA1","SPIDA1D1", "E4M2",
+		          "DMENUPIC", "GAMECONF"
+	Load = "extras.wad"
+	BannerColors = "00 7c 00", "a8 a8 a8"
+	IgnoreTitlePatches = 1
+}
+
+IWad
+{
 	Name = "DOOM: Unity Edition"
 	Autoname = "doom.id.doom1.unity"
 	Game = "Doom"
@@ -445,6 +463,21 @@ IWad
 
 IWad
 {
+	Name = "Final Doom: TNT - Evilution: KEX Edition"
+	Autoname = "doom.id.doom2.tnt.kex"
+	Game = "Doom"
+	Config = "Doom"
+	IWADName = "tnt.wad"
+	Mapinfo = "mapinfo/tnt.txt"
+	Compatibility = "Shorttex", "Stairs"
+	MustContain = "MAP01", "REDTNT2", "GAMECONF"
+	BannerColors = "a8 00 00", "a8 a8 a8"
+	Load = "extras.wad"
+	IgnoreTitlePatches = 1
+}
+
+IWad
+{
 	Name = "Final Doom: TNT - Evilution"
 	Autoname = "doom.id.doom2.tnt"
 	Game = "Doom"
@@ -468,6 +501,21 @@ IWad
 	Compatibility = "Shorttex"
 	MustContain = "MAP01", "CAMO1", "DMAPINFO"
 	BannerColors = "00 7c 00", "a8 a8 a8"
+	IgnoreTitlePatches = 1
+}
+
+IWad
+{
+	Name = "Final Doom: Plutonia Experiment: KEX Edition"
+	Autoname = "doom.id.doom2.plutonia.kex"
+	Game = "Doom"
+	Config = "Doom"
+	IWADName = "plutonia.wad"
+	Mapinfo = "mapinfo/plutonia.txt"
+	Compatibility = "Shorttex"
+	MustContain = "MAP01", "CAMO1", "GAMECONF"
+	BannerColors = "a8 00 00", "a8 a8 a8"
+	Load = "extras.wad"
 	IgnoreTitlePatches = 1
 }
 
@@ -498,6 +546,21 @@ IWad
 	BannerColors = "a8 00 00", "a8 a8 a8"
 	Load = "nerve.wad"
 	IgnoreTitlePatches = 1
+}
+
+IWad
+{
+	Name = "DOOM 2: KEX Edition"
+	Autoname = "doom.id.doom2.kex"
+	Game = "Doom"
+	Config = "Doom"
+	IWADName = "doom2.wad", 2
+	Mapinfo = "mapinfo/doom2.txt"
+	Compatibility = "Shorttex", "nosectionmerge"
+	MustContain = "MAP01", "DMENUPIC", "GAMECONF"
+	BannerColors = "00 7c 00", "a8 a8 a8"
+	IgnoreTitlePatches = 1
+	Load = "extras.wad"
 }
 
 IWad
@@ -621,12 +684,16 @@ Order	// Order in the IWAD selection box
 	"DOOM 2: BFG Edition"
 	"DOOM: XBox Edition"
 	"DOOM 2: XBox Edition"
+	"DOOM: KEX Edition"
 	"DOOM: Unity Edition"
+	"DOOM 2: KEX Edition"
 	"DOOM 2: Unity Edition"
 	"Final Doom: Plutonia Experiment"
 	"Final Doom: Plutonia Experiment: Unity Edition"
+	"Final Doom: Plutonia Experiment: KEX Edition"
 	"Final Doom: TNT - Evilution"
 	"Final Doom: TNT - Evilution: Unity Edition"
+	"Final Doom: TNT - Evilution: KEX Edition"
 	"Freedoom: Phase 1"
 	"Freedoom: Phase 2"
 	"FreeDM"


### PR DESCRIPTION
Adds new folders for the Doom + Doom II update, as well as new "[DOOMGAME]: KEX Edition" entries to the `gameinfo.txt` file

![GZDoom Launcher with new KEX Entries](https://github.com/user-attachments/assets/dae8db72-9b9e-4d4a-8a0b-d9a76088b0f8)

I have tested all the changes, works when I have Doom II removed from Steam folders

The following things are not done yet (low priority for now):
- `soundinfo` lumps for all KEX titles (`extras.wad` includes all the music in OGG format with `H_` and `O_` prefixes)
- Update stuff for those who own Doom + Doom II via GOG [1] or Bethesda Launcher, probably Game Pass as well (if possible)
- SIGIL, NRFTL and Legacy of Rust
- Linux changes

See [DOOM + DOOM II Release Notes on Slayers Club](https://slayersclub.bethesda.net/en-US/article/doom-doomii-release-notes) for information on the new update

----
[1]: Apparently GOG version got the Doom + Doom II Update https://www.gog.com/en/game/doom_doom_ii - I don't currently own GOG version of Doom + Doom II so I cannot test it