### PR TITLE
Fix down arrow key doing nothing after clicking the main menu

### DIFF
--- a/wadsrc/static/zscript/engine/ui/menu/listmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/listmenu.zs
@@ -188,11 +188,12 @@ class ListMenu : Menu
 	override bool MenuEvent (int mkey, bool fromcontroller)
 	{
 		int oldSelect = mDesc.mSelectedItem;
-		int startedAt = max(0, mDesc.mSelectedItem);
+		int startedAt;
 
 		switch (mkey)
 		{
 		case MKEY_Up:
+			startedAt = mDesc.mSelectedItem < 0 ? 0 : mDesc.mSelectedItem;
 			do
 			{
 				if (--mDesc.mSelectedItem < 0) mDesc.mSelectedItem = mDesc.mItems.Size()-1;
@@ -203,6 +204,7 @@ class ListMenu : Menu
 			return true;
 
 		case MKEY_Down:
+			startedAt = mDesc.mSelectedItem < 0 ? mDesc.mItems.Size()-1 : mDesc.mSelectedItem;
 			do
 			{
 				if (++mDesc.mSelectedItem >= mDesc.mItems.Size()) mDesc.mSelectedItem = 0;


### PR DESCRIPTION
Fixes #2646.

This issue was previously fixed in 0c2ed71cdd2676af6aecf6e26b0ab1a692e66d71, but that change added a bug that would trigger an infinite loop on scrolling in a list without any selectable items. Then 4fdbe81a132c472532985d31143c0dc26605283a restored the old behavior, reintroducing the issue. The new fix in this PR does handle lists without any selectable items correctly.

The problem is that the code tries to avoid infinite loops by checking at the end of each loop that `mDesc.mSelectedItem` has returned to the `startedAt` value, and when the menu had recently been clicked on, `mDesc.mSelectedItem` would start at -1, `startedAt` would be set to `max(0, mDesc.mSelectedItem) = 0`, which means that if the user pressed the down arrow and `mDesc.mSelectedItem` was incremented to `0`, then the cursor movement would be aborted because it's now equal to `startedAt`.

The solution is that when `mDesc.mSelectedItem` starts at -1, initialize `startedAt` differently depending on the movement direction, so that it matches the position that we're effectively moving from. When you press down arrow while `mDesc.mSelectedItem` starts at -1, we set `startedAt` to the last item in the list. (When you press up arrow, we still set `startedAt` to the first item in the list.)