### PR TITLE
Ortho projection Widescreen aspect ratio horizontal clipping fix

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_clipper.cpp
+++ b/src/rendering/hwrenderer/scene/hw_clipper.cpp
@@ -477,7 +477,7 @@ angle_t Clipper::PointToPseudoOrthoAngle(double x, double y)
 		angle_t af = viewpoint->FrustAngle;
 		double xproj = disp.XY().Length() * deltaangle(disp.Angle(), viewpoint->Angles.Yaw).Sin();
 		xproj *= viewpoint->ScreenProj;
-		if (fabs(xproj) < 2.0)
+		if (fabs(xproj) < r_viewwindow.WidescreenRatio*1.13) // 2.0)
 		{
 			return AngleToPseudo( viewpoint->Angles.Yaw.BAMs() - xproj * 0.5 * af );
 		}


### PR DESCRIPTION
Orthographic projection Widescreen aspect ratio horizontal clipping fixed. This one-line change only affects ortho viewpoints. Easy to verify in windowed mode (stretch window horizontally).