### PR TITLE
Updated packet handling

### DIFF
--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -117,8 +117,6 @@ static SOCKET mysocket = INVALID_SOCKET;
 static sockaddr_in sendaddress[MAXNETNODES];
 static uint8_t sendplayer[MAXNETNODES];
 
-constexpr int NET_EXIT = 0x80;
-
 #ifdef __WIN32__
 const char *neterror (void);
 #else
@@ -308,7 +306,7 @@ void PacketGet (void)
 					GetPlayerName(node).GetChars());
 			}
 
-			doomcom.data[0] = NET_EXIT;
+			doomcom.data[0] = NCMD_EXIT;
 			c = 1;
 		}
 		else if (err != WSAEWOULDBLOCK)
@@ -346,11 +344,8 @@ void PacketGet (void)
 	}
 	else if (c > 0)
 	{	//The packet is not from any in-game node, so we might as well discard it.
-		// Don't show the message for disconnect notifications.
-		if (TransmitBuffer[0] != NET_EXIT)
+		if (TransmitBuffer[0] == PRE_FAKE)
 		{
-			if (TransmitBuffer[0] != PRE_FAKE)
-				DPrintf(DMSG_WARNING, "Dropped packet: Unknown host (%s:%d)\n", inet_ntoa(fromaddress.sin_addr), fromaddress.sin_port);
 			// If it's someone waiting in the lobby, let them know the game already started
 			uint8_t msg[] = { PRE_FAKE, PRE_IN_PROGRESS };
 			PreSend(msg, 2, &fromaddress);

--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -117,6 +117,8 @@ static SOCKET mysocket = INVALID_SOCKET;
 static sockaddr_in sendaddress[MAXNETNODES];
 static uint8_t sendplayer[MAXNETNODES];
 
+constexpr int NET_EXIT = 0x80;
+
 #ifdef __WIN32__
 const char *neterror (void);
 #else
@@ -306,7 +308,7 @@ void PacketGet (void)
 					GetPlayerName(node).GetChars());
 			}
 
-			doomcom.data[0] = NCMD_EXIT;
+			doomcom.data[0] = NET_EXIT;
 			c = 1;
 		}
 		else if (err != WSAEWOULDBLOCK)
@@ -345,7 +347,7 @@ void PacketGet (void)
 	else if (c > 0)
 	{	//The packet is not from any in-game node, so we might as well discard it.
 		// Don't show the message for disconnect notifications.
-		if (TransmitBuffer[0] != NCMD_EXIT)
+		if (TransmitBuffer[0] != NET_EXIT)
 		{
 			if (TransmitBuffer[0] != PRE_FAKE)
 				DPrintf(DMSG_WARNING, "Dropped packet: Unknown host (%s:%d)\n", inet_ntoa(fromaddress.sin_addr), fromaddress.sin_port);

--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -521,7 +521,7 @@ void SendAbort (void)
 	}
 }
 
-static void SendConAck (int num_connected, int num_needed)
+void SendConAck (int num_connected, int num_needed)
 {
 	PreGamePacket packet;
 

--- a/src/common/engine/i_net.h
+++ b/src/common/engine/i_net.h
@@ -7,6 +7,7 @@
 int I_InitNetwork (void);
 void I_NetCmd (void);
 void I_NetMessage(const char*, ...);
+void I_NetError(const char* error);
 void I_NetProgress(int val);
 void I_NetInit(const char* msg, int num);
 bool I_NetLoop(bool (*timer_callback)(void*), void* userdata);

--- a/src/common/engine/st_start.h
+++ b/src/common/engine/st_start.h
@@ -55,6 +55,7 @@ public:
 	virtual void NetInit(const char *message, int num_players) {}
 	virtual void NetProgress(int count) {}
 	virtual void NetDone() {}
+	virtual void NetClose() {}
 	virtual bool NetLoop(bool (*timer_callback)(void *), void *userdata) { return false; }
 	virtual void AppendStatusLine(const char* status) {}
 	virtual void LoadingStatus(const char* message, int colors) {}
@@ -74,6 +75,7 @@ public:
 	void NetProgress(int count);
 	void NetMessage(const char* format, ...);	// cover for printf
 	void NetDone();
+	void NetClose();
 	bool NetLoop(bool (*timer_callback)(void*), void* userdata);
 protected:
 	int NetMaxPos, NetCurPos;

--- a/src/common/platform/posix/cocoa/st_console.h
+++ b/src/common/platform/posix/cocoa/st_console.h
@@ -66,6 +66,7 @@ public:
 	void NetInit(const char* message, int playerCount);
 	void NetProgress(int count);
 	void NetDone();
+	void NetClose();
 
 private:
 	NSWindow*            m_window;

--- a/src/common/platform/posix/cocoa/st_console.mm
+++ b/src/common/platform/posix/cocoa/st_console.mm
@@ -531,3 +531,8 @@ void FConsoleWindow::NetDone()
 		m_netAbortButton = nil;
 	}
 }
+
+void FConsoleWindow::NetClose()
+{
+	// TODO: Implement this
+}

--- a/src/common/platform/posix/cocoa/st_start.mm
+++ b/src/common/platform/posix/cocoa/st_start.mm
@@ -110,6 +110,11 @@ void FBasicStartupScreen::NetDone()
 	FConsoleWindow::GetInstance().NetDone();
 }
 
+void FBasicStartupScreen::NetClose()
+{
+	FConsoleWindow::GetInstance().NetClose();
+}
+
 bool FBasicStartupScreen::NetLoop(bool (*timerCallback)(void*), void* const userData)
 {
 	while (true)

--- a/src/common/platform/posix/sdl/st_start.cpp
+++ b/src/common/platform/posix/sdl/st_start.cpp
@@ -57,6 +57,7 @@ class FTTYStartupScreen : public FStartupScreen
 		void NetInit(const char *message, int num_players);
 		void NetProgress(int count);
 		void NetDone();
+		void NetClose();
 		bool NetLoop(bool (*timer_callback)(void *), void *userdata);
 	protected:
 		bool DidNetInit;
@@ -235,6 +236,11 @@ void FTTYStartupScreen::NetProgress(int count)
 		fprintf (stderr, "%*c[%2d/%2d]", NetMaxPos + 1 - NetCurPos, ' ', NetCurPos, NetMaxPos);
 		fflush (stderr);
 	}
+}
+
+void FTTYStartupScreen::NetClose()
+{
+	// TODO: Implement this
 }
 
 //===========================================================================

--- a/src/common/platform/win32/i_mainwindow.cpp
+++ b/src/common/platform/win32/i_mainwindow.cpp
@@ -128,6 +128,11 @@ void MainWindow::HideNetStartPane()
 	NetStartWindow::HideNetStartPane();
 }
 
+void MainWindow::CloseNetStartPane()
+{
+	NetStartWindow::NetClose();
+}
+
 void MainWindow::SetNetStartProgress(int pos)
 {
 	NetStartWindow::SetNetStartProgress(pos);

--- a/src/common/platform/win32/i_mainwindow.h
+++ b/src/common/platform/win32/i_mainwindow.h
@@ -29,6 +29,7 @@ public:
 	void SetNetStartProgress(int pos);
 	bool RunMessageLoop(bool (*timer_callback)(void*), void* userdata);
 	void HideNetStartPane();
+	void CloseNetStartPane();
 
 	void SetWindowTitle(const char* caption);
 

--- a/src/common/platform/win32/st_start.cpp
+++ b/src/common/platform/win32/st_start.cpp
@@ -201,3 +201,8 @@ bool FBasicStartupScreen::NetLoop(bool (*timer_callback)(void *), void *userdata
 {
 	return mainwindow.RunMessageLoop(timer_callback, userdata);
 }
+
+void FBasicStartupScreen::NetClose()
+{
+	mainwindow.CloseNetStartPane();
+}

--- a/src/common/widgets/netstartwindow.cpp
+++ b/src/common/widgets/netstartwindow.cpp
@@ -64,6 +64,12 @@ bool NetStartWindow::RunMessageLoop(bool (*newtimer_callback)(void*), void* newu
 	return Instance->exitreason;
 }
 
+void NetStartWindow::NetClose()
+{
+	if (Instance != nullptr)
+		Instance->OnClose();
+}
+
 NetStartWindow::NetStartWindow() : Widget(nullptr, WidgetType::Window)
 {
 	SetWindowBackground(Colorf::fromRgba8(51, 51, 51));

--- a/src/common/widgets/netstartwindow.h
+++ b/src/common/widgets/netstartwindow.h
@@ -14,6 +14,7 @@ public:
 	static void HideNetStartPane();
 	static void SetNetStartProgress(int pos);
 	static bool RunMessageLoop(bool (*timer_callback)(void*), void* userdata);
+	static void NetClose();
 
 private:
 	NetStartWindow();


### PR DESCRIPTION
Added "game in progress" message for players trying to join late. Removed "unknown host" logging since it's largely irrelevant to the person hosting the game. Correctly abort network window so game can process fatal errors instead of hanging on waiting to connect (currently only tested for win32 platforms). Potential fixes for unexpected disconnects in lobby not correctly updating the state of it.