### PR TITLE
Resolve compiler warning about destructor syntax

### DIFF
--- a/src/common/utility/tarray.h
+++ b/src/common/utility/tarray.h
@@ -924,7 +924,7 @@ public:
 		return *this;
 	}
 
-	~TDeletingArray<T, TT> ()
+	~TDeletingArray()
 	{
 		for (unsigned int i = 0; i < TArray<T,TT>::Size(); ++i)
 		{


### PR DESCRIPTION
gcc-14 warns:

```
tarray.h:927:9: warning: template-id not allowed for destructor in C++20 [-Wtemplate-id-cdtor]
  927 |         ~TDeletingArray<T, TT> ()
```

(A class can only ever have one destructor, so any template parameter list is unnecessary.)