### PR TITLE
Hotfix for reflections in floors/ceilings

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -452,9 +452,12 @@ void HWDrawInfo::CreateScene(bool drawpsprites)
 	angle_t a1 = FrustumAngle(); // horizontally clip the back of the viewport
 	mClipper->SafeAddClipRangeRealAngles(vp.Angles.Yaw.BAMs() + a1, vp.Angles.Yaw.BAMs() - a1);
 	Viewpoint.FrustAngle = a1;
-	double a2 = 20.0 + 0.5*Viewpoint.FieldOfView.Degrees(); // FrustumPitch for vertical clipping
-	if (a2 > 179.0) a2 = 179.0;
-	vClipper->SafeAddClipRangeDegPitches(vp.HWAngles.Pitch.Degrees() - a2, vp.HWAngles.Pitch.Degrees() + a2); // clip the suplex range
+	if (Viewpoint.IsAllowedOoB()) // No need for vertical clipper if viewpoint not allowed out of bounds
+	{
+		double a2 = 20.0 + 0.5*Viewpoint.FieldOfView.Degrees(); // FrustumPitch for vertical clipping
+		if (a2 > 179.0) a2 = 179.0;
+		vClipper->SafeAddClipRangeDegPitches(vp.HWAngles.Pitch.Degrees() - a2, vp.HWAngles.Pitch.Degrees() + a2); // clip the suplex range
+	}
 
 	// reset the portal manager
 	portalState.StartFrame();


### PR DESCRIPTION
I forgot one small check for vertical clipping.
This was causing vertically out-of-view subsectors to not show up in reflecting floors. Easy fix.