### PR TITLE
FOV scales orthographic view (up to 180 degrees)

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -990,7 +990,7 @@ void HWDrawInfo::RenderOrthoNoFog()
 		double vxdbl = Viewpoint.camera->X();
 		double vydbl = Viewpoint.camera->Y();
 		double ext = Viewpoint.camera->ViewPos->Offset.Length() ?
-			3.0 * Viewpoint.camera->ViewPos->Offset.Length() : 100.0;
+			3.0 * Viewpoint.camera->ViewPos->Offset.Length() * tan (Viewpoint.FieldOfView.Radians()*0.5) : 100.0;
 		FBoundingBox viewbox(vxdbl, vydbl, ext);
 
 		for (unsigned int kk = 0; kk < Level->subsectors.Size(); kk++)

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -704,7 +704,7 @@ void FRenderViewpoint::SetViewAngle(const FViewWindow& viewWindow)
 	HWAngles.Yaw = FAngle::fromDeg(270.0 - Angles.Yaw.Degrees());
 
 	if (IsOrtho() && (camera->ViewPos->Offset.XY().Length() > 0.0))
-		ScreenProj = 1.34396 / camera->ViewPos->Offset.Length(); // [DVR] Estimated. +/-1 should be top/bottom of screen.
+		ScreenProj = 1.34396 / camera->ViewPos->Offset.Length() / tan (FieldOfView.Radians()*0.5); // [DVR] Estimated. +/-1 should be top/bottom of screen.
 
 }
 


### PR DESCRIPTION
One line change in r_utility.cpp affecting a custom field.

Orthographic projection sees "more" of the sceen as fov increases, but only up to 180 degrees, after which it will have no effect. Orthographic projection has no meaning for fov since there is no Frustum. But since this is fundamental to the engine, I am reinterpreting it. Cherno wanted this. I'll update the wiki if this gets in.