### PR TITLE
Unified missile damage logic

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -4372,14 +4372,13 @@ void AActor::Tick ()
 					}
 					if (Vel.Z != 0 && (BounceFlags & BOUNCE_Actors))
 					{
-						bool res = P_BounceActor(this, onmo, true);
+						if (flags & MF_MISSILE)
+							P_DoMissileDamage(this, onmo);
+
 						// If the bouncer is a missile and has hit the other actor it needs to be exploded here
 						// to be in line with the case when an actor's side is hit.
-						if (!res && (flags & MF_MISSILE))
-						{
-							P_DoMissileDamage(this, onmo);
+						if (!P_BounceActor(this, onmo, true) && (flags & MF_MISSILE))
 							P_ExplodeMissile(this, nullptr, onmo);
-						}
 					}
 					else
 					{


### PR DESCRIPTION
Originally rippers were split into their own logic which would cause them to do inconsistent damage in DoMissileDamage calls and made some features inaccessible e.g. healing projectiles. Their logic has been moved into DoMissileDamage to make it easier to maintain going forward. On top of this, missiles that successfully bounce off Actor tops/bottoms will now deal damage (previously this was only done if it exploded on them).