### PR TITLE
View fix for frozen players

### DIFF
--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -464,7 +464,8 @@ bool P_NoInterpolation(player_t const *player, AActor const *actor)
 		&& player->mo->reactiontime == 0
 		&& !NoInterpolateView
 		&& !paused
-		&& !LocalKeyboardTurner;
+		&& !LocalKeyboardTurner
+		&& !player->mo->isFrozen();
 }
 
 //==========================================================================


### PR DESCRIPTION
Will no longer try and extrapolate mouse input that's bound to mispredict.