### PR TITLE
Added net id functions for ACS

### DIFF
--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -316,6 +316,23 @@ public:
 	{
 		return tid == 0 ? defactor : GetActorIterator(tid).Next();
 	}
+	AActor* SelectActorFromTID(int tid, size_t index, AActor *defactor)
+	{
+		if (tid == 0)
+			return defactor;
+
+		AActor* actor = nullptr;
+		size_t cur = 0u;
+		auto it = GetActorIterator(tid);
+		while ((actor = it.Next()) != nullptr)
+		{
+			if (cur == index)
+				return actor;
+			++cur;
+		}
+
+		return nullptr;
+	}
 
 	bool SectorHasTags(sector_t *sector)
 	{

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -4806,6 +4806,8 @@ enum EACSFunctions
 	ACSF_GetSectorHealth,
 	ACSF_GetLineHealth,
 	ACSF_SetSubtitleNumber,
+	ACSF_GetNetID,
+	ACSF_SetActivatorByNetID,
 
 		// Eternity's
 	ACSF_GetLineX = 300,
@@ -5380,6 +5382,13 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, int32_t *args, int &
 			actor = Level->SingleActorFromTID(args[0], activator);
 			return actor != NULL? DoubleToACS(actor->Vel.Z) : 0;
 
+		case ACSF_GetNetID:
+			MIN_ARG_COUNT(2);
+			actor = Level->SelectActorFromTID(args[0], args[1], activator);
+			if (argCount > 2)
+				actor = COPY_AAPTREX(Level, actor, args[2]);
+			return actor != nullptr ? actor->GetNetworkID() : NetworkEntityManager::WorldNetID;
+
 		case ACSF_SetPointer:
 			MIN_ARG_COUNT(2);
 			if (activator)
@@ -5428,6 +5437,18 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, int32_t *args, int &
 					activator = actor;
 					return 1;
 				}
+			}
+			return 0;
+
+		case ACSF_SetActivatorByNetID:
+			MIN_ARG_COUNT(1);
+			actor = dyn_cast<AActor>(NetworkEntityManager::GetNetworkEntity(args[0]));
+			if (argCount > 1)
+				actor = COPY_AAPTREX(Level, actor, args[1]);
+			if (actor != nullptr)
+			{
+				activator = actor;
+				return 1;
 			}
 			return 0;
 


### PR DESCRIPTION
Includes net id getter and activator setter functionality. Essentially acts as a pseudo pointer system for Actors within ACS.