### PR TITLE
Added LookForEnemiesEx() for returning all enemies in an area.

### DIFF
--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -1543,6 +1543,83 @@ int P_LookForTID (AActor *actor, INTBOOL allaround, FLookExParams *params)
 //
 //============================================================================
 
+bool ValidEnemyInBlock (AActor *lookee, AActor *other, void *lookparams)
+{
+	FLookExParams* params = (FLookExParams*)lookparams;
+
+	if (!(other->flags & MF_SHOOTABLE))
+		return false;			// not shootable (observer or dead)
+
+	if (other == lookee)
+		return false;			// is self
+
+	if (other->health <= 0)
+		return false;			// dead
+
+	if (other->flags2 & MF2_DORMANT)
+		return false;			// don't target dormant things
+
+	if (!(other->flags3 & MF3_ISMONSTER))
+		return false;			// don't target it if it isn't a monster (could be a barrel)
+
+	if (other->flags7 & MF7_NEVERTARGET)
+		return false;
+
+	bool keepChecking = false;
+	if (lookee->flags & MF_FRIENDLY)
+	{
+		if (other->flags & MF_FRIENDLY)
+		{
+			if (!lookee->IsFriend(other))
+			{
+				// This is somebody else's friend, so go after it
+				keepChecking = true;
+			}
+			else if (other->target != NULL && !(other->target->flags & MF_FRIENDLY))
+			{
+				other = other->target;
+				if (!(other->flags & MF_SHOOTABLE) ||
+					other->health <= 0 ||
+					(other->flags2 & MF2_DORMANT))
+				{
+					return false;
+				}
+			}
+		}
+		else
+		{
+			keepChecking = true;
+		}
+	}
+	else if (lookee->flags8 & MF8_SEEFRIENDLYMONSTERS && other->flags & MF_FRIENDLY)
+	{
+		keepChecking = true;
+	}
+
+	// [MBF] If the monster is already engaged in a one-on-one attack
+	// with a healthy friend, don't attack around 60% the time.
+
+	// [GrafZahl] This prevents friendlies from attacking all the same 
+	// target.
+
+	if (keepChecking)
+	{
+		AActor* targ = other->target;
+		if (targ && targ->target == other && pr_skiptarget() > 100 && lookee->IsFriend(targ) &&
+			targ->health * 2 >= targ->SpawnHealth())
+		{
+			return false;
+		}
+	}
+
+	// [KS] Hey, shouldn't there be a check for MF3_NOSIGHTCHECK here?
+
+	if (!keepChecking || !P_IsVisible(lookee, other, true, params))
+		return false;			// out of sight
+
+	return true;
+}
+
 AActor *LookForEnemiesInBlock (AActor *lookee, int index, void *extparam)
 {
 	FBlockNode *block;
@@ -1552,80 +1629,10 @@ AActor *LookForEnemiesInBlock (AActor *lookee, int index, void *extparam)
 	
 	for (block = lookee->Level->blockmap.blocklinks[index]; block != NULL; block = block->NextActor)
 	{
-		link = block->Me;
-
-        if (!(link->flags & MF_SHOOTABLE))
-			continue;			// not shootable (observer or dead)
-
-		if (link == lookee)
+		if (!ValidEnemyInBlock(lookee, block->Me, params))
 			continue;
 
-		if (link->health <= 0)
-			continue;			// dead
-
-		if (link->flags2 & MF2_DORMANT)
-			continue;			// don't target dormant things
-
-		if (!(link->flags3 & MF3_ISMONSTER))
-			continue;			// don't target it if it isn't a monster (could be a barrel)
-
-		if (link->flags7 & MF7_NEVERTARGET)
-			continue;
-
-		other = NULL;
-		if (lookee->flags & MF_FRIENDLY)
-		{
-			if (link->flags & MF_FRIENDLY)
-			{
-				if (!lookee->IsFriend(link))
-				{
-					// This is somebody else's friend, so go after it
-					other = link;
-				}
-				else if (link->target != NULL && !(link->target->flags & MF_FRIENDLY))
-				{
-					other = link->target;
-					if (!(other->flags & MF_SHOOTABLE) ||
-						other->health <= 0 ||
-						(other->flags2 & MF2_DORMANT))
-					{
-						other = NULL;;
-					}
-				}
-			}
-			else
-			{
-				other = link;
-			}
-		}
-		else if (lookee->flags8 & MF8_SEEFRIENDLYMONSTERS && link->flags & MF_FRIENDLY)
-		{
-			other = link;
-		}
-
-		// [MBF] If the monster is already engaged in a one-on-one attack
-		// with a healthy friend, don't attack around 60% the time.
-		
-		// [GrafZahl] This prevents friendlies from attacking all the same 
-		// target.
-		
-		if (other)
-		{
-			AActor *targ = other->target;
-			if (targ && targ->target == other && pr_skiptarget() > 100 && lookee->IsFriend (targ) &&
-				targ->health*2 >= targ->SpawnHealth())
-			{
-				continue;
-			}
-		}
-
-		// [KS] Hey, shouldn't there be a check for MF3_NOSIGHTCHECK here?
-
-		if (other == NULL || !P_IsVisible (lookee, other, true, params))
-			continue;			// out of sight
-
-
-		return other;
+		return block->Me;
 	}
 	return NULL;
 }

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -1309,15 +1309,6 @@ int P_IsVisible(AActor *lookee, AActor *other, INTBOOL allaround, FLookExParams 
 	return P_CheckSight(lookee, other, SF_SEEPASTSHOOTABLELINES);
 }
 
-//============================================================================
-//
-// LookForEnemiesEx
-//
-// [inkoalawetrust] Return a script array of all valid enemies of the caller
-// in range. For ZScript.
-//
-//============================================================================
-
 bool isTargetablePlayer(AActor *actor, player_t *player, INTBOOL allaround, void* lookparams)
 {
 	FLookExParams* params = (FLookExParams*)lookparams;
@@ -1435,6 +1426,15 @@ bool ValidEnemyInBlock(AActor* lookee, AActor* other, void* lookparams)
 	return true;
 }
 
+//============================================================================
+//
+// LookForEnemiesEx
+//
+// [inkoalawetrust] Return a script array of all valid enemies of the caller
+// in range. For ZScript.
+//
+//============================================================================
+
 DEFINE_ACTION_FUNCTION(AActor, LookForEnemiesEx)
 {
 	PARAM_SELF_PROLOGUE(AActor);
@@ -1443,6 +1443,9 @@ DEFINE_ACTION_FUNCTION(AActor, LookForEnemiesEx)
 	PARAM_BOOL(noPlayers);
 	PARAM_BOOL(allaround);
 	PARAM_POINTER(params, FLookExParams);
+
+	if (targets == nullptr)
+		ThrowAbortException(X_WRITE_NIL,"No targets array passed");
 
 	if (range == -1)
 		range = self->friendlyseeblocks * FBlockmap::MAPBLOCKUNITS;

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -851,6 +851,7 @@ class Actor : Thinker native
 	native bool LookForTid(bool allaround, LookExParams params = null);
 	native bool LookForEnemies(bool allaround, LookExParams params = null);
 	native bool LookForPlayers(bool allaround, LookExParams params = null);
+	native int LookForEnemiesEx(out Array<Actor> targets, double range = -1, bool allaround = false, LookExParams params = null);
 	native bool TeleportMove(Vector3 pos, bool telefrag, bool modifyactor = true);
 	native clearscope double DistanceBySpeed(Actor other, double speed) const;
 	native name GetSpecies();

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -851,7 +851,7 @@ class Actor : Thinker native
 	native bool LookForTid(bool allaround, LookExParams params = null);
 	native bool LookForEnemies(bool allaround, LookExParams params = null);
 	native bool LookForPlayers(bool allaround, LookExParams params = null);
-	native int LookForEnemiesEx(out Array<Actor> targets, double range = -1, bool allaround = false, LookExParams params = null);
+	native int LookForEnemiesEx(out Array<Actor> targets, double range = -1, bool noPlayers = true, bool allaround = false, LookExParams params = null);
 	native bool TeleportMove(Vector3 pos, bool telefrag, bool modifyactor = true);
 	native clearscope double DistanceBySpeed(Actor other, double speed) const;
 	native name GetSpecies();


### PR DESCRIPTION
This is a ZScript function that behaves more or less like LookForEnemies(), and optionally like LookForPlayers() too, and returns an array of pointers to every valid enemy it found in range (By passing an array by reference). Useful for custom look functions, such as for adding additional checks like a monster that only attacks flying enemies, or that can track multiple targets.

Below is an example mod with a test actor called EnemySearch, when spawned in, it will use the function to find every enemy in the area, print their name, and spawn a hovering plasma ball over their heads. When spawned as a friend with summonfriend, it will instead only do those two things with flying monsters.

[LookForEnemiesEx.zip](https://github.com/user-attachments/files/17302855/LookForEnemiesEx.zip)
