### PR TITLE
add default values, vec4 uniforms, and cvar uniforms to post-process uniforms

### DIFF
--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -240,6 +240,16 @@ void* FBaseCVar::GetExtraDataPointer()
 	return m_ExtraDataPointer;
 }
 
+void FBaseCVar::SetExtraDataPointer2(void *pointer)
+{
+	m_ExtraDataPointer2 = pointer;
+}
+
+void* FBaseCVar::GetExtraDataPointer2()
+{
+	return m_ExtraDataPointer2;
+}
+
 const char *FBaseCVar::GetHumanString(int precision) const
 {
 	return GetGenericRep(CVAR_String).String;

--- a/src/common/console/c_cvars.h
+++ b/src/common/console/c_cvars.h
@@ -222,8 +222,10 @@ public:
 	void ClearCallback();
 
 	void SetExtraDataPointer(void *pointer);
+	void SetExtraDataPointer2(void *pointer);
 
 	void* GetExtraDataPointer();
+	void* GetExtraDataPointer2();
 
 	int pnum = -1;
 	FName userinfoName;
@@ -259,7 +261,8 @@ private:
 	static inline bool m_UseCallback = false;
 	static inline bool m_DoNoSet = false;
 
-	void *m_ExtraDataPointer;
+	void *m_ExtraDataPointer = nullptr;
+	void *m_ExtraDataPointer2 = nullptr;
 
 	// These need to go away!
 	friend FString C_GetMassCVarString (uint32_t filter, bool compact);
@@ -275,6 +278,8 @@ private:
 	friend void FilterCompactCVars (TArray<FBaseCVar *> &cvars, uint32_t filter);
 	friend void C_DeinitConsole();
 	friend void C_ListCVarsWithoutDescription();
+
+	friend class GLDefsParser;
 };
 
 // Returns a string with all cvars whose flags match filter. In compact mode,

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.cpp
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.cpp
@@ -947,6 +947,7 @@ PPCustomShaderInstance::PPCustomShaderInstance(PostProcessShader *desc) : Desc(d
 		case PostProcessUniformType::Int: AddUniformField(offset, name, UniformType::Int, sizeof(int)); break;
 		case PostProcessUniformType::Vec2: AddUniformField(offset, name, UniformType::Vec2, sizeof(float) * 2); break;
 		case PostProcessUniformType::Vec3: AddUniformField(offset, name, UniformType::Vec3, sizeof(float) * 3, sizeof(float) * 4); break;
+		case PostProcessUniformType::Vec4: AddUniformField(offset, name, UniformType::Vec4, sizeof(float) * 4); break;
 		default: break;
 		}
 	}
@@ -1084,6 +1085,13 @@ void PPCustomShaderInstance::SetUniforms(PPRenderState *renderstate)
 				fValues[1] = (float)pair->Value.Values[1];
 				fValues[2] = (float)pair->Value.Values[2];
 				memcpy(dst, fValues, sizeof(float) * 3);
+				break;
+			case PostProcessUniformType::Vec4:
+				fValues[0] = (float)pair->Value.Values[0];
+				fValues[1] = (float)pair->Value.Values[1];
+				fValues[2] = (float)pair->Value.Values[2];
+				fValues[3] = (float)pair->Value.Values[3];
+				memcpy(dst, fValues, sizeof(float) * 4);
 				break;
 			default:
 				break;

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocessshader.cpp
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocessshader.cpp
@@ -116,6 +116,31 @@ DEFINE_ACTION_FUNCTION(_PPShader, SetUniform3f)
 	return 0;
 }
 
+DEFINE_ACTION_FUNCTION(_PPShader, SetUniform4f)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(shaderName);
+	PARAM_STRING(uniformName);
+	PARAM_FLOAT(x);
+	PARAM_FLOAT(y);
+	PARAM_FLOAT(z);
+	PARAM_FLOAT(w);
+
+	for (unsigned int i = 0; i < PostProcessShaders.Size(); i++)
+	{
+		PostProcessShader &shader = PostProcessShaders[i];
+		if (shader.Name == shaderName)
+		{
+			double *vec4 = shader.Uniforms[uniformName].Values;
+			vec4[0] = x;
+			vec4[1] = y;
+			vec4[2] = z;
+			vec4[3] = w;
+		}
+	}
+	return 0;
+}
+
 DEFINE_ACTION_FUNCTION(_PPShader, SetUniform1i)
 {
 	PARAM_PROLOGUE;

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocessshader.h
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocessshader.h
@@ -9,7 +9,8 @@ enum class PostProcessUniformType
 	Int,
 	Float,
 	Vec2,
-	Vec3
+	Vec3,
+	Vec4
 };
 
 struct PostProcessUniformValue

--- a/wadsrc/static/zscript/engine/ppshader.zs
+++ b/wadsrc/static/zscript/engine/ppshader.zs
@@ -4,5 +4,6 @@ struct PPShader native
 	native clearscope static void SetUniform1f(string shaderName, string uniformName, float value);
 	native clearscope static void SetUniform2f(string shaderName, string uniformName, vector2 value);
 	native clearscope static void SetUniform3f(string shaderName, string uniformName, vector3 value);
+	native clearscope static void SetUniform4f(string shaderName, string uniformName, vector4 value);
 	native clearscope static void SetUniform1i(string shaderName, string uniformName, int value);
 }


### PR DESCRIPTION
cvar uniform example:
```
uniform float example_strength = cvar cvar_example
uniform vec3 example_color = cvar cvar_example2
```
default value example:
```
uniform vec3 example_color = 1.0 0.5 0.5
```

[cvaruniform_example.zip](https://github.com/user-attachments/files/18319749/cvaruniform_example.zip)

