### PR TITLE
- implement `SPAC_Walking`, mostly useful for teleports or for line c…

### DIFF
--- a/specs/udmf_zdoom.txt
+++ b/specs/udmf_zdoom.txt
@@ -114,6 +114,7 @@ Note: All <bool> fields default to false unless mentioned otherwise.
                                   // texture to behave like an impassable line (projectiles
                                   // pass through it).
       checkswitchrange = <bool>;  // Switches can only be activated when vertically reachable.
+      walking = <bool>;           // Crossing activation checks if creature is on the ground, and fails if they are not.
       blockprojectiles = <bool>;  // Line blocks all projectiles
       blockuse = <bool>;          // Line blocks all use actions
       blocksight = <bool>;        // Line blocks monster line of sight

--- a/src/doomdata.h
+++ b/src/doomdata.h
@@ -199,6 +199,7 @@ enum SPAC
 	SPAC_UseBack = 1<<10,	// Can be used from the backside
 	SPAC_Damage = 1<<11,	// [ZZ] when linedef receives damage
 	SPAC_Death = 1<<12,		// [ZZ] when linedef receives damage and has 0 health
+	SPAC_Walking = 1<<13,	// Can only be used when standing on a floor (not falling or floating) - only for line cross, not use
 
 	SPAC_PlayerActivate = (SPAC_Cross|SPAC_Use|SPAC_Impact|SPAC_Push|SPAC_AnyCross|SPAC_UseThrough|SPAC_UseBack),
 };

--- a/src/maploader/udmf.cpp
+++ b/src/maploader/udmf.cpp
@@ -1002,6 +1002,10 @@ public:
 			// This switch contains all keys of the UDMF base spec which only apply to Hexen format specials
 			if (!isTranslated) switch (key.GetIndex())
 			{
+			case NAME_Walking:
+				Flag(ld->activation, SPAC_Walking, key);
+				continue;
+
 			case NAME_Playercross:
 				Flag(ld->activation, SPAC_Cross, key); 
 				continue;

--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -670,6 +670,7 @@ xx(Missilecross)
 xx(Anycross)
 xx(Monsteruse)
 xx(Monsterpush)
+xx(Walking)
 
 xx(ZDoom)
 xx(ZDoomTranslated)

--- a/src/playsim/p_spec.cpp
+++ b/src/playsim/p_spec.cpp
@@ -254,6 +254,13 @@ bool P_TestActivateLine (line_t *line, AActor *mo, int side, int activationType,
 		return false;
 	}
 
+	if ((activationType & (SPAC_Cross|SPAC_PCross)) && (lineActivation & SPAC_Walking))
+	{
+		// not on floor
+		if ((mo->Pos().Z > mo->floorz) && !(mo->flags2 & MF2_ONMOBJ))
+			return false;
+	}
+
 	if (lineActivation & SPAC_UseThrough)
 	{
 		lineActivation |= SPAC_Use;


### PR DESCRIPTION
…rossings that should not happen when the player is falling or flying

[flytest.zip](https://github.com/user-attachments/files/17076736/flytest.zip)
Test should work with any game (sans textures)