### PR TITLE
- enable mipmapping in 2D

### DIFF
--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -50,6 +50,7 @@
 //===========================================================================
 
 CVAR(Bool, gl_aalines, false, CVAR_ARCHIVE) 
+CVAR(Bool, hw_2dmip, true, CVAR_ARCHIVE)
 
 void Draw2D(F2DDrawer* drawer, FRenderState& state)
 {
@@ -70,6 +71,8 @@ void Draw2D(F2DDrawer* drawer, FRenderState& state, int x, int y, int width, int
 	state.EnableDepthTest(false);
 	state.EnableMultisampling(false);
 	state.EnableLineSmooth(gl_aalines);
+
+	bool cache_hw_2dmip = hw_2dmip; // cache cvar lookup so it's not done in a loop
 
 	auto &vertices = drawer->mVertices;
 	auto &indices = drawer->mIndices;
@@ -180,7 +183,7 @@ void Draw2D(F2DDrawer* drawer, FRenderState& state, int x, int y, int width, int
 			auto flags = cmd.mTexture->GetUseType() >= ETextureType::Special? UF_None : cmd.mTexture->GetUseType() == ETextureType::FontChar? UF_Font : UF_Texture;
 
 			auto scaleflags = cmd.mFlags & F2DDrawer::DTF_Indexed ? CTF_Indexed : 0;
-			state.SetMaterial(cmd.mTexture, flags, scaleflags, cmd.mFlags & F2DDrawer::DTF_Wrap ? CLAMP_NONE : CLAMP_XY_NOMIP, cmd.mTranslationId, -1);
+			state.SetMaterial(cmd.mTexture, flags, scaleflags, cmd.mFlags & F2DDrawer::DTF_Wrap ? CLAMP_NONE : (cache_hw_2dmip ? CLAMP_XY : CLAMP_XY_NOMIP), cmd.mTranslationId, -1);
 			state.EnableTexture(true);
 
 			// Canvas textures are stored upside down


### PR DESCRIPTION
This commit is already in VkDoom and has been for a few months. If this is not to be allowed though - I have to ask, why? What was the decision that led to disabling 2D mipmapping?