### PR TITLE
Max draw distance setting

### DIFF
--- a/src/common/rendering/gl/gl_renderstate.cpp
+++ b/src/common/rendering/gl/gl_renderstate.cpp
@@ -124,6 +124,7 @@ bool FGLRenderState::ApplyShader()
 
 	activeShader->muDesaturation.Set(mStreamData.uDesaturationFactor);
 	activeShader->muFogEnabled.Set(fogset);
+	activeShader->muMaxDrawFogTurnOn.Set(mMaxDrawFogTurnOn);
 
 	activeShader->muTextureMode.Set(GetTextureModeAndFlags(mTempTM));
 	activeShader->muLightParms.Set(mLightParms);

--- a/src/common/rendering/gl/gl_shader.cpp
+++ b/src/common/rendering/gl/gl_shader.cpp
@@ -275,6 +275,7 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 		#define uLightFactor uLightAttr.g
 		#define uLightDist uLightAttr.r
 		uniform int uFogEnabled;
+		uniform float uMaxDrawFogTurnOn;
 
 		// dynamic lights
 		uniform int uLightIndex;
@@ -579,6 +580,7 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 
 	muDesaturation.Init(hShader, "uDesaturationFactor");
 	muFogEnabled.Init(hShader, "uFogEnabled");
+	muMaxDrawFogTurnOn.Init(hShader, "uMaxDrawFogTurnOn");
 	muTextureMode.Init(hShader, "uTextureMode");
 	muLightParms.Init(hShader, "uLightAttr");
 	muClipSplit.Init(hShader, "uClipSplit");

--- a/src/common/rendering/gl/gl_shader.h
+++ b/src/common/rendering/gl/gl_shader.h
@@ -237,6 +237,7 @@ class FShader
 
 	FBufferedUniform1f muDesaturation;
 	FBufferedUniform1i muFogEnabled;
+	FBufferedUniform1f muMaxDrawFogTurnOn;
 	FBufferedUniform1i muTextureMode;
 	FBufferedUniform4f muLightParms;
 	FBufferedUniform2f muClipSplit;

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -224,6 +224,7 @@ protected:
 	int mTextureModeFlags;
 	int mSoftLight;
 	float mLightParms[4];
+	float mMaxDrawFogTurnOn;
 
 	float mAlphaThreshold;
 	float mClipSplit[2];
@@ -260,6 +261,7 @@ public:
 		mBrightmapEnabled = mGradientEnabled = mFogEnabled = mGlowEnabled = false;
 		mFogColor = 0xffffffff;
 		mStreamData.uFogColor = mFogColor;
+		mMaxDrawFogTurnOn = -1.0;
 		mTextureMode = -1;
 		mTextureClamp = 0;
 		mTextureModeFlags = 0;
@@ -546,6 +548,11 @@ public:
 		mFogColor = c;
 		mStreamData.uFogColor = mFogColor;
 		if (d >= 0.0f) mLightParms[2] = d * (-LOG2E / 64000.f);
+	}
+
+	void SetMaxDrawFog(float maxdrawdist)
+	{
+		mMaxDrawFogTurnOn = 0.5 * maxdrawdist;
 	}
 
 	void SetLightParms(float f, float d)

--- a/src/common/rendering/v_framebuffer.cpp
+++ b/src/common/rendering/v_framebuffer.cpp
@@ -116,6 +116,15 @@ void DFrameBuffer::SetClearColor(int color)
 	mSceneClearColor[3] = 1.f;
 }
 
+void DFrameBuffer::SetClearColorFog(PalEntry pe, int fogd, double dist)
+{
+	float factor = 1.0f / 255.f; // ( 1.f - exp( -fogd * dist / 64000.f ) ) / 255.f;
+	mSceneClearColor[0] = pe.r * factor;
+	mSceneClearColor[1] = pe.g * factor;
+	mSceneClearColor[2] = pe.b * factor;
+	mSceneClearColor[3] = 1.f;
+}
+
 //==========================================================================
 //
 // DFrameBuffer :: SetVSync

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -250,6 +250,7 @@ public:
 
 	// Report a game restart
 	void SetClearColor(int color);
+	void SetClearColorFog(PalEntry pe, int fogd, double dist);
 	virtual int Backend() { return 0; }
 	virtual const char* DeviceName() const { return "Unknown"; }
 	virtual void AmbientOccludeScene(float m5) {}

--- a/src/common/rendering/vulkan/renderer/vk_renderstate.cpp
+++ b/src/common/rendering/vulkan/renderer/vk_renderstate.cpp
@@ -383,6 +383,7 @@ void VkRenderState::ApplyPushConstants()
 	mPushConstants.uLightLevel = mLightParms[3];
 	mPushConstants.uAlphaThreshold = mAlphaThreshold;
 	mPushConstants.uClipSplit = { mClipSplit[0], mClipSplit[1] };
+	mPushConstants.uMaxDrawFogTurnOn = mMaxDrawFogTurnOn;
 
 	if (mMaterial.mMaterial)
 	{

--- a/src/common/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_shader.cpp
@@ -273,6 +273,7 @@ static const char *shaderBindings = R"(
 		int uBoneIndexBase;
 
 		int uDataIndex;
+		float uMaxDrawFogTurnOn;
 		int padding2, padding3;
 	};
 

--- a/src/common/rendering/vulkan/shaders/vk_shader.h
+++ b/src/common/rendering/vulkan/shaders/vk_shader.h
@@ -54,6 +54,7 @@ struct PushConstants
 	int uBoneIndexBase;
 
 	int uDataIndex;
+	float uMaxDrawFogTurnOn;
 	int padding1, padding2, padding3;
 };
 

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1829,6 +1829,7 @@ void FLevelLocals::Init()
 	outsidefog = info->outsidefog;
 	WallVertLight = info->WallVertLight*2;
 	WallHorizLight = info->WallHorizLight*2;
+	maxdrawdist = info->maxdrawdist;
 	if (info->gravity != 0.f)
 	{
 		if (info->gravity == DBL_MAX) gravity = 0;

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -665,6 +665,8 @@ public:
 	int			airsupply;
 	int			DefaultEnvironment;		// Default sound environment.
 
+	double      maxdrawdist;
+
 	DSeqNode *SequenceListHead;
 
 	// [RH] particle globals

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -551,6 +551,7 @@ public:
 	FInterpolator interpolator;
 
 	uint64_t	ShaderStartTime = 0;	// tell the shader system when we started the level (forces a timer restart)
+	double maxdrawdist = 3000.0;
 
 	static const int BODYQUESIZE = 32;
 	TObjPtr<AActor*> bodyque[BODYQUESIZE];

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -551,7 +551,6 @@ public:
 	FInterpolator interpolator;
 
 	uint64_t	ShaderStartTime = 0;	// tell the shader system when we started the level (forces a timer restart)
-	double maxdrawdist = 3000.0;
 
 	static const int BODYQUESIZE = 32;
 	TObjPtr<AActor*> bodyque[BODYQUESIZE];

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -296,6 +296,8 @@ void level_info_t::Reset()
 	skyfog = 0;
 	pixelstretch = 1.2f;
 
+	maxdrawdist = 3000.f;
+
 	specialactions.Clear();
 	DefaultEnvironment = 0;
 	PrecacheSounds.Clear();
@@ -1216,6 +1218,13 @@ DEFINE_MAP_OPTION(gravity, true)
 	info->gravity = parse.sc.Float;
 }
 
+DEFINE_MAP_OPTION(maxdrawdist, true)
+{
+	parse.ParseAssign();
+	parse.sc.MustGetFloat();
+	info->maxdrawdist = parse.sc.Float;
+}
+
 DEFINE_MAP_OPTION(nogravity, true)
 {
 	info->gravity = DBL_MAX;
@@ -1693,7 +1702,6 @@ DEFINE_MAP_OPTION(outro, true)
 {
 	parse.ParseCutscene(info->outro);
 }
-
 
 //==========================================================================
 //

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1828,6 +1828,7 @@ MapFlagHandlers[] =
 	{ "avoidmelee",						MITYPE_SETFLAG3,	LEVEL3_AVOIDMELEE, 0 },
 	{ "attenuatelights",				MITYPE_SETFLAG3,	LEVEL3_ATTENUATE, 0 },
 	{ "nofogofwar",					MITYPE_SETFLAG3,	LEVEL3_NOFOGOFWAR, 0 },
+	{ "voidfadetofog",					MITYPE_SETFLAG3,	LEVEL3_VOIDFADETOFOG, 0 },
 	{ "nobotnodes",						MITYPE_IGNORE,	0, 0 },		// Skulltag option: nobotnodes
 	{ "nopassover",						MITYPE_COMPATFLAG, COMPATF_NO_PASSMOBJ, 0 },
 	{ "passover",						MITYPE_CLRCOMPATFLAG, COMPATF_NO_PASSMOBJ, 0 },

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1828,7 +1828,7 @@ MapFlagHandlers[] =
 	{ "avoidmelee",						MITYPE_SETFLAG3,	LEVEL3_AVOIDMELEE, 0 },
 	{ "attenuatelights",				MITYPE_SETFLAG3,	LEVEL3_ATTENUATE, 0 },
 	{ "nofogofwar",					MITYPE_SETFLAG3,	LEVEL3_NOFOGOFWAR, 0 },
-	{ "voidfadetofog",					MITYPE_SETFLAG3,	LEVEL3_VOIDFADETOFOG, 0 },
+	{ "voidfadetoclear",				MITYPE_SETFLAG3,	LEVEL3_VOIDFADETOCLEAR, 0 },
 	{ "nobotnodes",						MITYPE_IGNORE,	0, 0 },		// Skulltag option: nobotnodes
 	{ "nopassover",						MITYPE_COMPATFLAG, COMPATF_NO_PASSMOBJ, 0 },
 	{ "passover",						MITYPE_CLRCOMPATFLAG, COMPATF_NO_PASSMOBJ, 0 },

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1694,6 +1694,7 @@ DEFINE_MAP_OPTION(outro, true)
 	parse.ParseCutscene(info->outro);
 }
 
+
 //==========================================================================
 //
 // All flag based map options 

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -296,7 +296,7 @@ void level_info_t::Reset()
 	skyfog = 0;
 	pixelstretch = 1.2f;
 
-	maxdrawdist = 3000.f;
+	maxdrawdist = -1.f; // <= 0 means not applied
 
 	specialactions.Clear();
 	DefaultEnvironment = 0;

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1694,7 +1694,6 @@ DEFINE_MAP_OPTION(outro, true)
 	parse.ParseCutscene(info->outro);
 }
 
-
 //==========================================================================
 //
 // All flag based map options 

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -271,7 +271,7 @@ enum ELevelFlags : unsigned int
 	LEVEL3_NOJUMPDOWN			= 0x00040000,	// only for MBF21. Inverse of MBF's dog_jumping flag.
 	LEVEL3_LIGHTCREATED		= 0x00080000,	// a light had been created in the last frame
 	LEVEL3_NOFOGOFWAR			= 0x00100000,	// disables effect of r_radarclipper CVAR on this map
-	LEVEL3_VOIDFADETOFOG		= 0x00200000,	// sets r_clearbuffer (void space) color to fog fade color
+	LEVEL3_VOIDFADETOCLEAR		= 0x00200000,	// sets r_clearbuffer (void space) color to clear color (default is fog/fade color)
 };
 
 

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -377,8 +377,6 @@ struct level_info_t
 	int			skyfog;
 	float		pixelstretch;
 
-	double      maxdrawdist;
-
 	// Redirection: If any player is carrying the specified item, then
 	// you go to the RedirectMap instead of this one.
 	FName		RedirectType;

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -377,6 +377,8 @@ struct level_info_t
 	int			skyfog;
 	float		pixelstretch;
 
+	double      maxdrawdist;
+
 	// Redirection: If any player is carrying the specified item, then
 	// you go to the RedirectMap instead of this one.
 	FName		RedirectType;

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -271,6 +271,7 @@ enum ELevelFlags : unsigned int
 	LEVEL3_NOJUMPDOWN			= 0x00040000,	// only for MBF21. Inverse of MBF's dog_jumping flag.
 	LEVEL3_LIGHTCREATED		= 0x00080000,	// a light had been created in the last frame
 	LEVEL3_NOFOGOFWAR			= 0x00100000,	// disables effect of r_radarclipper CVAR on this map
+	LEVEL3_VOIDFADETOFOG		= 0x00200000,	// sets r_clearbuffer (void space) color to fog fade color
 };
 
 

--- a/src/maploader/maploader.cpp
+++ b/src/maploader/maploader.cpp
@@ -3281,6 +3281,27 @@ void MapLoader::LoadLevel(MapData *map, const char *lumpname, int position)
 			seg++;
 		}
 	}
+	// [DVR] Make level foggy if maxdrawdist was set
+	if (Level->maxdrawdist > 0.0)
+	{
+		int newdensity = clamp<int> ((int)(192000.0 / Level->maxdrawdist), 0, 255);
+		if (Level->fogdensity < newdensity)
+		{
+			Level->fogdensity = newdensity;
+		}
+		if (Level->outsidefogdensity < newdensity)
+		{
+			Level->outsidefogdensity = newdensity;
+		}
+		Level->skyfog = 255; // blanket the sky with thick fog to prevent pop-in (see also r_clearbuffer = 5 or LEVEL3_VOIDFADETOFOG)
+		for (unsigned int ll = 0; ll < Level->sectors.Size(); ll++)
+		{
+			if (Level->sectors[ll].Colormap.FadeColor == 0) // if no fade set (in mapinfo)
+			{
+				Level->sectors[ll].SetFade(PalEntry(1, 1, 1)); // fade to black
+			}
+		}
+	}
 }
 
 //==========================================================================

--- a/src/maploader/maploader.cpp
+++ b/src/maploader/maploader.cpp
@@ -3293,7 +3293,7 @@ void MapLoader::LoadLevel(MapData *map, const char *lumpname, int position)
 		{
 			Level->outsidefogdensity = newdensity;
 		}
-		Level->skyfog = 255; // blanket the sky with thick fog to prevent pop-in (see also r_clearbuffer = 5 or LEVEL3_VOIDFADETOFOG)
+		Level->skyfog = 255; // blanket the sky with thick fog to prevent pop-in (see also r_clearbuffer = 5 or LEVEL3_VOIDFADETOCLEAR)
 		for (unsigned int ll = 0; ll < Level->sectors.Size(); ll++)
 		{
 			if (Level->sectors[ll].Colormap.FadeColor == 0) // if no fade set (in mapinfo)

--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -817,6 +817,7 @@ xx(floorglowheight)
 xx(ceilingglowcolor)
 xx(ceilingglowheight)
 xx(fogdensity)
+xx(maxdrawdist)
 
 xx(HealthFloor)
 xx(HealthCeiling)

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -1013,7 +1013,8 @@ void FLevelLocals::Serialize(FSerializer &arc, bool hubload)
 		("scrolls", Scrolls)
 		("automap", automap)
 		("interpolator", interpolator)
-		("frozenstate", frozenstate);
+		("frozenstate", frozenstate)
+		("maxdrawdist", maxdrawdist);
 
 
 	// Hub transitions must keep the current total time

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -959,14 +959,26 @@ void HWDrawInfo::RenderBSPNode (void *node)
 			if (!(no_renderflags[bsp->Index()] & SSRF_SEEN))
 				return;
 		}
+
 		if (Viewpoint.IsOrtho())
 		{
+			// Check max draw distance
+			if (r_radarclipper && !rClipper->CheckBoxClosestDist(bsp->bbox[side]))
+			{
+				return;
+			}
 			if (!vClipper->CheckBoxOrthoPitch(bsp->bbox[side]))
 			{
 				if (!(no_renderflags[bsp->Index()] & SSRF_SEEN))
 					return;
 			}
 		}
+		else if (!mClipper->CheckBoxClosestDist(bsp->bbox[side]))
+		{
+			// Check max draw distance
+			return;
+		}
+
 
 		node = bsp->children[side];
 	}

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -994,6 +994,7 @@ void HWDrawInfo::RenderOrthoNoFog()
 		double vydbl = Viewpoint.camera->Y();
 		double ext = Viewpoint.camera->ViewPos->Offset.Length() ?
 			3.0 * Viewpoint.camera->ViewPos->Offset.Length() : 100.0;
+		if (Level->maxdrawdist > 0.0) ext = min(ext, Level->maxdrawdist);
 		FBoundingBox viewbox(vxdbl, vydbl, ext);
 
 		for (unsigned int kk = 0; kk < Level->subsectors.Size(); kk++)

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -963,7 +963,7 @@ void HWDrawInfo::RenderBSPNode (void *node)
 		if (Viewpoint.IsOrtho())
 		{
 			// Check max draw distance
-			if (r_radarclipper && !rClipper->CheckBoxClosestDist(bsp->bbox[side]))
+			if (r_radarclipper && level.maxdrawdist > 0 && !rClipper->CheckBoxClosestDist(bsp->bbox[side]))
 			{
 				return;
 			}
@@ -973,7 +973,7 @@ void HWDrawInfo::RenderBSPNode (void *node)
 					return;
 			}
 		}
-		else if (!mClipper->CheckBoxClosestDist(bsp->bbox[side]))
+		else if (level.maxdrawdist > 0 && !mClipper->CheckBoxClosestDist(bsp->bbox[side]))
 		{
 			// Check max draw distance
 			return;

--- a/src/rendering/hwrenderer/scene/hw_clipper.cpp
+++ b/src/rendering/hwrenderer/scene/hw_clipper.cpp
@@ -586,7 +586,8 @@ bool Clipper::CheckBoxClosestDist(const float *bspcoord)
 {
 	int        boxpos;
 	bool distcheck;
-	double maxdist = level.maxdrawdist / r_viewpoint.FieldOfView.Sin(); // dividing by Sin(fov) for sniper scopes
+	double maxdist = level.maxdrawdist;
+	if (r_viewpoint.FieldOfView.Degrees() > 0.0) maxdist /= r_viewpoint.FieldOfView.Sin(); // dividing by Sin(fov) for sniper scopes
 	angle_t angle1, angle2;
 
 	const uint8_t* check;

--- a/src/rendering/hwrenderer/scene/hw_clipper.cpp
+++ b/src/rendering/hwrenderer/scene/hw_clipper.cpp
@@ -586,7 +586,7 @@ bool Clipper::CheckBoxClosestDist(const float *bspcoord)
 {
 	int        boxpos;
 	bool distcheck;
-	double maxdist = level.info->maxdrawdist; // Consider dividing by Sin(fov) for sniper scopes
+	double maxdist = level.maxdrawdist / r_viewpoint.FieldOfView.Sin(); // dividing by Sin(fov) for sniper scopes
 	angle_t angle1, angle2;
 
 	const uint8_t* check;

--- a/src/rendering/hwrenderer/scene/hw_clipper.cpp
+++ b/src/rendering/hwrenderer/scene/hw_clipper.cpp
@@ -586,7 +586,7 @@ bool Clipper::CheckBoxClosestDist(const float *bspcoord)
 {
 	int        boxpos;
 	bool distcheck;
-	double maxdist = level.maxdrawdist;
+	double maxdist = level.info->maxdrawdist; // Consider dividing by Sin(fov) for sniper scopes
 	angle_t angle1, angle2;
 
 	const uint8_t* check;

--- a/src/rendering/hwrenderer/scene/hw_clipper.cpp
+++ b/src/rendering/hwrenderer/scene/hw_clipper.cpp
@@ -594,8 +594,13 @@ bool Clipper::CheckBoxClosestDist(const float *bspcoord)
 	// Find the corners of the box
 	// that define the edges from current viewpoint.
 	auto &vp = viewpoint;
-	boxpos = (vp->Pos.X <= bspcoord[BOXLEFT] ? 0 : vp->Pos.X < bspcoord[BOXRIGHT ] ? 1 : 2) +
-		(vp->Pos.Y >= bspcoord[BOXTOP ] ? 0 : vp->Pos.Y > bspcoord[BOXBOTTOM] ? 4 : 8);
+	DVector3 vpPos = vp->Pos;
+	if (viewpoint->IsOrtho())
+	{
+		vpPos = viewpoint->camera->Pos();
+	}
+	boxpos = (vpPos.X <= bspcoord[BOXLEFT] ? 0 : vpPos.X < bspcoord[BOXRIGHT ] ? 1 : 2) +
+		(vpPos.Y >= bspcoord[BOXTOP ] ? 0 : vpPos.Y > bspcoord[BOXBOTTOM] ? 4 : 8);
 	
 	check = checkcoord[boxpos];
 	angle1 = PointToPseudoAngle (bspcoord[check[0]], bspcoord[check[1]]);
@@ -604,36 +609,33 @@ bool Clipper::CheckBoxClosestDist(const float *bspcoord)
 	switch (boxpos) // Distcheck if the closer corner is poking into the view area
 	{
 	case 0:
-		distcheck = (vp->Pos.XY() - DVector2(bspcoord[BOXLEFT], bspcoord[BOXTOP])).Length() < maxdist;
+		distcheck = (vpPos.XY() - DVector2(bspcoord[BOXLEFT], bspcoord[BOXTOP])).Length() < maxdist;
 		break;
 	case 1:
-		distcheck = (vp->Pos.Y - bspcoord[BOXTOP]) < maxdist;
+		distcheck = (vpPos.Y - bspcoord[BOXTOP]) < maxdist;
 		break;
 	case 2:
-		distcheck = (vp->Pos.XY() - DVector2(bspcoord[BOXRIGHT], bspcoord[BOXTOP])).Length() < maxdist;
+		distcheck = (vpPos.XY() - DVector2(bspcoord[BOXRIGHT], bspcoord[BOXTOP])).Length() < maxdist;
 		break;
 	case 4:
-		distcheck = (bspcoord[BOXLEFT] - vp->Pos.X) < maxdist;
+		distcheck = (bspcoord[BOXLEFT] - vpPos.X) < maxdist;
 		break;
 	case 6:
-		distcheck = (vp->Pos.X - bspcoord[BOXRIGHT]) < maxdist;
+		distcheck = (vpPos.X - bspcoord[BOXRIGHT]) < maxdist;
 		break;
 	case 8:
-		distcheck = (vp->Pos.XY() - DVector2(bspcoord[BOXLEFT], bspcoord[BOXBOTTOM])).Length() < maxdist;
+		distcheck = (vpPos.XY() - DVector2(bspcoord[BOXLEFT], bspcoord[BOXBOTTOM])).Length() < maxdist;
 		break;
 	case 9:
-		distcheck = (bspcoord[BOXBOTTOM] - vp->Pos.Y) < maxdist;
+		distcheck = (bspcoord[BOXBOTTOM] - vpPos.Y) < maxdist;
 		break;
 	case 10:
-		distcheck = (vp->Pos.XY() - DVector2(bspcoord[BOXRIGHT], bspcoord[BOXBOTTOM])).Length() < maxdist;
+		distcheck = (vpPos.XY() - DVector2(bspcoord[BOXRIGHT], bspcoord[BOXBOTTOM])).Length() < maxdist;
 		break;
 	default:
 		distcheck = true;
 		break;
 	}
-	if (!distcheck && boxpos != 5)
-	{
-		SafeAddClipRange(angle2, angle1);
-	}
+
 	return distcheck;
 }

--- a/src/rendering/hwrenderer/scene/hw_clipper.h
+++ b/src/rendering/hwrenderer/scene/hw_clipper.h
@@ -160,7 +160,8 @@ public:
 
 	bool CheckBox(const float *bspcoord);
 	bool CheckBoxOrthoPitch(const float *bspcoord);
-
+	bool CheckBoxClosestDist(const float *bspcoord);
+	
 	// Used to speed up angle calculations during clipping
 	inline angle_t GetClipAngle(vertex_t *v)
 	{

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -505,6 +505,7 @@ void HWDrawInfo::CreateScene(bool drawpsprites)
 void HWDrawInfo::RenderScene(FRenderState &state)
 {
 	const auto &vp = Viewpoint;
+	state.SetMaxDrawFog((float)(Level->maxdrawdist));
 	RenderAll.Clock();
 
 	state.SetDepthMask(true);

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -183,6 +183,33 @@ CCMD (maxdrawdist)
 	}
 }
 
+CCMD (setfade)
+{
+	FString colorstring;
+	uint32_t color;
+
+	if (argv.argc() < 2)
+	{
+		Printf ("setfade <color>\n");
+	}
+	else
+	{
+		if ( !(colorstring = V_GetColorStringByName (argv[1])).IsEmpty() )
+		{
+			color = V_GetColorFromString (colorstring.GetChars());
+		}
+		else
+		{
+			color = V_GetColorFromString (argv[1]);
+		}
+		level.fadeto = color;
+		for (unsigned int kk = 0; kk < level.sectors.Size(); kk++)
+		{
+			level.sectors[kk].SetFade(color);
+		}
+	}
+}
+
 int 			viewwindowx;
 int 			viewwindowy;
 int				viewwidth;
@@ -1208,6 +1235,7 @@ void R_SetupFrame(FRenderViewpoint& viewPoint, const FViewWindow& viewWindow, AA
 									 (actor->Level->skyfog > 0 ? actor->Level->skyfog :
 									  viewPoint.sector->Colormap.FogDensity) : actor->Level->fogdensity,
 									 actor->Level->maxdrawdist);
+			SWRenderer->SetClearColor(viewPoint.sector->Colormap.FadeColor);
 		}
     }
 	

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -147,11 +147,11 @@ CCMD (maxdrawdist)
 
 	if (argv.argc() < 2)
 	{
-		Printf ("maxdrawdist %.1f (default: 3000.0)\n", level.maxdrawdist);
+		Printf ("maxdrawdist %.1f (default: 3000.0)\n", level.info->maxdrawdist);
 	}
 	else
 	{
-		level.maxdrawdist = strtod(argv[1], nullptr);
+		level.info->maxdrawdist = strtod(argv[1], nullptr);
 	}
 }
 

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -166,6 +166,19 @@ CCMD (maxdrawdist)
 				}
 			}
 		}
+		else // revert to default
+		{
+			level.fogdensity = level.info->fogdensity;
+			level.outsidefogdensity = level.info->outsidefogdensity;
+			level.skyfog = level.info->skyfog;
+			for (unsigned int kk = 0; kk < level.sectors.Size(); kk++)
+			{
+				if (level.sectors[kk].Colormap.FadeColor == PalEntry(1, 1, 1))
+				{
+					level.sectors[kk].Colormap.FadeColor.SetRGB(level.fadeto); // revert
+				}
+			}
+		}
 		level.maxdrawdist = strtod(argv[1], nullptr);
 	}
 }

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -154,7 +154,7 @@ CCMD (maxdrawdist)
 	{
 		if (strtod(argv[1], nullptr) > 0.0)
 		{
-			int newdensity = clamp<int> ((int)(192000.0 / strtod(argv[1], nullptr)), 0, 255);
+			int newdensity = clamp<int> ((int)(19200.0 / strtod(argv[1], nullptr)), 1, 255); // Let minimum be 1 to set the correct flags
 			level.fogdensity = max(newdensity, level.info->fogdensity);
 			level.outsidefogdensity = max(newdensity, level.info->outsidefogdensity);
 			level.skyfog = 255; // blanket the sky with thick fog to prevent pop-in (see also r_clearbuffer = 5 or LEVEL3_VOIDFADETOCLEAR)

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -148,7 +148,7 @@ CCMD (maxdrawdist)
 
 	if (argv.argc() < 2)
 	{
-		Printf ("maxdrawdist %.1f (default: -1.0, not applied of <= 0.0)\n", level.maxdrawdist);
+		Printf ("maxdrawdist %.1f (default: -1.0, not applied if <= 0.0)\n", level.maxdrawdist);
 	}
 	else
 	{
@@ -1165,7 +1165,7 @@ void R_SetupFrame(FRenderViewpoint& viewPoint, const FViewWindow& viewWindow, AA
 		else
 			color = pr_hom();
 
-		if (hom == 5 && gl_fogmode != 0)
+		if ((hom == 5 || actor->Level->flags3 & LEVEL3_VOIDFADETOFOG) && gl_fogmode != 0)
 		{
 			screen->SetClearColorFog(viewPoint.sector->Colormap.FadeColor,
 									 viewPoint.sector->Colormap.FogDensity > 0 ?

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -152,6 +152,20 @@ CCMD (maxdrawdist)
 	}
 	else
 	{
+		if (strtod(argv[1], nullptr) > 0.0)
+		{
+			int newdensity = clamp<int> ((int)(192000.0 / strtod(argv[1], nullptr)), 0, 255);
+			level.fogdensity = max(newdensity, level.info->fogdensity);
+			level.outsidefogdensity = max(newdensity, level.info->outsidefogdensity);
+			level.skyfog = 255; // blanket the sky with thick fog to prevent pop-in (see also r_clearbuffer = 5 or LEVEL3_VOIDFADETOFOG)
+			for (unsigned int kk = 0; kk < level.sectors.Size(); kk++)
+			{
+				if (level.sectors[kk].Colormap.FadeColor == 0) // if no fade set (in mapinfo)
+				{
+					level.sectors[kk].SetFade(PalEntry(1, 1, 1)); // fade to black
+				}
+			}
+		}
 		level.maxdrawdist = strtod(argv[1], nullptr);
 	}
 }

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -157,7 +157,7 @@ CCMD (maxdrawdist)
 			int newdensity = clamp<int> ((int)(192000.0 / strtod(argv[1], nullptr)), 0, 255);
 			level.fogdensity = max(newdensity, level.info->fogdensity);
 			level.outsidefogdensity = max(newdensity, level.info->outsidefogdensity);
-			level.skyfog = 255; // blanket the sky with thick fog to prevent pop-in (see also r_clearbuffer = 5 or LEVEL3_VOIDFADETOFOG)
+			level.skyfog = 255; // blanket the sky with thick fog to prevent pop-in (see also r_clearbuffer = 5 or LEVEL3_VOIDFADETOCLEAR)
 			for (unsigned int kk = 0; kk < level.sectors.Size(); kk++)
 			{
 				if (level.sectors[kk].Colormap.FadeColor == 0) // if no fade set (in mapinfo)
@@ -1192,7 +1192,16 @@ void R_SetupFrame(FRenderViewpoint& viewPoint, const FViewWindow& viewWindow, AA
 		else
 			color = pr_hom();
 
-		if ((hom == 5 || actor->Level->flags3 & LEVEL3_VOIDFADETOFOG) && gl_fogmode != 0)
+		screen->SetClearColor(color);
+		SWRenderer->SetClearColor(color);
+	}
+    else
+	{
+		if ((actor->Level->flags3 & LEVEL3_VOIDFADETOCLEAR) || (gl_fogmode == 0))
+		{
+			screen->SetClearColor(GPalette.BlackIndex);
+		}
+		else
 		{
 			screen->SetClearColorFog(viewPoint.sector->Colormap.FadeColor,
 									 viewPoint.sector->Colormap.FogDensity > 0 ?
@@ -1200,14 +1209,6 @@ void R_SetupFrame(FRenderViewpoint& viewPoint, const FViewWindow& viewWindow, AA
 									  viewPoint.sector->Colormap.FogDensity) : actor->Level->fogdensity,
 									 actor->Level->maxdrawdist);
 		}
-		else
-			screen->SetClearColor(color);
-
-		SWRenderer->SetClearColor(color);
-	}
-    else
-	{
-		screen->SetClearColor(GPalette.BlackIndex);
     }
 	
 	

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -142,6 +142,19 @@ CUSTOM_CVARD(Float, r_actorspriteshadowfadeheight, 0.0, CVAR_ARCHIVE | CVAR_GLOB
 		self = 8192.f;
 }
 
+CCMD (maxdrawdist)
+{
+
+	if (argv.argc() < 2)
+	{
+		Printf ("maxdrawdist %.1f (default: 3000.0)\n", level.maxdrawdist);
+	}
+	else
+	{
+		level.maxdrawdist = strtod(argv[1], nullptr);
+	}
+}
+
 int 			viewwindowx;
 int 			viewwindowy;
 int				viewwidth;

--- a/src/rendering/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.cpp
@@ -456,7 +456,7 @@ namespace swrenderer
 		};
 		int boxpos;
 		bool distcheck;
-		double maxdist = level.maxdrawdist;
+		double maxdist = level.info->maxdrawdist; // Consider dividing by Sin(fov) for sniper scopes
 		
 		const int* check;
 

--- a/src/rendering/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.cpp
@@ -502,58 +502,6 @@ namespace swrenderer
 			distcheck = true;
 			break;
 		}
-		if (!distcheck && boxpos != 5)
-		{
-			x1 = bspcoord[checkcoord[boxpos][0]] - Thread->Viewport->viewpoint.Pos.X;
-			y1 = bspcoord[checkcoord[boxpos][1]] - Thread->Viewport->viewpoint.Pos.Y;
-			x2 = bspcoord[checkcoord[boxpos][2]] - Thread->Viewport->viewpoint.Pos.X;
-			y2 = bspcoord[checkcoord[boxpos][3]] - Thread->Viewport->viewpoint.Pos.Y;
-			// Sitting on a line?
-			if (y1 * (x1 - x2) + x1 * (y2 - y1) >= -EQUAL_EPSILON)
-				return true;
-			rx1 = x1 * Thread->Viewport->viewpoint.Sin - y1 * Thread->Viewport->viewpoint.Cos;
-			rx2 = x2 * Thread->Viewport->viewpoint.Sin - y2 * Thread->Viewport->viewpoint.Cos;
-			ry1 = x1 * Thread->Viewport->viewpoint.TanCos + y1 * Thread->Viewport->viewpoint.TanSin;
-			ry2 = x2 * Thread->Viewport->viewpoint.TanCos + y2 * Thread->Viewport->viewpoint.TanSin;
-
-			if (Thread->Portal->MirrorFlags & RF_XFLIP)
-			{
-				double t = -rx1;
-				rx1 = -rx2;
-				rx2 = t;
-				std::swap(ry1, ry2);
-			}
-		
-			auto viewport = Thread->Viewport.get();
-
-			if (rx1 >= -ry1)
-			{
-				if (rx1 > ry1) return false;	// left edge is off the right side
-				if (ry1 == 0) return false;
-				sx1 = xs_RoundToInt(viewport->CenterX + rx1 * viewport->CenterX / ry1);
-			}
-			else
-			{
-				if (rx2 < -ry2) return false;	// wall is off the left side
-				if (rx1 - rx2 - ry2 + ry1 == 0) return false;	// wall does not intersect view volume
-				sx1 = 0;
-			}
-
-			if (rx2 <= ry2)
-			{
-				if (rx2 < -ry2) return false;	// right edge is off the left side
-				if (ry2 == 0) return false;
-				sx2 = xs_RoundToInt(viewport->CenterX + rx2 * viewport->CenterX / ry2);
-			}
-			else
-			{
-				if (rx1 > ry1) return false;	// wall is off the right side
-				if (ry2 - ry1 - rx2 + rx1 == 0) return false;	// wall does not intersect view volume
-				sx2 = viewwidth;
-			}
-			VisibleSegmentRenderer visitor;
-			Thread->ClipSegments->Clip(sx1, sx2, true, &visitor);
-		}
 		return distcheck;
 	}
 

--- a/src/rendering/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.cpp
@@ -456,7 +456,7 @@ namespace swrenderer
 		};
 		int boxpos;
 		bool distcheck;
-		double maxdist = level.info->maxdrawdist; // Consider dividing by Sin(fov) for sniper scopes
+		double maxdist = level.maxdrawdist / r_viewpoint.FieldOfView.Sin(); // dividing by Sin(fov) for sniper scopes
 		
 		const int* check;
 
@@ -984,7 +984,7 @@ namespace swrenderer
 				return;
 
 			// Check max draw distance
-			if (!CheckBoxClosestDist(bsp->bbox[side]))
+			if (level.maxdrawdist > 0 && !CheckBoxClosestDist(bsp->bbox[side]))
 				return;
 
 			node = bsp->children[side];

--- a/src/rendering/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.cpp
@@ -456,7 +456,8 @@ namespace swrenderer
 		};
 		int boxpos;
 		bool distcheck;
-		double maxdist = level.maxdrawdist / r_viewpoint.FieldOfView.Sin(); // dividing by Sin(fov) for sniper scopes
+		double maxdist = level.maxdrawdist;
+		if (r_viewpoint.FieldOfView.Degrees() > 0.0) maxdist /= r_viewpoint.FieldOfView.Sin(); // dividing by Sin(fov) for sniper scopes
 		
 		const int* check;
 

--- a/src/rendering/swrenderer/scene/r_opaque_pass.h
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.h
@@ -82,6 +82,7 @@ namespace swrenderer
 		void RenderBSPNode(void *node);
 		void RenderSubsector(subsector_t *sub);
 		bool CheckBBox(float *bspcoord);
+		bool CheckBoxClosestDist(const float *bspcoord);
 
 		void AddPolyobjs(subsector_t *sub);
 

--- a/src/rendering/swrenderer/scene/r_scene.cpp
+++ b/src/rendering/swrenderer/scene/r_scene.cpp
@@ -98,7 +98,7 @@ namespace swrenderer
 		ActiveRatio(width, height, &trueratio);
 		viewport->SetViewport(player->camera->Level, MainThread(), width, height, trueratio);
 
-		if (r_clearbuffer != 0 || r_debug_draw != 0)
+		if (r_clearbuffer != 0 || r_debug_draw != 0 || ((player->camera->Level->maxdrawdist > 0.0) && !(player->camera->Level->flags3 & LEVEL3_VOIDFADETOCLEAR)))
 		{
 			if (!viewport->RenderTarget->IsBgra())
 			{

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2784,6 +2784,7 @@ DEFINE_FIELD_X(LevelInfo, level_info_t, pixelstretch)
 DEFINE_FIELD_X(LevelInfo, level_info_t, RedirectType)
 DEFINE_FIELD_X(LevelInfo, level_info_t, RedirectMapName)
 DEFINE_FIELD_X(LevelInfo, level_info_t, teamdamage)
+DEFINE_FIELD_X(LevelInfo, level_info_t, maxdrawdist)
 
 DEFINE_GLOBAL_NAMED(currentVMLevel, level)
 DEFINE_FIELD(FLevelLocals, sectors)
@@ -2835,6 +2836,7 @@ DEFINE_FIELD(FLevelLocals, deathsequence)
 DEFINE_FIELD_BIT(FLevelLocals, frozenstate, frozen, 1)	// still needed for backwards compatibility.
 DEFINE_FIELD_NAMED(FLevelLocals, i_compatflags, compatflags)
 DEFINE_FIELD_NAMED(FLevelLocals, i_compatflags2, compatflags2)
+DEFINE_FIELD(FLevelLocals, maxdrawdist)
 DEFINE_FIELD(FLevelLocals, info);
 
 DEFINE_FIELD_BIT(FLevelLocals, flags, noinventorybar, LEVEL_NOINVENTORYBAR)

--- a/wadsrc/static/shaders/glsl/main.fp
+++ b/wadsrc/static/shaders/glsl/main.fp
@@ -855,6 +855,13 @@ void main()
 			{
 				fogdist = max(16.0, distance(pixelpos.xyz, uCameraPos.xyz));
 			}
+			if (uMaxDrawFogTurnOn > 0.0)
+			{
+				if (fogdist > uMaxDrawFogTurnOn)
+				{
+					fogdist = fogdist + 30.0 * (fogdist - uMaxDrawFogTurnOn);
+				}
+			}
 			fogfactor = exp2 (uFogDensity * fogdist);
 		}
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -363,6 +363,7 @@ struct LevelInfo native
 	native readonly name RedirectType;
 	native readonly String RedirectMapName;
 	native readonly double teamdamage;
+	native readonly double maxdrawdist;
 
 	native bool isValid() const;
 	native String LookupLevelName() const;


### PR DESCRIPTION
Added the ability to not draw any node in the BSP whose bounding box is farther from the viewpoint than a `maxdrawdist` value from `struct Flevellocals`. Works in both hardware and software renderer modes.

Demo of speed up in Frozen Time bridge scene on a 12-year old CPU: https://www.youtube.com/watch?v=2oUUpMxDngc
`maxdrawdist` can be supplied from `MAPINFO` lump as well as changed from console live. It will persist through saved games. Default is set to `-1`, and won't activate unless greater than `0`.

The absence of drawn regions will show up as void space with clearbuffer color (normally controlled by the existing CVar `r_clearbuffer`). If using fog, this color can be set to match the local or global fog fade color by either setting the `LEVEL3_VOIDFADETOFOG` flag (set `voidfadetofog` in `MAPINFO` lump) or setting `r_clearbuffer` to `5`.

I wish I knew how to just replace the void space with a sky box but couldn't figure it out.