### PR TITLE
Prevent console from laying open when intro cutscene plays

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1236,6 +1236,7 @@ void G_Ticker ()
 		case ga_intro:
 			gamestate = GS_INTRO;
 			gameaction = ga_nothing;
+			C_HideConsole(); // On some systems, console is open during intro
 			break;
 
 


### PR DESCRIPTION
Console starts open and obscures half the screen when intro plays (only on some systems).
