### PR TITLE
Add support for fire textures in ANIMDEFS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1022,6 +1022,7 @@ set (PCH_SOURCES
 	common/textures/multipatchtexturebuilder.cpp
 	common/textures/skyboxtexture.cpp
 	common/textures/animtexture.cpp
+	common/textures/firetexture.cpp
 	common/textures/v_collection.cpp
 	common/textures/formats/automaptexture.cpp
 	common/textures/formats/brightmaptexture.cpp

--- a/src/common/textures/firetexture.cpp
+++ b/src/common/textures/firetexture.cpp
@@ -1,0 +1,139 @@
+/*
+** firetexture.cpp
+** PSX/N64-style fire texture implementation
+**
+**---------------------------------------------------------------------------
+** Copyright Cacodemon345 2024
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions
+** are met:
+**
+** 1. Redistributions of source code must retain the above copyright
+**    notice, this list of conditions and the following disclaimer.
+** 2. Redistributions in binary form must reproduce the above copyright
+**    notice, this list of conditions and the following disclaimer in the
+**    documentation and/or other materials provided with the distribution.
+** 3. The name of the author may not be used to endorse or promote products
+**    derived from this software without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+** IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+** OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+** IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+** INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+** NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+** THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**---------------------------------------------------------------------------
+**
+*/
+
+/* Algorithm based on https://github.com/fabiensanglard/DoomFirePSX */
+
+#include "bitmap.h"
+#include "firetexture.h"
+#include "m_random.h"
+#include "imagehelpers.h"
+
+#include "engineerrors.h"
+
+static constexpr int32_t FIRESKY_W = 64;
+static constexpr int32_t FIRESKY_H = 128;
+
+FireTexture::FireTexture()
+{
+	SetSize(FIRESKY_W, FIRESKY_H);
+	Image.Clear();
+	Image.AppendFill(0, Width * Height);
+}
+
+void FireTexture::SetPalette(TArray<PalEntry>& colors)
+{
+	Palette.Clear();
+	Palette.Append(colors);
+
+	/* This shouldn't happen in any circumstances. */
+	if (Palette.Size() > 256)
+	{
+		I_FatalError("Fire palette too big!");
+	}
+
+	for (unsigned int i = 0; i < Width; i++) {
+		Image[(Height - 1) * Width + i] = (uint8_t)(Palette.Size() - 1);
+	}
+}
+
+void FireTexture::Update()
+{
+	for (unsigned int y = 1; y < Height; y++)
+	{
+		for (unsigned int x = 0; x < Width; x++)
+		{
+			uint8_t srcPixel = Image[y * Width + x];
+
+			if (srcPixel == 0)
+			{
+				Image[(y - 1) * Width + x] = 0;
+			}
+			else
+			{
+				int XRand = M_Random() & 3;
+				int destRand = M_Random() & 1;
+
+				Image[(y - 1) * Width + ((x + 1 - XRand) % Width)] = srcPixel - destRand;
+			}
+		}
+	}
+}
+
+FBitmap FireTexture::GetBgraBitmap(const PalEntry* remap, int* trans)
+{
+	FBitmap bitmap;
+	bitmap.Create(Width, Height);
+	uint32_t* pixels = (uint32_t*)bitmap.GetPixels();
+
+	for (unsigned int y = 0; y < Height; y++)
+	{
+		for (unsigned int x = 0; x < Width; x++)
+		{
+			pixels[y * Width + x] = Palette[Image[y * Width + x]];
+		}
+	}
+	
+	return bitmap;
+}
+
+TArray<uint8_t> FireTexture::Get8BitPixels(bool alphatex)
+{
+	FBitmap bitmap = GetBgraBitmap(nullptr, nullptr);
+	const uint8_t* data = bitmap.GetPixels();
+
+	uint8_t* dest_p;
+	int dest_adv = Height;
+	int dest_rew = Width * Height - 1;
+
+	TArray<uint8_t> Pixels(Width * Height);
+	dest_p = Pixels.Data();
+
+	bool doalpha = alphatex;
+	// Convert the source image from row-major to column-major format and remap it
+	for (int y = Height; y != 0; --y)
+	{
+		for (int x = Width; x != 0; --x)
+		{
+			int b = *data++;
+			int g = *data++;
+			int r = *data++;
+			int a = *data++;
+			if (a < 128) *dest_p = 0;
+			else *dest_p = ImageHelpers::RGBToPalette(doalpha, r, g, b);
+			dest_p += dest_adv;
+		}
+		dest_p -= dest_rew;
+	}
+	return Pixels;
+}

--- a/src/common/textures/firetexture.h
+++ b/src/common/textures/firetexture.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "textures.h"
+
+
+class FireTexture : public FTexture
+{
+	TArray<uint8_t> Image;
+	TArray<PalEntry> Palette;
+
+public:
+	FireTexture();
+	void SetPalette(TArray<PalEntry>& colors);
+	void Update();
+	virtual FBitmap GetBgraBitmap(const PalEntry* remap, int* trans) override;
+	virtual TArray<uint8_t> Get8BitPixels(bool alphatex) override;
+};

--- a/src/common/textures/image.cpp
+++ b/src/common/textures/image.cpp
@@ -306,7 +306,8 @@ void FImageSource::EndPrecaching()
 
 void FImageSource::RegisterForPrecache(FImageSource *img, bool requiretruecolor)
 {
-	img->CollectForPrecache(precacheInfo, requiretruecolor);
+	if (img)
+		img->CollectForPrecache(precacheInfo, requiretruecolor);
 }
 
 //==========================================================================

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -1146,7 +1146,10 @@ void FTextureAnimator::UpdateAnimations (uint64_t mstime)
 		if (updated)
 		{
 			fire->texture->CleanHardwareData();
-			delete fire->texture->GetSoftwareTexture();
+
+			if (fire->texture->GetSoftwareTexture())
+				delete fire->texture->GetSoftwareTexture();
+
 			fire->texture->SetSoftwareTexture(nullptr);
 		}
 	}

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -62,7 +62,12 @@ static FRandom pr_animatepictures ("AnimatePics");
 
 void FTextureAnimator::DeleteAll()
 {
+	for (unsigned int i = 0; i < mFireTextures.Size(); i++)
+	{
+		mFireTextures[i].texture->CleanHardwareData(true);
+	}
 	mAnimations.Clear();
+	mFireTextures.Clear();
 
 	for (unsigned i = 0; i < mSwitchDefs.Size(); i++)
 	{
@@ -347,6 +352,10 @@ void FTextureAnimator::InitAnimDefs ()
 				{
 					TexMan.GameTexture(picnum)->SetSkyOffset(sc.Number);
 				}
+			}
+			else if (sc.Compare("firetexture"))
+			{
+				ParseFireTexture (sc);
 			}
 			else
 			{
@@ -782,6 +791,84 @@ void FTextureAnimator::ParseCameraTexture(FScanner &sc)
 	viewer->SetDisplaySize((float)fitwidth, (float)fitheight);
 }
 
+void FTextureAnimator::ParseFireTexture(FScanner& sc)
+{
+	FString picname;
+	FFireTexture fireTexture;
+	TArray<PalEntry> palette;
+	uint32_t duration;
+
+	sc.MustGetString();
+	picname = sc.String;
+	sc.MustGetStringName("tics");
+	sc.MustGetValue(true);
+	duration = uint32_t(sc.Float * 1000 / TICRATE);
+
+	FGameTexture* gametex = MakeGameTexture(new FireTexture(), picname.GetChars(), ETextureType::Wall);
+	// No decals here.
+	gametex->SetNoDecals(true);
+	if (sc.GetString())
+	{
+		if (sc.Compare("allowdecals"))
+		{
+			gametex->SetNoDecals(false);
+		}
+		else
+		{
+			sc.UnGet();
+		}
+	}
+	while (sc.GetString())
+	{
+		if (sc.Compare("color"))
+		{
+			uint8_t r, g, b, a;
+			sc.MustGetValue(false);
+			r = sc.Number;
+			sc.MustGetValue(false);
+			g = sc.Number;
+			sc.MustGetValue(false);;
+			b = sc.Number;
+			sc.MustGetValue(false);
+			a = sc.Number;
+			palette.Push(PalEntry(a, r, g, b));
+			if (a != 255 && a != 0);
+				gametex->SetTranslucent(true);
+
+			if (palette.Size() > 256)
+			{
+				sc.ScriptError("Too many colors specified!");
+			}
+		}
+		else if (sc.Compare("palette"))
+		{
+			uint8_t index = 0;
+			sc.MustGetValue(false);
+			index = sc.Number;
+			PalEntry pal = GPalette.BaseColors[index];
+			pal.a = pal.isBlack() ? 0 : 255;
+			palette.Push(pal);
+
+			if (palette.Size() > 256)
+			{
+				sc.ScriptError("Too many colors specified!");
+			}
+		}
+		else
+		{
+			sc.UnGet();
+			break;
+		}
+	}
+
+	fireTexture.texture = gametex;
+	fireTexture.Duration = duration;
+	fireTexture.SwitchTime = 0;
+	static_cast<FireTexture*>(gametex->GetTexture())->SetPalette(palette);
+	mFireTextures.Push(fireTexture);
+	TexMan.AddGameTexture(gametex);
+}
+
 //==========================================================================
 //
 // FTextureAnimator :: FixAnimations
@@ -1040,6 +1127,29 @@ FTextureID FTextureAnimator::UpdateStandaloneAnimation(FStandaloneAnimation &ani
 
 void FTextureAnimator::UpdateAnimations (uint64_t mstime)
 {
+	for (unsigned int i = 0; i < mFireTextures.Size(); i++)
+	{
+		FFireTexture* fire = &mFireTextures[i];
+		bool updated = false;
+
+		if (fire->SwitchTime == 0)
+		{
+			fire->SwitchTime = mstime + fire->Duration;
+		}
+		else while (fire->SwitchTime <= mstime)
+		{
+			static_cast<FireTexture*>(fire->texture->GetTexture())->Update();
+			fire->SwitchTime = mstime + fire->Duration;
+			updated = true;
+		}
+
+		if (updated)
+		{
+			fire->texture->CleanHardwareData();
+			delete fire->texture->GetSoftwareTexture();
+			fire->texture->SetSoftwareTexture(nullptr);
+		}
+	}
 	for (unsigned int j = 0; j < mAnimations.Size(); ++j)
 	{
 		FAnimDef *anim = &mAnimations[j];

--- a/src/gamedata/textures/animations.h
+++ b/src/gamedata/textures/animations.h
@@ -5,6 +5,7 @@
 #include "textureid.h"
 #include "tarray.h"
 #include "s_soundinternal.h"
+#include "firetexture.h"
 
 struct FStandaloneAnimation
 {
@@ -16,6 +17,13 @@ struct FStandaloneAnimation
 };
 
 static_assert(sizeof(FStandaloneAnimation) == sizeof(uint64_t)*2);
+
+struct FFireTexture
+{
+	uint32_t Duration; // Duration before updates.
+	uint64_t SwitchTime; // Absolute time before update.
+	FGameTexture* texture;
+};
 
 struct FAnimDef
 {
@@ -77,6 +85,7 @@ class FTextureAnimator
 	TArray<FAnimDef> mAnimations;
 	TArray<FSwitchDef*> mSwitchDefs;
 	TArray<FDoorAnimation> mAnimatedDoors;
+	TArray<FFireTexture> mFireTextures;
 
 	void ParseAnim(FScanner& sc, ETextureType usetype);
 	FAnimDef* ParseRangeAnim(FScanner& sc, FTextureID picnum, ETextureType usetype, bool missing);
@@ -84,6 +93,7 @@ class FTextureAnimator
 	void ParseWarp(FScanner& sc);
 	void ParseCanvasTexture(FScanner& sc);
 	void ParseCameraTexture(FScanner& sc);
+	void ParseFireTexture(FScanner& sc);
 	FTextureID ParseFramenum(FScanner& sc, FTextureID basepicnum, ETextureType usetype, bool allowMissing);
 	void ParseTime(FScanner& sc, uint32_t& min, uint32_t& max);
 

--- a/src/rendering/swrenderer/drawers/r_draw_sky32.h
+++ b/src/rendering/swrenderer/drawers/r_draw_sky32.h
@@ -64,6 +64,8 @@ namespace swrenderer
 				{
 					uint32_t sample_index = (((((uint32_t)frac) << 8) >> FRACBITS) * textureheight0) >> FRACBITS;
 					*dest = source0[sample_index];
+					if (*dest == 0)
+						*dest |= 0xff000000;
 					dest += pitch;
 					frac += fracstep;
 				}
@@ -90,6 +92,8 @@ namespace swrenderer
 			{
 				uint32_t sample_index = (((((uint32_t)frac) << 8) >> FRACBITS) * textureheight0) >> FRACBITS;
 				uint32_t fg = source0[sample_index];
+				if (fg == 0)
+					fg |= 0xff000000;
 
 				uint32_t alpha = max(min(frac >> (16 - start_fade), 256), 0);
 				uint32_t inv_alpha = 256 - alpha;
@@ -110,6 +114,8 @@ namespace swrenderer
 			{
 				uint32_t sample_index = (((((uint32_t)frac) << 8) >> FRACBITS) * textureheight0) >> FRACBITS;
 				*dest = source0[sample_index];
+				if (*dest == 0)
+					*dest |= 0xff000000;
 
 				frac += fracstep;
 				dest += pitch;
@@ -121,6 +127,8 @@ namespace swrenderer
 			{
 				uint32_t sample_index = (((((uint32_t)frac) << 8) >> FRACBITS) * textureheight0) >> FRACBITS;
 				uint32_t fg = source0[sample_index];
+				if (fg == 0)
+					fg |= 0xff000000;
 
 				uint32_t alpha = max(min(((2 << 24) - frac) >> (16 - start_fade), 256), 0);
 				uint32_t inv_alpha = 256 - alpha;
@@ -189,6 +197,8 @@ namespace swrenderer
 					{
 						uint32_t sample_index2 = min(sample_index, maxtextureheight1);
 						fg = source1[sample_index2];
+						if (fg == 0)
+							fg |= 0xff000000;
 					}
 
 					*dest = fg;
@@ -222,6 +232,8 @@ namespace swrenderer
 				{
 					uint32_t sample_index2 = min(sample_index, maxtextureheight1);
 					fg = source1[sample_index2];
+					if (fg == 0)
+						fg |= 0xff000000;
 				}
 
 				uint32_t alpha = max(min(frac >> (16 - start_fade), 256), 0);
@@ -245,6 +257,8 @@ namespace swrenderer
 				{
 					uint32_t sample_index2 = min(sample_index, maxtextureheight1);
 					fg = source1[sample_index2];
+					if (fg == 0)
+						fg |= 0xff000000;
 				}
 				*dest = fg;
 
@@ -262,6 +276,8 @@ namespace swrenderer
 				{
 					uint32_t sample_index2 = min(sample_index, maxtextureheight1);
 					fg = source1[sample_index2];
+					if (fg == 0)
+						fg |= 0xff000000;
 				}
 
 				uint32_t alpha = max(min(((2 << 24) - frac) >> (16 - start_fade), 256), 0);

--- a/src/rendering/swrenderer/drawers/r_draw_sky32_sse2.h
+++ b/src/rendering/swrenderer/drawers/r_draw_sky32_sse2.h
@@ -64,6 +64,8 @@ namespace swrenderer
 				{
 					uint32_t sample_index = (((((uint32_t)frac) << 8) >> FRACBITS) * textureheight0) >> FRACBITS;
 					*dest = source0[sample_index];
+					if (*dest == 0)
+						*dest |= 0xff000000;
 					dest += pitch;
 					frac += fracstep;
 				}
@@ -90,6 +92,8 @@ namespace swrenderer
 			{
 				uint32_t sample_index = (((((uint32_t)frac) << 8) >> FRACBITS) * textureheight0) >> FRACBITS;
 				uint32_t fg = source0[sample_index];
+				if (fg == 0)
+					fg |= 0xff000000;
 
 				__m128i alpha = _mm_set1_epi16(max(min(frac >> (16 - start_fade), 256), 0));
 				__m128i inv_alpha = _mm_sub_epi16(_mm_set1_epi16(256), alpha);
@@ -108,6 +112,8 @@ namespace swrenderer
 			{
 				uint32_t sample_index = (((((uint32_t)frac) << 8) >> FRACBITS) * textureheight0) >> FRACBITS;
 				*dest = source0[sample_index];
+				if (*dest == 0)
+					*dest |= 0xff000000;
 
 				frac += fracstep;
 				dest += pitch;
@@ -119,6 +125,8 @@ namespace swrenderer
 			{
 				uint32_t sample_index = (((((uint32_t)frac) << 8) >> FRACBITS) * textureheight0) >> FRACBITS;
 				uint32_t fg = source0[sample_index];
+				if (fg == 0)
+					fg |= 0xff000000;
 
 				__m128i alpha = _mm_set1_epi16(max(min(((2 << 24) - frac) >> (16 - start_fade), 256), 0));
 				__m128i inv_alpha = _mm_sub_epi16(_mm_set1_epi16(256), alpha);
@@ -173,6 +181,8 @@ namespace swrenderer
 					{
 						uint32_t sample_index2 = min(sample_index, maxtextureheight1);
 						fg = source1[sample_index2];
+						if (fg == 0)
+							fg |= 0xff000000;
 					}
 
 					*dest = fg;
@@ -218,6 +228,8 @@ namespace swrenderer
 				{
 					uint32_t sample_index2 = min(sample_index, maxtextureheight1);
 					fg = source1[sample_index2];
+					if (fg == 0)
+						fg |= 0xff000000;
 				}
 
 				__m128i alpha = _mm_set1_epi16(max(min(frac >> (16 - start_fade), 256), 0));
@@ -241,6 +253,8 @@ namespace swrenderer
 				{
 					uint32_t sample_index2 = min(sample_index, maxtextureheight1);
 					fg = source1[sample_index2];
+					if (fg == 0)
+						fg |= 0xff000000;
 				}
 				*dest = fg;
 
@@ -258,6 +272,8 @@ namespace swrenderer
 				{
 					uint32_t sample_index2 = min(sample_index, maxtextureheight1);
 					fg = source1[sample_index2];
+					if (fg == 0)
+						fg |= 0xff000000;
 				}
 
 				__m128i alpha = _mm_set1_epi16(max(min(((2 << 24) - frac) >> (16 - start_fade), 256), 0));


### PR DESCRIPTION
This PR adds support for defining fire textures in ANIMDEFS.

Syntax is:
FIRETEXTURE tics <numtics>

followed by a series of either "palette index" or "color red green blue alpha".

Example (converted from Legacy of Rust's SKYDEFS definition):
```
firetexture FIRETEST tics 2.00025
	palette 0
	palette 47
	palette 191
	palette 187
	palette 235
	palette 234
	palette 232
	palette 167
	palette 166
	palette 165
	palette 223
	palette 221
	palette 220
	palette 219
	palette 217
	palette 216
	palette 215
	palette 214
	palette 213
	palette 164
	palette 163
	palette 162
	palette 161
	palette 160
	palette 231
	palette 230
	palette 229
	palette 228
	palette 227
	palette 226
	palette 225
	palette 224
```