### PR TITLE
Fix load/save menus not starting scrolled to the selected entry

### DIFF
--- a/wadsrc/static/zscript/engine/ui/menu/loadsavemenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/loadsavemenu.zs
@@ -483,8 +483,8 @@ class SaveMenu : LoadSaveMenu
 	{
 		Super.Init(parent, desc);
 		manager.InsertNewSaveNode();
-		TopItem = 0;
 		Selected = manager.ExtractSaveData (-1);
+		TopItem = MAX(0, Selected - listboxRows + 1);
 		UpdateSaveComment();
 	}
 
@@ -623,8 +623,8 @@ class LoadMenu : LoadSaveMenu
 	override void Init(Menu parent, ListMenuDescriptor desc)
 	{
 		Super.Init(parent, desc);
-		TopItem = 0;
 		Selected = manager.ExtractSaveData (-1);
+		TopItem = MAX(0, Selected - listboxRows + 1);
 		UpdateSaveComment();
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ZDoom/gzdoom/issues/2645.

I used the same calculation for `TopItem` here that's used when scrolling down in a list. Both the save and load menus now start scrolled down the minimum amount to make the initially-selected item visible. (If the initially-selected item is already visible without scrolling, then no scrolling is done.)