### PR TITLE
WorldThingGoalReached Virtual

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -310,6 +310,7 @@ public:
 	void WorldThingGround(AActor* actor, FState* st);
 	void WorldThingRevived(AActor* actor);
 	void WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
+	void WorldThingGoalReached(AActor* actor, AActor* oldgoal);
 	void WorldThingDestroyed(AActor* actor);
 	void WorldLinePreActivated(line_t* line, AActor* actor, int activationType, bool* shouldactivate);
 	void WorldLineActivated(line_t* line, AActor* actor, int activationType);
@@ -471,8 +472,10 @@ struct EventManager
 	void WorldThingGround(AActor* actor, FState* st);
 	// called after AActor::Revive.
 	void WorldThingRevived(AActor* actor);
-	// called before P_DamageMobj and before AActor::DamageMobj virtuals.
+	// called after damage has been dealt
 	void WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
+	// called when the actor changes goals. Goal is the OLD goal.
+	void WorldThingGoalReached(AActor* actor, AActor* oldgoal);
 	// called before AActor::Destroy of each actor.
 	void WorldThingDestroyed(AActor* actor);
 	// called in P_ActivateLine before executing special, set shouldactivate to false to prevent activation.

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -51,6 +51,7 @@
 #include "actorinlines.h"
 #include "a_ceiling.h"
 #include "shadowinlines.h"
+#include "events.h"
 
 #include "gi.h"
 
@@ -2549,7 +2550,8 @@ void A_DoChase (AActor *actor, bool fastchase, FState *meleestate, FState *missi
 	// [RH] Don't attack if just moving toward goal
 	if (actor->target == actor->goal || (actor->flags5&MF5_CHASEGOAL && actor->goal != NULL))
 	{
-		AActor * savedtarget = actor->target;
+		AActor *savedtarget = actor->target;
+		AActor *savedgoal = actor->goal;
 		actor->target = actor->goal;
 		bool result = P_CheckMeleeRange(actor);
 		actor->target = savedtarget;
@@ -2572,7 +2574,7 @@ void A_DoChase (AActor *actor, bool fastchase, FState *meleestate, FState *missi
 			DAngle lastgoalang = actor->goal->Angles.Yaw;
 			int delay;
 			AActor * newgoal = iterator.Next ();
-			if (newgoal != NULL && actor->goal == actor->target)
+			if (newgoal != nullptr && actor->goal == actor->target)
 			{
 				delay = newgoal->args[1];
 				actor->reactiontime = delay * TICRATE + actor->Level->maptime;
@@ -2592,6 +2594,8 @@ void A_DoChase (AActor *actor, bool fastchase, FState *meleestate, FState *missi
 			}
 			actor->flags7 &= ~MF7_INCHASE;
 			actor->goal = newgoal;
+			if (actor->goal != savedgoal)
+				actor->Level->localEventManager->WorldThingGoalReached(actor, savedgoal);
 			return;
 		}
 		if (actor->goal == actor->target) goto nomissile;

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -2371,6 +2371,20 @@ nosee:
 	return 0;
 }
 
+void GoalReached(AActor* self, AActor* oldgoal)
+{
+	if (self && self->Level)
+		self->Level->localEventManager->WorldThingGoalReached(self, oldgoal);
+}
+
+DEFINE_ACTION_FUNCTION(AActor, GoalReached)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_OBJECT(oldgoal, AActor);
+	GoalReached(self, oldgoal);
+	return 0;
+}
+
 //=============================================================================
 //
 // A_Chase
@@ -2594,8 +2608,7 @@ void A_DoChase (AActor *actor, bool fastchase, FState *meleestate, FState *missi
 			}
 			actor->flags7 &= ~MF7_INCHASE;
 			actor->goal = newgoal;
-			if (actor->goal != savedgoal)
-				actor->Level->localEventManager->WorldThingGoalReached(actor, savedgoal);
+			GoalReached(actor, savedgoal);
 			return;
 		}
 		if (actor->goal == actor->target) goto nomissile;

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -813,6 +813,9 @@ class Actor : Thinker native
 		movecount = random[TryWalk](0, 15);
 		return true;
 	}
+
+	// Calls WorldThingGoalReached.
+	native void GoalReached(Actor oldgoal);
 	
 	native bool TryMove(vector2 newpos, int dropoff, bool missilecheck = false, FCheckPosition tm = null);
 	native bool CheckMove(vector2 newpos, int flags = 0, FCheckPosition tm = null);

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -74,9 +74,9 @@ struct WorldEvent native play version("2.4")
     native readonly bool IsReopen;
     // for unloaded, name of next map (if any)
     native readonly String NextMap;
-    // for thingspawned/thingdied/thingdestroyed/thingground
+    // for thingspawned/thingdied/thingdestroyed/thingground/thinggoalreached
     native readonly Actor Thing;
-    // for thingdied. can be null
+    // for thingdied. can be null. [MC] Also used for ThingGoalReached, inflictor is the old goal.
     native readonly Actor Inflictor;
     // for thingdamaged, line/sector damaged
     native readonly int Damage;
@@ -154,6 +154,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual void WorldThingGround(WorldEvent e) {}
     virtual void WorldThingRevived(WorldEvent e) {}
     virtual void WorldThingDamaged(WorldEvent e) {}
+    virtual void WorldThingGoalReached(WorldEvent e) {}
     virtual void WorldThingDestroyed(WorldEvent e) {}
     virtual void WorldLinePreActivated(WorldEvent e) {}
     virtual void WorldLineActivated(WorldEvent e) {}


### PR DESCRIPTION
Added WorldThingGoalReached(WorldEvent e).

Called whenever an actor chasing a goal reaches it, only by A_DoChase.

- `Thing`: actor that reached the goal
- `Inflictor`: The previous goal it just reached.
- The new goal is stored in actor's `goal`.