### PR TITLE
Minor optimization for Ortho

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_clipper.cpp
+++ b/src/rendering/hwrenderer/scene/hw_clipper.cpp
@@ -476,8 +476,8 @@ angle_t Clipper::PointToPseudoOrthoAngle(double x, double y)
 	{
 		angle_t af = viewpoint->FrustAngle;
 		double xproj = disp.XY().Length() * deltaangle(disp.Angle(), viewpoint->Angles.Yaw).Sin();
-		xproj *= viewpoint->ScreenProj;
-		if (fabs(xproj) < r_viewwindow.WidescreenRatio*1.13) // 2.0)
+		xproj *= viewpoint->ScreenProjX;
+		if (fabs(xproj) < 1.13)
 		{
 			return AngleToPseudo( viewpoint->Angles.Yaw.BAMs() - xproj * 0.5 * af );
 		}

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -167,6 +167,7 @@ FRenderViewpoint::FRenderViewpoint()
 	sector = nullptr;
 	FieldOfView =  DAngle::fromDeg(90.); // Angles in the SCREENWIDTH wide window
 	ScreenProj = 0.0;
+	ScreenProjX = 0.0;
 	TicFrac = 0.0;
 	FrameTime = 0;
 	extralight = 0;
@@ -704,7 +705,10 @@ void FRenderViewpoint::SetViewAngle(const FViewWindow& viewWindow)
 	HWAngles.Yaw = FAngle::fromDeg(270.0 - Angles.Yaw.Degrees());
 
 	if (IsOrtho() && (camera->ViewPos->Offset.XY().Length() > 0.0))
+	{
 		ScreenProj = 1.34396 / camera->ViewPos->Offset.Length() / tan (FieldOfView.Radians()*0.5); // [DVR] Estimated. +/-1 should be top/bottom of screen.
+		ScreenProjX = ScreenProj * 0.5 / viewWindow.WidescreenRatio;
+	}
 
 }
 

--- a/src/rendering/r_utility.h
+++ b/src/rendering/r_utility.h
@@ -43,6 +43,7 @@ struct FRenderViewpoint
 	sector_t		*sector;		// [RH] keep track of sector viewing from
 	DAngle			FieldOfView;	// current field of view
 	double			ScreenProj;	// Screen projection factor for orthographic projection
+	double			ScreenProjX;	// Same for X-axis (screenspace)
 
 	double			TicFrac;		// fraction of tic for interpolation
 	uint32_t		FrameTime;		// current frame's time in tics.


### PR DESCRIPTION
Reduce number of multiply operations per frame (to one) and increase x-axis clipper range for orthographic projection.

There was also a small visual rendering glitch that only showed up when forcing an aspect ratio other than 16:9 (or for certain aspect ratios in windowed mode). Fixed.

Here is a small test wad (modified from Major Cooke's example) to show the visual glitch on a camera texture. Just force an aspect ratio in "Set Video Mode" options menu:

[camtest_modded.wad.zip](https://github.com/user-attachments/files/17530936/camtest_modded.wad.zip)
