### PR TITLE
Fixed startpos not saving

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -96,6 +96,8 @@
 static FRandom pr_dmspawn ("DMSpawn");
 static FRandom pr_pspawn ("PlayerSpawn");
 
+extern int startpos, laststartpos;
+
 bool WriteZip(const char* filename, const FileSys::FCompressedBuffer* content, size_t contentcount);
 bool	G_CheckDemoStatus (void);
 void	G_ReadDemoTiccmd (ticcmd_t *cmd, int player);
@@ -2146,7 +2148,9 @@ void G_DoLoadGame ()
 
 	arc("ticrate", time[0])
 		("leveltime", time[1])
-		("globalfreeze", globalfreeze);
+		("globalfreeze", globalfreeze)
+		("startpos", startpos)
+		("laststartpos", laststartpos);
 	// dearchive all the modifications
 	level.time = Scale(time[1], TICRATE, time[0]);
 
@@ -2433,6 +2437,10 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 		savegameglobals("ticrate", tic);
 		savegameglobals("leveltime", level.time);
 	}
+
+	savegameglobals("globalfreeze", globalfreeze)
+					("startpos", startpos)
+					("laststartpos", laststartpos);
 
 	STAT_Serialize(savegameglobals);
 	FRandom::StaticWriteRNGState(savegameglobals);

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -111,6 +111,8 @@ EXTERN_CVAR (Int, disableautosave)
 EXTERN_CVAR (String, playerclass)
 
 extern uint8_t globalfreeze, globalchangefreeze;
+int startpos = 0; // [RH] Support for multiple starts per level
+int laststartpos = 0;
 
 #define SNAP_ID			MAKE_ID('s','n','A','p')
 #define DSNP_ID			MAKE_ID('d','s','N','p')
@@ -652,7 +654,9 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 		gamestate = GS_LEVEL;
 	}
 	
-	G_DoLoadLevel (mapname, 0, false, !savegamerestore);
+	if (!savegamerestore)
+		startpos = laststartpos = 0;
+	G_DoLoadLevel (mapname, startpos, false, !savegamerestore);
 
 	if (!savegamerestore && (gameinfo.gametype == GAME_Strife || (SBarInfoScript[SCRIPT_CUSTOM] != nullptr && SBarInfoScript[SCRIPT_CUSTOM]->GetGameType() == GAME_Strife)))
 	{
@@ -669,7 +673,6 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 // G_DoCompleted
 //
 static FString	nextlevel;
-static int		startpos;	// [RH] Support for multiple starts per level
 extern int		NoWipe;		// [RH] Don't wipe when travelling in hubs
 static int		changeflags;
 static bool		unloading;
@@ -1100,7 +1103,6 @@ void G_DoCompleted (void)
 	if (gamestate == GS_TITLELEVEL)
 	{
 		G_DoLoadLevel (nextlevel, startpos, false, false);
-		startpos = 0;
 		viewactive = true;
 		return;
 	}
@@ -1373,7 +1375,6 @@ void G_DoLoadLevel(const FString &nextmapname, int position, bool autosave, bool
 void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool autosave, bool newGame)
 {
 	MapName = nextmapname;
-	static int lastposition = 0;
 	int i;
 
 	if (NextSkill >= 0)
@@ -1385,9 +1386,9 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 	}
 
 	if (position == -1)
-		position = lastposition;
+		position = laststartpos;
 	else
-		lastposition = position;
+		laststartpos = position;
 
 	Init();
 	StatusBar->DetachAllMessages ();
@@ -1575,7 +1576,6 @@ void G_DoWorldDone (void)
 	}
 	primaryLevel->StartTravel ();
 	G_DoLoadLevel (nextlevel, startpos, true, false);
-	startpos = 0;
 	gameaction = ga_nothing;
 	viewactive = true; 
 }


### PR DESCRIPTION
Will now load properly from save games preventing respawning at the wrong player starts. This also fixes `globalfreeze` not saving.