### PR TITLE
Returning FrustumAngle() function to its pre-isometric-mode version

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -299,6 +299,7 @@ public:
 	void SetViewMatrix(const FRotator &angles, float vx, float vy, float vz, bool mirror, bool planemirror);
 	void SetupView(FRenderState &state, float vx, float vy, float vz, bool mirror, bool planemirror);
 	angle_t FrustumAngle();
+	angle_t FrustumAngleOoB();
 
 	void DrawDecals(FRenderState &state, TArray<HWDecal *> &decals);
 	void DrawPlayerSprites(bool hudModelStep, FRenderState &state);


### PR DESCRIPTION
Returning FrustumAngle() function to its pre-isometric-mode version and creating a conditional alternate function only for out-of-bounds viewpoints. 
`atan()` was causing slowdowns in maps like `Monuments_RC2.wad` (might optimize that later into a lookup table).