### PR TITLE
Fix coop key share failing if the item was spawned in-game (for examp…

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -700,7 +700,7 @@ class Inventory : Actor
 			toucher.HasReceived(self, cls);
 
 			// If the item can be shared, make sure every player gets a copy.
-			if (multiplayer && !deathmatch && !bDropped && ShouldShareItem(toucher))
+			if (multiplayer && !deathmatch && ShouldShareItem(toucher))
 				ShareItemWithPlayers(toucher);
 		}
 		return res, toucher;


### PR DESCRIPTION
…le, via the console)