### PR TITLE
OrthographicCamera Actor

### DIFF
--- a/wadsrc/static/mapinfo/common.txt
+++ b/wadsrc/static/mapinfo/common.txt
@@ -78,6 +78,7 @@ DoomEdNums
   9081 = SkyPicker
   9082 = SectorSilencer
   9083 = SkyCamCompat
+  9084 = OrthographicCamera
   9200 = Decal
   9300 = "$PolyAnchor"
   9301 = "$PolySpawn"

--- a/wadsrc/static/zscript/actors/shared/camera.zs
+++ b/wadsrc/static/zscript/actors/shared/camera.zs
@@ -238,7 +238,7 @@ Class OrthographicCamera : Actor
 	}
 
 	private int current;
-	private void UpdateViewPos()
+	protected void UpdateViewPos()
 	{
 		current = args[0];
 		SetViewPos((-abs(max(1.0, double(current))), 0, 0), VPSF_ORTHOGRAPHIC|VPSF_ALLOWOUTOFBOUNDS);

--- a/wadsrc/static/zscript/actors/shared/camera.zs
+++ b/wadsrc/static/zscript/actors/shared/camera.zs
@@ -237,7 +237,7 @@ Class OrthographicCamera : Actor
 		Super.Tick();
 	}
 
-	private int current;
+	protected int current;
 	protected void UpdateViewPos()
 	{
 		current = args[0];

--- a/wadsrc/static/zscript/actors/shared/camera.zs
+++ b/wadsrc/static/zscript/actors/shared/camera.zs
@@ -212,3 +212,35 @@ class SpectatorCamera : Actor
 		}
 	}
 }
+
+Class OrthographicCamera : Actor
+{
+	Default
+	{
+		+NOBLOCKMAP
+		+NOINTERACTION
+		CameraHeight 0;
+		RenderStyle "None";
+	}
+
+	override void PostBeginPlay()
+	{
+		Super.PostBeginPlay();
+		UpdateViewPos();
+	}
+	
+	override void Tick()
+	{
+		if (current != args[0])
+			UpdateViewPos();
+		
+		Super.Tick();
+	}
+
+	private int current;
+	private void UpdateViewPos()
+	{
+		current = args[0];
+		SetViewPos((-abs(max(1.0, double(current))), 0, 0), VPSF_ORTHOGRAPHIC|VPSF_ALLOWOUTOFBOUNDS);
+	}
+}


### PR DESCRIPTION
This will make setting up orthographic cameras in map editors far easier. Once this is merged, I'll send a pull request over to Ultimate Doom Builder that implements support.

Arguments are as follows: 
- 0: Offset. This pushes the camera further away, going behind the camera. Default is 1.0 (converted to negative - the value cannot go lower than that).