### PR TITLE
Tweak KEX/Unity order in IWAD selection box to be consistent across games

### DIFF
--- a/wadsrc_extra/static/iwadinfo.txt
+++ b/wadsrc_extra/static/iwadinfo.txt
@@ -76,7 +76,7 @@ IWad
 
 IWad
 {
-	Name = "Hacx: Twitch'n Kill"
+	Name = "Hacx: Twitch 'n Kill"
 	Game = "Doom"
 	Config = "Hacx"
 	Autoname = "hacx.hacx1"
@@ -719,11 +719,11 @@ Order	// Order in the IWAD selection box
 	"DOOM: KEX Edition"
 	"DOOM: Unity Edition"
 	"Final Doom: Plutonia Experiment"
-	"Final Doom: Plutonia Experiment: Unity Edition"
 	"Final Doom: Plutonia Experiment: KEX Edition"
+	"Final Doom: Plutonia Experiment: Unity Edition"
 	"Final Doom: TNT - Evilution"
-	"Final Doom: TNT - Evilution: Unity Edition"
 	"Final Doom: TNT - Evilution: KEX Edition"
+	"Final Doom: TNT - Evilution: Unity Edition"
 	"Freedoom: Phase 1"
 	"Freedoom: Phase 2"
 	"FreeDM"
@@ -742,7 +742,7 @@ Order	// Order in the IWAD selection box
 	"Chex(R) Quest 3"
 	"Action Doom 2: Urban Brawl"
 	"Harmony"
-	"Hacx: Twitch'n Kill"
+	"Hacx: Twitch 'n Kill"
 	"Hacx 2.0"
 	"The Adventures of Square"
 	"The Adventures of Square (Square-ware)"


### PR DESCRIPTION
- Fix missing space in "Hacx: Twitch 'n Kill".
  - The official capitalization seems a bit inconsistent with ["HacX" being regularly used by its original developers](http://www.drnostromo.com/hacx/), but [the Doom wiki uses "Hacx"](https://doomwiki.org/wiki/Hacx).

___

- See https://github.com/ZDoom/gzdoom/issues/2669#issuecomment-2291320473.