### PR TITLE
Limiting r_radarclipper effect to OoB viewpoints only

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -286,12 +286,12 @@ void HWDrawInfo::AddLine (seg_t *seg, bool portalclip)
 	angle_t startAngleR = clipperr.PointToPseudoAngle(seg->v2->fX(), seg->v2->fY());
 	angle_t endAngleR = clipperr.PointToPseudoAngle(seg->v1->fX(), seg->v1->fY());
 
-	if(r_radarclipper && !(Level->flags3 & LEVEL3_NOFOGOFWAR) && (startAngleR - endAngleR >= ANGLE_180))
+	if(Viewpoint.IsAllowedOoB() && r_radarclipper && !(Level->flags3 & LEVEL3_NOFOGOFWAR) && (startAngleR - endAngleR >= ANGLE_180))
 	{
 		if (!seg->backsector) clipperr.SafeAddClipRange(startAngleR, endAngleR);
 		else if((seg->sidedef != nullptr) && !uint8_t(seg->sidedef->Flags & WALLF_POLYOBJ) && (currentsector->sectornum != seg->backsector->sectornum))
 		{
-			if (in_area == area_default) in_area = hw_CheckViewArea(seg->v2, seg->v1, seg->frontsector, seg->backsector);
+			if (in_area == area_default) in_area = hw_CheckViewArea(seg->v1, seg->v2, seg->frontsector, seg->backsector);
 			backsector = hw_FakeFlat(seg->backsector, in_area, true);
 			if (hw_CheckClip(seg->sidedef, currentsector, backsector)) clipperr.SafeAddClipRange(startAngleR, endAngleR);
 		}
@@ -1011,7 +1011,7 @@ void HWDrawInfo::RenderBSP(void *node, bool drawpsprites)
 	// Give the DrawInfo the viewpoint in fixed point because that's what the nodes are.
 	viewx = FLOAT2FIXED(Viewpoint.Pos.X);
 	viewy = FLOAT2FIXED(Viewpoint.Pos.Y);
-	if (r_radarclipper && !(Level->flags3 & LEVEL3_NOFOGOFWAR) && Viewpoint.IsAllowedOoB() && (Viewpoint.camera->ViewPos->Flags & VPSF_ABSOLUTEOFFSET))
+	if (r_radarclipper && !(Level->flags3 & LEVEL3_NOFOGOFWAR) && Viewpoint.IsAllowedOoB())
 	{
 		if (Viewpoint.camera->tracer != NULL)
 		{


### PR DESCRIPTION
Limiting `r_radarclipper` effect to Out-of-Bounds viewpoints only. Opens the possibility of leaving it `true` by default in the future.

The cvar `r_radarclipper` is set to `false` by default. Its value gets recorded per iwad in the ini file.
It was meant for OoB-allowed viewpoints (enables clipping from point of view of some actor position that is within bounds).
It has no business doing anything when viewpoint is not allowed out of bounds.

We don't want visual infidelity when end users play with the cvar and accidentally leave it `true` while using regular third-person cameras (like say, `chasecam` looking around a corner).