### PR TITLE
Decoupled animations for MD2, MD3, and UE1 models

### DIFF
--- a/src/common/models/model.h
+++ b/src/common/models/model.h
@@ -73,6 +73,13 @@ enum EFrameError
 	FErr_Singleframe = -3
 };
 
+enum EAnimationMethod
+{
+	AM_None = 0x0,
+	AM_LegacyAnimation = 0x1,
+	AM_ModernAnimation = 0x2
+};
+
 class FModel
 {
 public:
@@ -101,6 +108,7 @@ public:
 	void DestroyVertexBuffer();
 
 	bool hasSurfaces = false;
+	int aniMethod = AM_None;
 
 	FString mFileName;
 	std::pair<FString, FString> mFilePath;

--- a/src/common/models/model_md2.h
+++ b/src/common/models/model_md2.h
@@ -108,7 +108,8 @@ public:
 		info.numLODs = 0;
 		texCoords = NULL;
 		framevtx = NULL;
-	}
+		aniMethod = AM_LegacyAnimation;
+	};
 	virtual ~FDMDModel();
 
 	virtual bool Load(const char * fn, int lumpnum, const char * buffer, int length) override;

--- a/src/common/models/model_md2.h
+++ b/src/common/models/model_md2.h
@@ -113,6 +113,9 @@ public:
 
 	virtual bool Load(const char * fn, int lumpnum, const char * buffer, int length) override;
 	virtual int FindFrame(const char* name, bool nodefault) override;
+	int FindFirstFrame(FName name) override;
+	int FindLastFrame(FName name) override;
+	double FindFramerate(FName name) override;
 	virtual void RenderFrame(FModelRenderer *renderer, FGameTexture * skin, int frame, int frame2, double inter, FTranslationID translation, const FTextureID* surfaceskinids, const TArray<VSMatrix>& boneData, int boneStartPosition) override;
 	virtual void LoadGeometry();
 	virtual void AddSkins(uint8_t *hitlist, const FTextureID* surfaceskinids) override;

--- a/src/common/models/model_md3.h
+++ b/src/common/models/model_md3.h
@@ -63,7 +63,10 @@ class FMD3Model : public FModel
 	TArray<MD3Surface> Surfaces;
 
 public:
-	FMD3Model() = default;
+	FMD3Model()
+	{
+		aniMethod = AM_LegacyAnimation;
+	};
 
 	virtual bool Load(const char * fn, int lumpnum, const char * buffer, int length) override;
 	virtual int FindFrame(const char* name, bool nodefault) override;

--- a/src/common/models/model_md3.h
+++ b/src/common/models/model_md3.h
@@ -67,6 +67,9 @@ public:
 
 	virtual bool Load(const char * fn, int lumpnum, const char * buffer, int length) override;
 	virtual int FindFrame(const char* name, bool nodefault) override;
+	int FindFirstFrame(FName name) override;
+	int FindLastFrame(FName name) override;
+	double FindFramerate(FName name) override;
 	virtual void RenderFrame(FModelRenderer *renderer, FGameTexture * skin, int frame, int frame2, double inter, FTranslationID translation, const FTextureID* surfaceskinids, const TArray<VSMatrix>& boneData, int boneStartPosition) override;
 	void LoadGeometry();
 	void BuildVertexBuffer(FModelRenderer *renderer);

--- a/src/common/models/model_ue1.h
+++ b/src/common/models/model_ue1.h
@@ -26,6 +26,9 @@ public:
 
 	bool Load(const char * fn, int lumpnum, const char * buffer, int length) override;
 	int FindFrame(const char* name, bool nodefault) override;
+	int FindFirstFrame(FName name) override;
+	int FindLastFrame(FName name) override;
+	double FindFramerate(FName name) override;
 	void RenderFrame(FModelRenderer *renderer, FGameTexture * skin, int frame, int frame2, double inter, FTranslationID translation, const FTextureID* surfaceskinids, const TArray<VSMatrix>& boneData, int boneStartPosition) override;
 	void BuildVertexBuffer(FModelRenderer *renderer) override;
 	void AddSkins(uint8_t *hitlist, const FTextureID* surfaceskinids) override;

--- a/src/common/models/model_ue1.h
+++ b/src/common/models/model_ue1.h
@@ -46,6 +46,7 @@ public:
 		numFrames = 0;
 		numPolys = 0;
 		numGroups = 0;
+		aniMethod = AM_LegacyAnimation;
 	}
 	~FUE1Model();
 

--- a/src/common/models/models_iqm.cpp
+++ b/src/common/models/models_iqm.cpp
@@ -13,6 +13,7 @@ IMPLEMENT_CLASS(DBoneComponents, false, false);
 
 IQMModel::IQMModel()
 {
+	aniMethod = AM_ModernAnimation;
 }
 
 IQMModel::~IQMModel()

--- a/src/common/models/models_md2.cpp
+++ b/src/common/models/models_md2.cpp
@@ -358,6 +358,21 @@ int FDMDModel::FindFrame(const char* name, bool nodefault)
 	return FErr_NotFound;
 }
 
+int FDMDModel::FindFirstFrame(FName name)
+{
+	return 0;
+}
+
+int FDMDModel::FindLastFrame(FName name)
+{
+	return info.numFrames;
+}
+
+double FDMDModel::FindFramerate(FName name)
+{
+	return 10.0;
+}
+
 //===========================================================================
 //
 //

--- a/src/common/models/models_md3.cpp
+++ b/src/common/models/models_md3.cpp
@@ -339,6 +339,21 @@ int FMD3Model::FindFrame(const char* name, bool nodefault)
 	return FErr_NotFound;
 }
 
+int FMD3Model::FindFirstFrame(FName name)
+{
+	return 0;
+}
+
+int FMD3Model::FindLastFrame(FName name)
+{
+	return Frames.Size();
+}
+
+double FMD3Model::FindFramerate(FName name)
+{
+	return 15.0;
+}
+
 //===========================================================================
 //
 //

--- a/src/common/models/models_ue1.cpp
+++ b/src/common/models/models_ue1.cpp
@@ -232,6 +232,21 @@ int FUE1Model::FindFrame(const char* name, bool nodefault)
 	return index;
 }
 
+int FUE1Model::FindFirstFrame(FName name)
+{
+	return 0;
+}
+
+int FUE1Model::FindLastFrame(FName name)
+{
+	return numFrames;
+}
+
+double FUE1Model::FindFramerate(FName name)
+{
+	return 30.0;
+}
+
 void FUE1Model::RenderFrame( FModelRenderer *renderer, FGameTexture *skin, int frame, int frame2, double inter, FTranslationID translation, const FTextureID* surfaceskinids, const TArray<VSMatrix>& boneData, int boneStartPosition)
 {
 	// the moment of magic

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -5182,11 +5182,6 @@ void SetAnimationInternal(AActor * self, FName animName, double framerate, int s
 	}
 
 	int animEnd = mdl->FindLastFrame(animName);
-
-	if(framerate < 0)
-	{
-		framerate = mdl->FindFramerate(animName);
-	}
 	
 	int len = animEnd - animStart;
 
@@ -5253,11 +5248,6 @@ void SetAnimationFrameRateInternal(AActor * self, double framerate, double ticFr
 	EnsureModelData(self);
 
 	if(self->modelData->curAnim.flags & ANIMOVERRIDE_NONE) return;
-
-	if(framerate < 0)
-	{
-		ThrowAbortException(X_OTHER, "Cannot set negative framerate");
-	}
 
 
 	double tic = self->Level->totaltime;

--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -434,13 +434,19 @@ void RenderFrameModels(FModelRenderer *renderer, FLevelLocals *Level, const FSpr
 			{
 				animationid = smf->animationIDs[i];
 			}
-			if(!is_decoupled)
+			//modelFrame
+			if (is_decoupled && decoupled_next_frame != -1)
 			{
-				//modelFrame
+				//[LemonKing] Set modelframe to use decoupled frame data
+				modelframe = decoupled_main_frame;
+				modelframenext = decoupled_next_frame;
+			}
+			else
+			{
 				if (actor->modelData->modelFrameGenerators.Size() > i
-				 && (unsigned)actor->modelData->modelFrameGenerators[i] < modelsamount
-				 && smf->modelframes[actor->modelData->modelFrameGenerators[i]] >= 0
-				   ) {
+					&& (unsigned)actor->modelData->modelFrameGenerators[i] < modelsamount
+					&& smf->modelframes[actor->modelData->modelFrameGenerators[i]] >= 0
+					) {
 					modelframe = smf->modelframes[actor->modelData->modelFrameGenerators[i]];
 
 					if (smfNext) 


### PR DESCRIPTION
Added compatibility for decoupled animations for use with MD2, MD3, and UE1 models.

Functionality remains the same with `SetAnimation()`, but the param `animName` will be ignored with any non-IQM model.

`M000 A -1 NoDelay SetAnimation('', 5, 0, 0, flags:SAF_LOOP);`

https://github.com/user-attachments/assets/4d1eadce-5c0e-4352-bb4c-9473b47fd74a

