### PR TITLE
Allows billboard facing camera to work without XY billboarding enabled

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -425,7 +425,7 @@ bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
 	float yy = -center.Y + y;
 	float zz = -center.Z + z;
 	// [Nash] check for special sprite drawing modes
-	if (drawWithXYBillboard || isWallSprite)
+	if (drawWithXYBillboard || drawBillboardFacingCamera || isWallSprite)
 	{
 		mat.MakeIdentity();
 		mat.Translate(center.X, center.Z, center.Y); // move to sprite center

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -404,8 +404,8 @@ bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
 
 	const bool drawBillboardFacingCamera = hw_force_cambbpref ? gl_billboard_faces_camera :
 		gl_billboard_faces_camera
-		&& ((actor && (!(actor->renderflags2 & RF2_BILLBOARDNOFACECAMERA) || (actor->renderflags2 & RF2_BILLBOARDFACECAMERA)))
-		|| (particle && particle->texture.isValid() && (!(particle->flags & SPF_NOFACECAMERA) || (particle->flags & SPF_FACECAMERA))));
+		|| ((actor && (!(actor->renderflags2 & RF2_BILLBOARDNOFACECAMERA) && (actor->renderflags2 & RF2_BILLBOARDFACECAMERA)))
+		|| (particle && particle->texture.isValid() && (!(particle->flags & SPF_NOFACECAMERA) && (particle->flags & SPF_FACECAMERA))));
 
 	// [Nash] has +ROLLSPRITE
 	const bool drawRollSpriteActor = (actor != nullptr && actor->renderflags & RF_ROLLSPRITE);


### PR DESCRIPTION
Allows the `drawBillboardFacingCamera` if block here:

https://github.com/ZDoom/gzdoom/blob/712dd1133d18436ee7e9a5a4c3208e57ddfe0c02/src/rendering/hwrenderer/scene/hw_sprites.cpp#L438-L450

to be reached without `drawWithXYBillboard` being `true` here:

https://github.com/ZDoom/gzdoom/blob/712dd1133d18436ee7e9a5a4c3208e57ddfe0c02/src/rendering/hwrenderer/scene/hw_sprites.cpp#L427-L429

Without this, the force billboard facing camera flag (along with the user render option `sprites face camera`) only functions while the XY billboarding flag is enabled (or the user render option `sprite billboard` is set to `X/Y axis`).

Also fixed the incorrect boolean logic for `drawBillboardFacingCamera`. `gl_billboard_faces_camera` should not be required to be true. NOFACECAMERA and FACECAMERA flags both need to be checked. NOFACECAMERA being false does not mean FACECAMERA is true.