### PR TITLE
Added itemcls to HasReceived

### DIFF
--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -534,7 +534,9 @@ class Actor : Thinker native
 	// [AA] Called by inventory items at the end of CallTryPickup to let actors
 	// do something with the items they've received. 'Item' might be null for
 	// items that disappear on pickup.
-	virtual void HasReceived(Inventory item) {}
+	// 'itemcls' is passed unconditionally, so it can still be read even if
+	// 'item' is null due to being destroyed with GoAwayAndDie() on pickup.
+	virtual void HasReceived(Inventory item, class<Inventory> itemcls) {}
 
   // Called in TryMove if the mover ran into another Actor. This isn't called on players
 	// if they're currently predicting. Guarantees collisions unlike CanCollideWith.
@@ -705,7 +707,7 @@ class Actor : Thinker native
 	native void SoundAlert(Actor target, bool splash = false, double maxdist = 0);
 	native void ClearBounce();
 	native TerrainDef GetFloorTerrain();
-	native bool CheckLocalView(int consoleplayer = -1 /* parameter is not used anymore but needed for backward compatibilityö. */);
+	native bool CheckLocalView(int consoleplayer = -1 /* parameter is not used anymore but needed for backward compatibilityï¿½. */);
 	native bool CheckNoDelay();
 	native bool UpdateWaterLevel (bool splash = true);
 	native bool IsZeroDamage();

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -536,7 +536,7 @@ class Actor : Thinker native
 	// items that disappear on pickup.
 	// 'itemcls' is passed unconditionally, so it can still be read even if
 	// 'item' is null due to being destroyed with GoAwayAndDie() on pickup.
-	virtual void HasReceived(Inventory item, class<Inventory> itemcls) {}
+	virtual void HasReceived(Inventory item, class<Inventory> itemcls = null) {}
 
   // Called in TryMove if the mover ran into another Actor. This isn't called on players
 	// if they're currently predicting. Guarantees collisions unlike CanCollideWith.
@@ -707,7 +707,7 @@ class Actor : Thinker native
 	native void SoundAlert(Actor target, bool splash = false, double maxdist = 0);
 	native void ClearBounce();
 	native TerrainDef GetFloorTerrain();
-	native bool CheckLocalView(int consoleplayer = -1 /* parameter is not used anymore but needed for backward compatibility�. */);
+	native bool CheckLocalView(int consoleplayer = -1 /* parameter is not used anymore but needed for backward compatibility. */);
 	native bool CheckNoDelay();
 	native bool UpdateWaterLevel (bool splash = true);
 	native bool IsZeroDamage();

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -646,9 +646,10 @@ class Inventory : Actor
 		// unmorphed versions of a currently morphed actor cannot pick up anything. 
 		if (bUnmorphed) return false, null;
 
-		//[AA] starting with true, so that CanReceive can unset it,
+		// [AA] starting with true, so that CanReceive can unset it,
 		// if necessary:
 		bool res = true;
+		class<Inventory> cls = self.GetClass();
 		// [AA] CanReceive lets the actor receiving the item process it first.
 		if (!toucher.CanReceive(self))
 		{
@@ -695,7 +696,7 @@ class Inventory : Actor
 				}
 			}
 			// [AA] Let the toucher do something with the item they've just received:
-			toucher.HasReceived(self);
+			toucher.HasReceived(self, cls);
 
 			// If the item can be shared, make sure every player gets a copy.
 			if (multiplayer && !deathmatch && !bDropped && ShouldShareItem(toucher))


### PR DESCRIPTION
CallTryPickup will cache the item's class and pass it to HasReceived, so the latter will know what item was received even if the item has been destroyed by the time it's called.

P.S. Again (because this happened before), I don't know what's up with line 708 in actor.zs. There seems to be an invalid character there, I didn't add any changes manually, VSCode just did that.