### PR TITLE
Fix A_PlaySound not working for DSDHACKED-defined sounds

### DIFF
--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -843,7 +843,7 @@ static void CreateScratchFunc(FunctionCallEmitter &emitters, int value1, int val
 // misc1 = sound, misc2 = attenuation none (true) or normal (false)
 static void CreatePlaySoundFunc(FunctionCallEmitter &emitters, int value1, int value2, MBFParamState* state)
 { // A_PlaySound
-	emitters.AddParameterIntConst(DehFindSound(value1 - 1, true).index());		// soundid
+	emitters.AddParameterIntConst(DehFindSound(value1 - 1, false).index());		// soundid
 	emitters.AddParameterIntConst(CHAN_BODY);							// channel
 	emitters.AddParameterFloatConst(1);									// volume
 	emitters.AddParameterIntConst(false);								// looping


### PR DESCRIPTION
See title -- A_PlaySound currently isn't working for DSDHACKED-defined sounds. This affects several actors in the new Legacy of Rust expansion (incinerator flames, vassago flames, banshees).

That said, I'm not totally sure if this commit is the best way to fix it, since I'm not totally sure of the intent of the `DehFindSound` function's `mustexist` arg -- if it's set to `true`, it skips DSDHACKED resolution completely; maybe that's the actual bug here?

If someone with a bit more knowledge on this bit of code could chime in, that'd help a bit. Want to make sure I'm not breaking something or missing a bigger picture.