### PR TITLE
Remove 35 FPS cap from menus

### DIFF
--- a/src/common/rendering/gl/gl_framebuffer.h
+++ b/src/common/rendering/gl/gl_framebuffer.h
@@ -72,6 +72,7 @@ public:
     FTexture *WipeEndScreen() override;
 
 	int camtexcount = 0;
+	int vsyncstate = -2;
 };
 
 }

--- a/src/common/rendering/gles/gles_framebuffer.cpp
+++ b/src/common/rendering/gles/gles_framebuffer.cpp
@@ -66,6 +66,9 @@ EXTERN_CVAR(Bool, cl_capfps)
 EXTERN_CVAR(Int, gl_pipeline_depth);
 
 EXTERN_CVAR(Bool, gl_sort_textures);
+#ifdef _WIN32
+EXTERN_CVAR(Bool, gl_control_tear)
+#endif
 
 extern bool vid_hdr_active;
 
@@ -266,7 +269,16 @@ void OpenGLFrameBuffer::Swap()
 
 void OpenGLFrameBuffer::SetVSync(bool vsync)
 {
-	Super::SetVSync(vsync);
+#ifdef _WIN32
+	int newvsyncstate = vsync ? (gl_control_tear ? -1 : 1) : 0;
+#else
+	int newvsyncstate = !!vsync;
+#endif
+	if (newvsyncstate != vsyncstate)
+	{
+		vsyncstate = newvsyncstate;
+		Super::SetVSync(vsync);
+	}
 }
 
 //===========================================================================

--- a/src/common/rendering/gles/gles_framebuffer.h
+++ b/src/common/rendering/gles/gles_framebuffer.h
@@ -66,6 +66,7 @@ public:
     FTexture *WipeEndScreen() override;
 
 	int camtexcount = 0;
+	int vsyncstate = -2;
 };
 
 }

--- a/src/common/rendering/vulkan/system/vk_commandbuffer.cpp
+++ b/src/common/rendering/vulkan/system/vk_commandbuffer.cpp
@@ -173,8 +173,7 @@ void VkCommandBufferManager::WaitForCommands(bool finish, bool uploadOnly)
 
 	if (finish)
 	{
-		if (!fb->GetVSync())
-			fb->FPSLimit();
+		fb->FPSLimit();
 		fb->GetFramebufferManager()->QueuePresent();
 	}
 

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -733,6 +733,8 @@ CVAR(Bool, vid_activeinbackground, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 EXTERN_CVAR(Bool, r_drawvoxels)
 EXTERN_CVAR(Int, gl_tonemap)
+EXTERN_CVAR(Bool, vid_vsync)
+EXTERN_CVAR(Bool, cl_capfps)
 static uint32_t GetCaps()
 {
 	ActorRenderFeatureFlags FlagSet;
@@ -1060,6 +1062,8 @@ void D_Display ()
 			//stb.Unclock();
 			//Printf("Stbar = %f\n", stb.TimeMS());
 		}
+
+		screen->SetVSync(vid_vsync);
 	}
 	else
 	{
@@ -1086,6 +1090,9 @@ void D_Display ()
 			default:
 				break;
 		}
+
+		// We don't want to fry GPUs here if the map is not rendered.
+		screen->SetVSync(vid_vsync || !(cl_capfps && pauseext));
 	}
 	if (!hud_toggled)
 	{

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -1876,7 +1876,7 @@ void TryRunTics (void)
 	int 		counts;
 	int 		numplaying;
 
-	bool doWait = (cl_capfps || pauseext || (r_NoInterpolate && !M_IsAnimated()));
+	bool doWait = (cl_capfps || pauseext);
 
 	// get real tics
 	if (doWait)


### PR DESCRIPTION
This PR removes the 35 FPS cap from menus.

The changes made are:

1. Menus are no longer capped to 35 frames per second.
2. If there's no map being rendered at the moment, VSync is forced on and the menus are capped to the monitor's refresh rate should the VSync settings be respected.
3. If maps are being rendered, normal `vid_vsync` behaviour is followed and menus are capped to `vid_maxfps`.
4. The Vulkan renderer now always follows `vid_maxfps` settings as AMD drivers completely ignore swapchain present modes for windowed surfaces existing on FreeSync displays, instead forcing it to `VK_PRESENT_MODE_IMMEDIATE_KHR`, causing the actual FPS to go past `vid_maxfps`.