### PR TITLE
Fix MBF21 A_RadiusDamage crash & broken 'distance' arg

### DIFF
--- a/wadsrc/static/zscript/actors/attacks.zs
+++ b/wadsrc/static/zscript/actors/attacks.zs
@@ -626,7 +626,7 @@ extend class Actor
 	}
 
 	deprecated("2.3", "For Dehacked use only")
-	void A_RadiusDamage(int dam, double dist)
+	void A_RadiusDamage(int dam, int dist)
 	{
 		A_Explode(dam, dist);
 	}


### PR DESCRIPTION
MBF21's A_RadiusDamage takes an int as its 'distance' arg, rather than a double -- this is correct code-side, but the ZScript definition used `double`, causing it to read junk data for the radius (and sometimes crash).

This probably fixes #2656, since the Incinerator (flamethrower) uses A_RadiusDamage and the crash's call stack included the `clamp` function mentioned in the other thread, though I don't have a Linux box handy to doublecheck.