### PR TITLE
Add WorldRailgunPreFired and WorldRailFired virtual for railgun attacks

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -4,6 +4,7 @@
 #include "dobject.h"
 #include "serializer.h"
 #include "d_event.h"
+#include "p_local.h"
 #include "sbar.h"
 #include "info.h"
 #include "vm.h"
@@ -312,6 +313,7 @@ public:
 	void WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
 	void WorldThingDestroyed(AActor* actor);
 	bool WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside);
+	bool WorldRailgunPreFired(FName damageType, PClassActor* pufftype, FRailParams* param);
 	void WorldHitscanFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags);
 	void WorldLinePreActivated(line_t* line, AActor* actor, int activationType, bool* shouldactivate);
 	void WorldLineActivated(line_t* line, AActor* actor, int activationType);
@@ -403,6 +405,8 @@ struct FWorldEvent
 	double AttackOffsetSide = 0;
 	double AttackZ = 0;
 	PClassActor* AttackPuffType = nullptr;
+	FRailParams RailParams;
+	int AttackLineFlags = 0;
 };
 
 struct FPlayerEvent
@@ -481,6 +485,8 @@ struct EventManager
 	bool WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside);
 	// called when a hitscan attack has been fired
 	void WorldHitscanFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags);
+	// called when a railgun attack has been fired (can be overridden to block it)
+	bool WorldRailgunPreFired(FName damageType, PClassActor* pufftype, FRailParams* param);
 	// called inside AActor::Grind just before the corpse is destroyed
 	void WorldThingGround(AActor* actor, FState* st);
 	// called after AActor::Revive.

--- a/src/events.h
+++ b/src/events.h
@@ -315,6 +315,7 @@ public:
 	bool WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside);
 	bool WorldRailgunPreFired(FName damageType, PClassActor* pufftype, FRailParams* param);
 	void WorldHitscanFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags);
+	void WorldRailgunFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags);
 	void WorldLinePreActivated(line_t* line, AActor* actor, int activationType, bool* shouldactivate);
 	void WorldLineActivated(line_t* line, AActor* actor, int activationType);
 	int WorldSectorDamaged(sector_t* sector, AActor* source, int damage, FName damagetype, int part, DVector3 position, bool isradius);
@@ -485,6 +486,8 @@ struct EventManager
 	bool WorldHitscanPreFired(AActor* actor, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags, double sz, double offsetforward, double offsetside);
 	// called when a hitscan attack has been fired
 	void WorldHitscanFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags);
+	// called when a railgun attack has been fired
+	void WorldRailgunFired(AActor* actor, const DVector3& AttackPos, const DVector3& DamagePosition, AActor* Inflictor, int flags);
 	// called when a railgun attack has been fired (can be overridden to block it)
 	bool WorldRailgunPreFired(FName damageType, PClassActor* pufftype, FRailParams* param);
 	// called inside AActor::Grind just before the corpse is destroyed

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5416,7 +5416,7 @@ void P_RailAttack(FRailParams *p)
 	// disabled because not complete yet.
 	flags = (puffDefaults->flags6 & MF6_NOTRIGGER) ? TRACE_ReportPortals : TRACE_PCross | TRACE_Impact | TRACE_ReportPortals;
 
-	if (source->Level->localEventManager->WorldHitscanPreFired(source, source->Angles.Yaw + p->angleoffset, p->distance, source->Angles.Pitch + p->pitchoffset, p->damage, damagetype, puffclass, flags, p->offset_z, 0, p->offset_xy))
+	if (source->Level->localEventManager->WorldRailgunPreFired(damagetype, puffclass, p))
 	{
 		return;
 	}

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5577,7 +5577,7 @@ void P_RailAttack(FRailParams *p)
 		}
 	}
 
-	source->Level->localEventManager->WorldHitscanFired(source, start, trace.HitPos, thepuff, flags);
+	source->Level->localEventManager->WorldRailgunFired(source, start, trace.HitPos, thepuff, flags);
 
 	if (thepuff != NULL)
 	{

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -167,6 +167,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual void WorldThingDestroyed(WorldEvent e) {}
     virtual bool WorldHitscanPreFired(WorldEvent e) { return false; }
     virtual bool WorldRailgunPreFired(WorldEvent e) { return false; }
+    virtual void WorldRailgunFired(WorldEvent e) {}
     virtual void WorldHitscanFired(WorldEvent e) {}
     virtual void WorldLinePreActivated(WorldEvent e) {}
     virtual void WorldLineActivated(WorldEvent e) {}

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -97,14 +97,16 @@ struct WorldEvent native play version("2.4")
     native readonly bool DamageIsRadius;
     native int NewDamage;
     native readonly State CrushedState;
-	native readonly double AttackAngle;
-	native readonly double AttackPitch;
-	native readonly double AttackDistance;
-	native readonly vector3 AttackPos;
-	native readonly double AttackOffsetForward;
-	native readonly double AttackOffsetSide;
-	native readonly double AttackZ;
-	native readonly class<Actor> AttackPuffType;
+    native readonly int AttackLineFlags;
+    native readonly double AttackAngle;
+    native readonly double AttackPitch;
+    native readonly double AttackDistance;
+    native readonly vector3 AttackPos;
+    native readonly double AttackOffsetForward;
+    native readonly double AttackOffsetSide;
+    native readonly double AttackZ;
+    native readonly class<Actor> AttackPuffType;
+    native readonly FRailParams RailParams;
 }
 
 struct PlayerEvent native play version("2.4")
@@ -163,7 +165,8 @@ class StaticEventHandler : Object native play version("2.4")
     virtual void WorldThingRevived(WorldEvent e) {}
     virtual void WorldThingDamaged(WorldEvent e) {}
     virtual void WorldThingDestroyed(WorldEvent e) {}
-	virtual bool WorldHitscanPreFired(WorldEvent e) { return false; }
+    virtual bool WorldHitscanPreFired(WorldEvent e) { return false; }
+    virtual bool WorldRailgunPreFired(WorldEvent e) { return false; }
     virtual void WorldHitscanFired(WorldEvent e) {}
     virtual void WorldLinePreActivated(WorldEvent e) {}
     virtual void WorldLineActivated(WorldEvent e) {}


### PR DESCRIPTION
This PR adds `WorldRailgunPreFired` virtual for railgun attacks, which can block them like `WorldHitscanPreFired` by return values, and `WorldRailgunFired` as the railgun-equivalent of `WorldHitscanFired`.

As `WorldHitscanPreFired` passes all LineAttack parameters, its railgun equivalent has been made to do the same for consistency reasons.

`AttackLineFlags` is now used for LineAttack flags information instead of `DamageFlags`.

Indentation in `event.zs` has been fixed again.