### PR TITLE
Weapon Selection Modifiers

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -315,7 +315,7 @@ CCMD (slot)
 		if (slot < NUM_WEAPON_SLOTS && mo)
 		{
 			// Needs to be redone
-			IFVIRTUALPTRNAME(mo, NAME_PlayerPawn, PickWeapon)
+			IFVM(PlayerPawn, FindWeapon)
 			{
 				VMValue param[] = { mo, slot, !(dmflags2 & DF2_DONTCHECKAMMO) };
 				VMReturn ret((void**)&SendItemUse);
@@ -367,7 +367,7 @@ CCMD (weapnext)
 	if (mo)
 	{
 		// Needs to be redone
-		IFVIRTUALPTRNAME(mo, NAME_PlayerPawn, PickNextWeapon)
+		IFVM(PlayerPawn, FindNextWeapon)
 		{
 			VMValue param[] = { mo };
 			VMReturn ret((void**)&SendItemUse);
@@ -394,7 +394,7 @@ CCMD (weapprev)
 	if (mo)
 	{
 		// Needs to be redone
-		IFVIRTUALPTRNAME(mo, NAME_PlayerPawn, PickPrevWeapon)
+		IFVM(PlayerPawn, FindPrevWeapon)
 		{
 			VMValue param[] = { mo };
 			VMReturn ret((void**)&SendItemUse);

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -1366,7 +1366,20 @@ class Inventory : Actor
 		}
 	}
 
-	
+	virtual Weapon ModifyPickWeapon(int slot, bool checkammo, Weapon originalPick)
+	{
+		return originalPick;
+	}
+
+	virtual Weapon ModifyPickNextWeapon(Weapon originalPick)
+	{
+		return originalPick;
+	}
+
+	virtual Weapon ModifyPickPrevWeapon(Weapon originalPick)
+	{
+		return originalPick;
+	}
 	
 }
 

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2334,6 +2334,24 @@ class PlayerPawn : Actor
 		return ReadyWeapon;
 	}
 
+	Weapon CallModifyPickWeapon(int slot, bool checkammo, Weapon pick)
+	{
+		let cur = inv;
+		
+		if(cur) do
+		{
+			pick = cur.ModifyPickWeapon(slot, checkammo, pick);
+		}
+		while(cur = cur.inv)
+		
+		return pick;
+	}
+
+	Weapon FindWeapon(int slot, bool checkammo)
+	{
+		return CallModifyPickWeapon(slot, checkammo, PickWeapon(slot, checkammo));
+	}
+
 	//===========================================================================
 	//
 	// FindMostRecentWeapon
@@ -2438,6 +2456,24 @@ class PlayerPawn : Actor
 		return ReadyWeapon;
 	}
 
+	Weapon CallModifyPickNextWeapon(Weapon pick)
+	{
+		let cur = inv;
+		
+		if(cur) do
+		{
+			pick = cur.ModifyPickNextWeapon(pick);
+		}
+		while(cur = cur.inv)
+		
+		return pick;
+	}
+
+	Weapon FindNextWeapon()
+	{
+		return CallModifyPickNextWeapon(PickNextWeapon());
+	}
+
 	//===========================================================================
 	//
 	// FWeaponSlots :: PickPrevWeapon
@@ -2489,6 +2525,24 @@ class PlayerPawn : Actor
 			} while ((slot != startslot || index != startindex) && slotschecked <= NUM_WEAPON_SLOTS);
 		}
 		return player.ReadyWeapon;
+	}
+
+	Weapon CallModifyPickPrevWeapon(Weapon pick)
+	{
+		let cur = inv;
+		
+		if(cur) do
+		{
+			pick = cur.ModifyPickPrevWeapon(pick);
+		}
+		while(cur = cur.inv)
+		
+		return pick;
+	}
+
+	Weapon FindPrevWeapon()
+	{
+		return CallModifyPickPrevWeapon(PickPrevWeapon());
 	}
 
 	//============================================================================

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2347,9 +2347,16 @@ class PlayerPawn : Actor
 		return pick;
 	}
 
+	virtual Weapon PostFindWeapon(int slot, bool checkammo, Weapon orig, Weapon mod)
+	{
+		return mod;
+	}
+
 	Weapon FindWeapon(int slot, bool checkammo)
 	{
-		return CallModifyPickWeapon(slot, checkammo, PickWeapon(slot, checkammo));
+		let orig = PickWeapon(slot, checkammo);
+		let mod = CallModifyPickWeapon(slot, checkammo, orig);
+		return PostFindWeapon(slot, checkammo, orig, mod);
 	}
 
 	//===========================================================================
@@ -2469,9 +2476,16 @@ class PlayerPawn : Actor
 		return pick;
 	}
 
+	virtual Weapon PostFindNextWeapon(Weapon orig, Weapon mod)
+	{
+		return mod;
+	}
+
 	Weapon FindNextWeapon()
 	{
-		return CallModifyPickNextWeapon(PickNextWeapon());
+		let orig = PickNextWeapon();
+		let mod = CallModifyPickNextWeapon(orig);
+		return PostFindNextWeapon(orig, mod);
 	}
 
 	//===========================================================================
@@ -2540,9 +2554,16 @@ class PlayerPawn : Actor
 		return pick;
 	}
 
+	virtual Weapon PostFindPrevWeapon(Weapon orig, Weapon mod)
+	{
+		return mod;
+	}
+
 	Weapon FindPrevWeapon()
 	{
-		return CallModifyPickPrevWeapon(PickPrevWeapon());
+		let orig = PickPrevWeapon();
+		let mod = CallModifyPickPrevWeapon(orig);
+		return PostFindPrevWeapon(orig, mod);
 	}
 
 	//============================================================================


### PR DESCRIPTION
Adds the ability for inventory to override weapon selection of player pawns, but also adds a post version of those functions within pawns. This ensures that pawns can have the final say. However, they default to let the inventory modified result through.