### PR TITLE
Smaller aspect ratio screens were getting over-clipped

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -366,9 +366,16 @@ angle_t HWDrawInfo::FrustumAngle()
 {
 	// If pitch is larger than this you can look all around at an FOV of 90 degrees
 	if (fabs(Viewpoint.HWAngles.Pitch.Degrees()) > 89.0)  return 0xffffffff;
+	int aspMult = AspectMultiplier(r_viewwindow.WidescreenRatio); // 48 == square window
+	double absPitch = fabs(Viewpoint.HWAngles.Pitch.Degrees());
+	 // Smaller aspect ratios still clip too much. Need a better solution
+	if (aspMult > 36 && absPitch > 30.0)  return 0xffffffff;
+	else if (aspMult > 40 && absPitch > 25.0)  return 0xffffffff;
+	else if (aspMult > 45 && absPitch > 20.0)  return 0xffffffff;
+	else if (aspMult > 47 && absPitch > 10.0) return 0xffffffff;
 
 	double xratio = r_viewwindow.FocalTangent / Viewpoint.PitchCos;
-	double floatangle = 0.035 + atan ( xratio ) * 48.0 / AspectMultiplier(r_viewwindow.WidescreenRatio); // this is radians
+	double floatangle = 0.05 + atan ( xratio ) * 48.0 / aspMult; // this is radians
 	angle_t a1 = DAngle::fromRad(floatangle).BAMs();
 
 	if (a1 >= ANGLE_90) return 0xffffffff;


### PR DESCRIPTION
Someone was running windowed mode at smaller aspect ratio and discovered clipped regions at the edges of the screen.

This is a brute-force if-else solution. The real math can be figured out later.

Larger aspect ratios (wider screens) were always good. I really thought that I had solved this.