### PR TITLE
Fixed problem in CheckForShadows().

### DIFF
--- a/src/playsim/shadowinlines.h
+++ b/src/playsim/shadowinlines.h
@@ -88,6 +88,7 @@ inline AActor* CheckForShadows(AActor* self, AActor* other, DVector3 pos, double
 	if ((other && (other->flags & MF_SHADOW)) || (self->flags9 & MF9_DOSHADOWBLOCK))
 	{
 		AActor* shadowBlock = P_CheckForShadowBlock(self, other, pos, penaltyFactor);
+		if (other && !(other->flags & MF_SHADOW)) other = nullptr; //Other doesn't have MF_SHADOW, so don't count them as a valid return.
 		return shadowBlock ? shadowBlock : other;
 	}
 	return nullptr;


### PR DESCRIPTION
This PR fixes a major regression in CheckForShadows() that made it always return a +SHADOW or +SHADOWBLOCK actor even when there were none. Causing monsters to always have messy aim if +DOSHADOWBLOCK is on. Now CheckForShadows() should only return a pointer if the target actually has MF_SHADOW, or if an MF9_SHADOWBLOCK actor is standing in the way.