### PR TITLE
- address adaptive sync flicker issue

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -75,7 +75,9 @@
 
 EXTERN_CVAR (Int, disableautosave)
 EXTERN_CVAR (Int, autosavecount)
-EXTERN_CVAR(Bool, cl_capfps)
+EXTERN_CVAR (Bool, cl_capfps)
+EXTERN_CVAR (Bool, vid_vsync)
+EXTERN_CVAR (Int, vid_maxfps)
 
 //#define SIMULATEERRORS		(RAND_MAX/3)
 #define SIMULATEERRORS			0
@@ -1880,7 +1882,7 @@ void TryRunTics (void)
 
 	bool doWait = (cl_capfps || pauseext || (r_NoInterpolate && !M_IsAnimated()));
 
-	if (vid_dontdowait)
+	if (vid_dontdowait && ((vid_maxfps > 0) || (vid_vsync == true)))
 		doWait = false;
 
 	// get real tics

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -150,6 +150,8 @@ static int	oldentertics;
 
 extern	bool	 advancedemo;
 
+CVAR(Bool, vid_dontdowait, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+
 CVAR(Bool, net_ticbalance, false, CVAR_SERVERINFO | CVAR_NOSAVE)
 CUSTOM_CVAR(Int, net_extratic, 0, CVAR_SERVERINFO | CVAR_NOSAVE)
 {
@@ -1877,6 +1879,9 @@ void TryRunTics (void)
 	int 		numplaying;
 
 	bool doWait = (cl_capfps || pauseext || (r_NoInterpolate && !M_IsAnimated()));
+
+	if (vid_dontdowait)
+		doWait = false;
 
 	// get real tics
 	if (doWait)


### PR DESCRIPTION
Got a complaint in Discord that activating the menu causes some screens to flicker due to adaptive sync. This disables the cap and allows the game to run to its maximum FPS.