### PR TITLE
Registered/Shareware Doom 1 chat sound fix

### DIFF
--- a/wadsrc/static/mapinfo/doom1.txt
+++ b/wadsrc/static/mapinfo/doom1.txt
@@ -6,6 +6,7 @@ gameinfo
 	creditpage = "CREDIT", "HELP2"
 	titlemusic = "$MUSIC_INTRO"
 	titletime = 5
+	chatsound = "misc/chat2"
 	finalemusic = "$MUSIC_VICTOR"
 	finaleflat = "FLOOR4_8"
 	finalepage = "HELP2", "VICTORY2", "ENDPIC"

--- a/wadsrc/static/mapinfo/ultdoom.txt
+++ b/wadsrc/static/mapinfo/ultdoom.txt
@@ -3,7 +3,6 @@ include "mapinfo/doom1.txt"
 gameinfo
 {
 	creditpage = "CREDIT"
-	chatsound = "misc/chat2"
 	finalepage = "CREDIT", "VICTORY2", "ENDPIC"
 	infopage = "HELP1", "CREDIT"
 }


### PR DESCRIPTION
For many years, the registered (non-ultimate) and shareware versions of Doom used the wrong chat sound (`misc/chat`, as per `mapinfo/doomcommon.txt`) that only works in Doom 2. Unlike Ultimate Doom which loads `mapinfo/ultdoom.txt` that correctly replaces the chat sound to `misc/chat2`, the registered/shareware versions load `mapinfo/doom1.txt` which doesn't.

Moving the line `chatsound = "misc/chat2"` from `mapinfo/ultdoom.txt` to `mapinfo/doom1.txt` fixes the issue.