### PR TITLE
Various bouncing fixes

### DIFF
--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -3574,7 +3574,9 @@ bool FSlide::BounceWall(AActor *mo)
 	double         movelen;
 	line_t			*line;
 
-	if (!(mo->BounceFlags & BOUNCE_Walls))
+	// The plane bounce flags need to be checked here in case it hit a ramp while
+	// moving along the xy axes.
+	if (!(mo->BounceFlags & (BOUNCE_Walls | BOUNCE_Ceilings | BOUNCE_Floors)))
 	{
 		return false;
 	}
@@ -3609,16 +3611,18 @@ bool FSlide::BounceWall(AActor *mo)
 		if (floordist <= ceildist)
 		{
 			NextLowestFloorAt(mo->Sector, mo->X(), mo->Y(), mo->Z(), 0, mo->MaxStepHeight, nullptr, &ff);
-			mo->FloorBounceMissile(ff != nullptr ? *ff->top.plane : mo->floorsector->floorplane, ff != nullptr);
-			return true;
+			return !mo->FloorBounceMissile(ff != nullptr ? *ff->top.plane : mo->floorsector->floorplane, ff != nullptr);
 		}
 		else
 		{
 			NextHighestCeilingAt(mo->Sector, mo->X(), mo->Y(), mo->Z(), mo->Top(), 0, nullptr, &ff);
-			mo->FloorBounceMissile(ff != nullptr ? *ff->bottom.plane : mo->ceilingsector->ceilingplane, ff != nullptr);
-			return true;
+			return !mo->FloorBounceMissile(ff != nullptr ? *ff->bottom.plane : mo->ceilingsector->ceilingplane, ff != nullptr);
 		}
 	}
+
+	if (!(mo->BounceFlags & BOUNCE_Walls))
+		return false;
+
 	line = bestslideline;
 
 	if (mo->flags & MF_MISSILE)

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -1775,9 +1775,13 @@ bool AActor::FloorBounceMissile (secplane_t &plane, bool is3DFloor)
 		}
 	}
 
+	DVector3 norm = plane.Normal();
+	if (is3DFloor)
+		norm = -norm;
+
 	bool onsky;
 
-	if (plane.fC() < 0)
+	if (norm.Z < 0)
 	{ // on ceiling
 		if (!(BounceFlags & BOUNCE_Ceilings))
 			return true;
@@ -1808,10 +1812,6 @@ bool AActor::FloorBounceMissile (secplane_t &plane, bool is3DFloor)
 		return true;
 	}
 
-	DVector3 norm = plane.Normal();
-	if (is3DFloor)
-		norm = -norm;
-
 	double dot = (Vel | norm) * 2;
 
 	if (BounceFlags & (BOUNCE_HereticType | BOUNCE_MBF))
@@ -1839,7 +1839,7 @@ bool AActor::FloorBounceMissile (secplane_t &plane, bool is3DFloor)
 	// Set bounce state
 	if (BounceFlags & BOUNCE_UseBounceState)
 	{
-		FName names[2] = { NAME_Bounce, plane.fC() < 0 ? NAME_Ceiling : NAME_Floor };
+		FName names[2] = { NAME_Bounce, norm.Z < 0 ? NAME_Ceiling : NAME_Floor };
 		FState *bouncestate = FindState(2, names);
 		if (bouncestate != nullptr)
 		{


### PR DESCRIPTION
Fixed bounce flag checks being inversed on 3D floors. Decoupled wall bouncing flag from floor/ceiling flags since they relied on it in the case of hitting steep ramps. Fixed wall bounces that actually bounce off planes not returning the correct value.