### PR TITLE
Add a basic overridable footstep system and TERRAIN lump fixes.

### DIFF
--- a/src/gamedata/p_terrain.cpp
+++ b/src/gamedata/p_terrain.cpp
@@ -77,8 +77,8 @@ enum ETerrainKeywords
 	TR_DAMAGETIMEMASK,
 	TR_FOOTCLIP,
 	TR_STEPVOLUME,
-	TR_WALKINGSTEPTIME,
-	TR_RUNNINGSTEPTIME,
+	TR_WALKSTEPTICS,
+	TR_RUNSTEPTICS,
 	TR_LEFTSTEPSOUNDS,
 	TR_RIGHTSTEPSOUNDS,
 	TR_LIQUID,
@@ -179,8 +179,8 @@ static const char *TerrainKeywords[] =
 	"damagetimemask",
 	"footclip",
 	"stepvolume",
-	"walkingsteptime",
-	"runningsteptime",
+	"walksteptics",
+	"runsteptics",
 	"leftstepsounds",
 	"rightstepsounds",
 	"liquid",
@@ -599,7 +599,7 @@ static void GenericParse (FScanner &sc, FGenericParse *parser, const char **keyw
 
 		case GEN_Time:
 			sc.MustGetFloat ();
-			SET_FIELD (int, (int)(sc.Float * TICRATE));
+			SET_FIELD (int, (int)(sc.Float));
 			break;
 
 		case GEN_Bool:

--- a/src/gamedata/p_terrain.cpp
+++ b/src/gamedata/p_terrain.cpp
@@ -83,7 +83,8 @@ enum ETerrainKeywords
 	TR_RIGHTSTEPSOUNDS,
 	TR_LIQUID,
 	TR_FRICTION,
-	TR_ALLOWPROTECTION
+	TR_ALLOWPROTECTION,
+	TR_STEPSOUNDS
 };
 
 enum EGenericType
@@ -187,6 +188,7 @@ static const char *TerrainKeywords[] =
 	"friction",
 	"allowprotection",
 	"damageonland",
+	"stepsounds",
 	NULL
 };
 
@@ -223,6 +225,7 @@ static FGenericParse TerrainParser[] =
 	{ GEN_Custom, {(size_t)ParseFriction} },
 	{ GEN_Bool,   {myoffsetof(FTerrainDef, AllowProtection)} },
 	{ GEN_Bool,   {myoffsetof(FTerrainDef, DamageOnLand)} },
+	{ GEN_Sound,  {myoffsetof(FTerrainDef, StepSound)} },
 };
 
 
@@ -747,3 +750,4 @@ DEFINE_FIELD(FTerrainDef, AllowProtection)
 DEFINE_FIELD(FTerrainDef, DamageOnLand)
 DEFINE_FIELD(FTerrainDef, Friction)
 DEFINE_FIELD(FTerrainDef, MoveFactor)
+DEFINE_FIELD(FTerrainDef, StepSound)

--- a/src/gamedata/p_terrain.h
+++ b/src/gamedata/p_terrain.h
@@ -118,6 +118,7 @@ struct FTerrainDef
 	bool DamageOnLand;
 	double Friction;
 	double MoveFactor;
+	FSoundID StepSound;
 };
 
 extern TArray<FSplashDef> Splashes;

--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -352,7 +352,7 @@ void	P_TraceBleed (int damage, AActor *target, AActor *missile);		// missile ver
 void	P_TraceBleed(int damage, FTranslatedLineTarget *t, AActor *puff);		// hitscan version
 void	P_TraceBleed (int damage, AActor *target);		// random direction version
 bool	P_HitFloor (AActor *thing);
-bool	P_HitWater (AActor *thing, sector_t *sec, const DVector3 &pos, bool checkabove = false, bool alert = true, bool force = false);
+bool	P_HitWater (AActor *thing, sector_t *sec, const DVector3 &pos, bool checkabove = false, bool alert = true, bool force = false, int flags = 0);
 
 
 struct FRailParams

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6725,10 +6725,7 @@ foundone:
 	// Don't splash for living things with small vertical velocities.
 	// There are levels where the constant splashing from the monsters gets extremely annoying
 	if (!(flags & THW_NOVEL) && ((thing->flags3 & MF3_ISMONSTER || thing->player) && thing->Vel.Z >= -6) && !force)
-	{
-		Printf("Aborting P_HitWater().");
 		return Terrains[terrainnum].IsLiquid;
-	}
 
 	splash = &Splashes[splashnum];
 

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -770,7 +770,7 @@ class Actor : Thinker native
 	native Actor SpawnPuff(class<Actor> pufftype, vector3 pos, double hitdir, double particledir, int updown, int flags = 0, Actor victim = null);
 	native void SpawnBlood (Vector3 pos1, double dir, int damage);
 	native void BloodSplatter (Vector3 pos, double hitangle, bool axe = false);
-	native bool HitWater (sector sec, Vector3 pos, bool checkabove = false, bool alert = true, bool force = false);
+	native bool HitWater (sector sec, Vector3 pos, bool checkabove = false, bool alert = true, bool force = false, int flags = 0);
 	native void PlaySpawnSound(Actor missile);
 	native clearscope bool CountsAsKill() const;
 	

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -1742,6 +1742,15 @@ class PlayerPawn : Actor
 
 			if (Delay <= 0) return;
 
+			//Generic foot-agnostic sound takes precedence.
+			if (Ground.StepSound && GetAge() % Delay == 0)
+			{
+				A_StartSound (Ground.StepSound,flags:CHANF_OVERLAP,volume:Ground.StepVolume);
+				bool Heavy = Mass >= 200 ? 0 : THW_SMALL; //Big player makes big splash.
+				HitWater (CurSector,(Pos.XY,CurSector.FloorPlane.ZatPoint(Pos.XY)),True,False,flags:Heavy|THW_NOVEL);
+				return;
+			}
+
 			//Apparently most people walk with their right foot first, so assume that here.
 			bool LeftStep; //Prevent the right step playing twice.
 			if (GetAge() % (Delay*2) == 0)

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -1740,32 +1740,26 @@ class PlayerPawn : Actor
 			bool Running = (cmd.buttons & BT_RUN); //Holding down run key, or it's toggled.
 			int Delay = !Running ? Ground.WalkStepTics : Ground.RunStepTics;
 
-			if (Delay <= 0) return;
+			if (Delay <= 0 || GetAge() % Delay != 0) return;
+
+			Sound Step = Ground.StepSound;
 
 			//Generic foot-agnostic sound takes precedence.
-			if (Ground.StepSound && GetAge() % Delay == 0)
+			if (!Step)
 			{
-				A_StartSound (Ground.StepSound,flags:CHANF_OVERLAP,volume:Ground.StepVolume);
-				bool Heavy = Mass >= 200 ? 0 : THW_SMALL; //Big player makes big splash.
-				HitWater (CurSector,(Pos.XY,CurSector.FloorPlane.ZatPoint(Pos.XY)),True,False,flags:Heavy|THW_NOVEL);
-				return;
+				//Apparently most people walk with their right foot first, so assume that here.
+				if (GetAge() % (Delay*2) == 0)
+					Step = Ground.LeftStepSound;
+				else
+					Step = Ground.RightStepSound;
 			}
 
-			//Apparently most people walk with their right foot first, so assume that here.
-			bool LeftStep; //Prevent the right step playing twice.
-			if (GetAge() % (Delay*2) == 0)
-			{
-				A_StartSound (Ground.LeftStepSound,flags:CHANF_OVERLAP,volume:Ground.StepVolume);
-				bool Heavy = Mass >= 200 ? 0 : THW_SMALL; //Big player makes big splash.
-				HitWater (CurSector,(Pos.XY,CurSector.FloorPlane.ZatPoint(Pos.XY)),True,False,flags:Heavy|THW_NOVEL);
-				LeftStep = True;
-			}
-			if (!LeftStep && GetAge() % Delay == 0)
-			{
-				A_StartSound (Ground.RightStepSound,flags:CHANF_OVERLAP,volume:Ground.StepVolume);
-				bool Heavy = Mass >= 200 ? 0 : THW_SMALL; //Big player makes big splash.
-				HitWater (CurSector,(Pos.XY,CurSector.FloorPlane.ZatPoint(Pos.XY)),True,False,flags:Heavy|THW_NOVEL);
-			}
+			if (Step)
+				A_StartSound (Step,flags:CHANF_OVERLAP,volume:Ground.StepVolume);
+
+			//Steps make splashes regardless.
+			bool Heavy = Mass >= 200 ? 0 : THW_SMALL; //Big player makes big splash.
+			HitWater (CurSector,(Pos.XY,CurSector.FloorPlane.ZatPoint(Pos.XY)),True,False,flags:Heavy|THW_NOVEL);
 		}
 	}
 

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1466,6 +1466,12 @@ enum ECompatFlags
 	COMPATF2_VOODOO_ZOMBIES = 1 << 15,  // allow playerinfo, playerpawn, and voodoo health to all be different, and allow monster targetting of 'dead' players that have positive health
 };
 
+enum HitWaterFlags
+{
+	THW_SMALL	= 1 << 0,
+	THW_NOVEL	= 1 << 1,
+};
+
 const M_E        = 2.7182818284590452354;  // e
 const M_LOG2E    = 1.4426950408889634074;  // log_2 e
 const M_LOG10E   = 0.43429448190325182765; // log_10 e

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -613,6 +613,7 @@ struct TerrainDef native
 	native bool DamageOnLand;
 	native double Friction;
 	native double MoveFactor;
+	native Sound StepSound;
 };
 
 enum EPickStart


### PR DESCRIPTION
This PR mainly adds a basic footstep system (Off my default) through a MakeFootsteps() virtual in PlayerPawn, it's off by default and must be turned on with a new bMakeFootsteps PlayerPawn flag. And makes use of all the footstep-related parameters in TERRAIN that have apparently existed for about _twenty years_. The MakeFootsteps() virtual can be used for totally custom footstep logic as well, such as replacing it with a more logical system that plays footsteps at a frequency dependant on how fast the player is actually moving.

In addition to the new barebones footstep system using existing variables. This PR also fixes a 20-something year old discrepancy that made the Walk/RunStepTics variables unusable. Adds two flags for customizing HitWater(). And also adds a generic, foot-agnostic StepSound field to TERRAIN.


Also, below is an example mod attached, MAP01 has several TERRAIN surfaces, a few liquids and one metal terrain with footstep sounds defined. To enabled the footsteps, type "give TerrainSearch" in the console.
[splash.zip](https://github.com/user-attachments/files/17252115/splash.zip)
