### PR TITLE
Added MF9_FORCESECTORDAMAGE.

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -445,6 +445,7 @@ enum ActorFlag9
 	MF9_DECOUPLEDANIMATIONS		= 0x00000010,	// [RL0] Decouple model animations from states
 	MF9_NOSECTORDAMAGE			= 0x00000020,	// [inkoalawetrust] Actor ignores any sector-based damage (i.e damaging floors, NOT crushers)
 	MF9_ISPUFF					= 0x00000040,	// [AA] Set on actors by P_SpawnPuff
+	MF9_FORCESECTORDAMAGE		= 0x00000080,	// [inkoalawetrust] Actor ALWAYS takes hurt floor damage if there's any. Even if the floor doesn't have SECMF_HURTMONSTERS.
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -4435,7 +4435,7 @@ void AActor::Tick ()
 		if (ObjectFlags & OF_EuthanizeMe) return;
 	}
 	//[inkoalawetrust] Genericized level damage handling that makes sector, 3D floor, and TERRAIN flat damage affect monsters and other NPCs too.
-	if (!(flags9 & MF9_NOSECTORDAMAGE) && (player || (player == nullptr && Sector->MoreFlags & SECMF_HURTMONSTERS)))
+	if ((!(flags9 & MF9_NOSECTORDAMAGE) || flags9 & MF9_FORCESECTORDAMAGE) && (player || (player == nullptr && (Sector->MoreFlags & SECMF_HURTMONSTERS || flags9 & MF9_FORCESECTORDAMAGE))))
 	{
 		P_ActorOnSpecial3DFloor(this);
 		P_ActorInSpecialSector(this,Sector);

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -355,6 +355,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF9, DECOUPLEDANIMATIONS, AActor, flags9),
 	DEFINE_FLAG(MF9, NOSECTORDAMAGE, AActor, flags9),
 	DEFINE_PROTECTED_FLAG(MF9, ISPUFF, AActor, flags9), //[AA] was spawned by SpawnPuff
+	DEFINE_FLAG(MF9, FORCESECTORDAMAGE, AActor, flags9),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
This flag forces non-player actors to take damage from hurt floors even if SECMF_HURTMONSTERS isn't true.

I was going to add this in my initial PR (#2479), but it was merged before I added it in.