### PR TITLE
Add system for modular SBARINFO

### DIFF
--- a/src/g_statusbar/sbarinfo.cpp
+++ b/src/g_statusbar/sbarinfo.cpp
@@ -644,7 +644,7 @@ void SBarInfo::ParseSBarInfo(int lump)
 					barNum = sc.MustMatchString(StatusBars);
 				}
 				// SBARINFO_APPENDSTATUSBAR shouldn't delete the old HUD if it exists.
-				if (command != SBARINFO_APPENDSTATUSBAR)
+				if(command != SBARINFO_APPENDSTATUSBAR)
 				{
 					if (this->huds[barNum] != NULL)
 					{
@@ -652,7 +652,7 @@ void SBarInfo::ParseSBarInfo(int lump)
 					}
 					this->huds[barNum] = new SBarInfoMainBlock(this);
 				}
-				else if (this->huds[barNum] == NULL)
+				else if(this->huds[barNum] == NULL)
 				{
 					sc.ScriptError("Status bar '%s' has not been created and cannot be appended to. Use 'StatusBar' instead.", StatusBars[barNum]);
 				}

--- a/src/g_statusbar/sbarinfo.cpp
+++ b/src/g_statusbar/sbarinfo.cpp
@@ -654,7 +654,7 @@ void SBarInfo::ParseSBarInfo(int lump)
 				}
 				else if (this->huds[barNum] == NULL)
 				{
-					sc.ScriptError( "AppendStatusBar can't be used on a HUD that doesn't exist yet." );
+					sc.ScriptError("Status bar '%s' has not been created and cannot be appended to. Use 'StatusBar' instead.", StatusBars[barNum]);
 				}
 				if(barNum == STBAR_AUTOMAP)
 				{

--- a/src/g_statusbar/sbarinfo.cpp
+++ b/src/g_statusbar/sbarinfo.cpp
@@ -490,12 +490,9 @@ void SBarInfo::ParseSBarInfo(int lump)
 			continue;
 		}
 		int baselump = -2;
-		FString SBarInfoTopLevelString;
-		if(sc.GetString(SBarInfoTopLevelString))
-		{ // Store the string if the next token is a string, and revert scanner state afterwards
-			sc.UnGet();
-		}
-		switch(sc.MustMatchString(SBarInfoTopLevel))
+		// Store the command, used for the switch statement and case SBARINFO_APPENDSTATUSBAR.
+		const int command = sc.MustMatchString(SBarInfoTopLevel);
+		switch(command)
 		{
 			case SBARINFO_BASE:
 				baseSet = true;
@@ -647,14 +644,17 @@ void SBarInfo::ParseSBarInfo(int lump)
 					barNum = sc.MustMatchString(StatusBars);
 				}
 				// SBARINFO_APPENDSTATUSBAR shouldn't delete the old HUD if it exists.
-				const bool append = (SBarInfoTopLevelString.CompareNoCase("appendstatusbar") == 0);
-				if (!append)
+				if (command != SBARINFO_APPENDSTATUSBAR)
 				{
 					if (this->huds[barNum] != NULL)
 					{
 						delete this->huds[barNum];
 					}
 					this->huds[barNum] = new SBarInfoMainBlock(this);
+				}
+				else if (this->huds[barNum] == NULL)
+				{
+					sc.ScriptError( "AppendStatusBar can't be used on a HUD that doesn't exist yet." );
 				}
 				if(barNum == STBAR_AUTOMAP)
 				{

--- a/src/g_statusbar/sbarinfo.cpp
+++ b/src/g_statusbar/sbarinfo.cpp
@@ -490,6 +490,11 @@ void SBarInfo::ParseSBarInfo(int lump)
 			continue;
 		}
 		int baselump = -2;
+		FString SBarInfoTopLevelString;
+		if(sc.GetString(SBarInfoTopLevelString))
+		{ // Store the string if the next token is a string, and revert scanner state afterwards
+			sc.UnGet();
+		}
 		switch(sc.MustMatchString(SBarInfoTopLevel))
 		{
 			case SBARINFO_BASE:
@@ -642,7 +647,7 @@ void SBarInfo::ParseSBarInfo(int lump)
 					barNum = sc.MustMatchString(StatusBars);
 				}
 				// SBARINFO_APPENDSTATUSBAR shouldn't delete the old HUD if it exists.
-				const bool append = (sc.MustMatchString(SBarInfoTopLevel) == SBARINFO_APPENDSTATUSBAR);
+				const bool append = (SBarInfoTopLevelString.CompareNoCase("appendstatusbar") == 0);
 				if (!append)
 				{
 					if (this->huds[barNum] != NULL)

--- a/src/g_statusbar/sbarinfo.cpp
+++ b/src/g_statusbar/sbarinfo.cpp
@@ -381,6 +381,7 @@ enum //Key words
 	SBARINFO_MUGSHOT,
 	SBARINFO_CREATEPOPUP,
 	SBARINFO_PROTRUSION,
+	SBARINFO_APPENDSTATUSBAR,
 };
 
 enum //Bar types
@@ -410,6 +411,7 @@ static const char *SBarInfoTopLevel[] =
 	"mugshot",
 	"createpopup",
 	"protrusion",
+	"appendstatusbar",
 	NULL
 };
 
@@ -629,6 +631,7 @@ void SBarInfo::ParseSBarInfo(int lump)
 				sc.MustGetToken(';');
 				break;
 			case SBARINFO_STATUSBAR:
+			case SBARINFO_APPENDSTATUSBAR:
 			{
 				if(!baseSet) //If the user didn't explicitly define a base, do so now.
 					gameType = GAME_Any;
@@ -638,11 +641,16 @@ void SBarInfo::ParseSBarInfo(int lump)
 					sc.MustGetToken(TK_Identifier);
 					barNum = sc.MustMatchString(StatusBars);
 				}
-				if (this->huds[barNum] != NULL)
+				// SBARINFO_APPENDSTATUSBAR shouldn't delete the old HUD if it exists.
+				const bool append = (sc.MustMatchString(SBarInfoTopLevel) == SBARINFO_APPENDSTATUSBAR);
+				if (!append)
 				{
-					delete this->huds[barNum];
+					if (this->huds[barNum] != NULL)
+					{
+						delete this->huds[barNum];
+					}
+					this->huds[barNum] = new SBarInfoMainBlock(this);
 				}
-				this->huds[barNum] = new SBarInfoMainBlock(this);
 				if(barNum == STBAR_AUTOMAP)
 				{
 					automapbar = true;


### PR DESCRIPTION
Doing this to keep parity with [a Zandronum patch request.](https://zandronum.com/tracker/view.php?id=4303)
- Added new top level "AppendStatusBar", allowing for extra SBARINFO code to be added to custom SBARINFO definitions.