### PR TITLE
Fixed bouncing on 3D floors

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -873,7 +873,7 @@ public:
 	void PlayPushSound();
 
 	// Called when an actor with MF_MISSILE and MF2_FLOORBOUNCE hits the floor
-	bool FloorBounceMissile (secplane_t &plane);
+	bool FloorBounceMissile (secplane_t &plane, bool is3DFloor);
 
 	// Called by RoughBlockCheck
 	bool IsOkayToAttack (AActor *target);

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -2486,7 +2486,9 @@ bool P_TryMove(AActor *thing, const DVector2 &pos,
 						// If it's a bouncer, let it bounce off its new floor, too.
 						if (thing->BounceFlags & BOUNCE_Floors)
 						{
-							thing->FloorBounceMissile(tm.floorsector->floorplane);
+							F3DFloor* ff = nullptr;
+							NextLowestFloorAt(tm.sector, tm.pos.X, tm.pos.Y, tm.pos.Z, 0, thing->MaxStepHeight, nullptr, &ff);
+							thing->FloorBounceMissile(ff != nullptr ? *ff->top.plane : tm.floorsector->floorplane, ff != nullptr);
 						}
 						else
 						{
@@ -3603,14 +3605,17 @@ bool FSlide::BounceWall(AActor *mo)
 	{ // Could not find a wall, so bounce off the floor/ceiling instead.
 		double floordist = mo->Z() - mo->floorz;
 		double ceildist = mo->ceilingz - mo->Z();
+		F3DFloor* ff = nullptr;
 		if (floordist <= ceildist)
 		{
-			mo->FloorBounceMissile(mo->Sector->floorplane);
+			NextLowestFloorAt(mo->Sector, mo->X(), mo->Y(), mo->Z(), 0, mo->MaxStepHeight, nullptr, &ff);
+			mo->FloorBounceMissile(ff != nullptr ? *ff->top.plane : mo->floorsector->floorplane, ff != nullptr);
 			return true;
 		}
 		else
 		{
-			mo->FloorBounceMissile(mo->Sector->ceilingplane);
+			NextHighestCeilingAt(mo->Sector, mo->X(), mo->Y(), mo->Z(), mo->Top(), 0, nullptr, &ff);
+			mo->FloorBounceMissile(ff != nullptr ? *ff->bottom.plane : mo->ceilingsector->ceilingplane, ff != nullptr);
 			return true;
 		}
 	}

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1851,8 +1851,9 @@ DEFINE_ACTION_FUNCTION(AActor, BouncePlane)
 {
 	PARAM_SELF_PROLOGUE(AActor);
 	PARAM_POINTER(plane, secplane_t);
+	PARAM_BOOL(is3DFloor);
 
-	ACTION_RETURN_BOOL(self->FloorBounceMissile(*plane));
+	ACTION_RETURN_BOOL(self->FloorBounceMissile(*plane, is3DFloor));
 }
 
 DEFINE_ACTION_FUNCTION(AActor, PlayBounceSound)

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -866,7 +866,7 @@ class Actor : Thinker native
 	native void PlayPushSound();
 	native bool BounceActor(Actor blocking, bool onTop);
 	native bool BounceWall(Line l = null);
-	native bool BouncePlane(readonly<SecPlane> plane);
+	native bool BouncePlane(readonly<SecPlane> plane, bool is3DFloor = false);
 	native void PlayBounceSound(bool onFloor);
 	native bool ReflectOffActor(Actor blocking);
 


### PR DESCRIPTION
This will now correctly pull from 3D floors when bouncing instead of always the floor/ceiling plane of the sector it's in. The autooff bouncing feature will also now check against the dot product of the vel against the plane normal so that the feature works more as expected when interacting with slopes.