### PR TITLE
Sanitize VisualThinker statnum assignment

### DIFF
--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -427,7 +427,7 @@ public:
 	DThinker *CreateThinker(PClass *cls, int statnum = STAT_DEFAULT)
 	{
 		DThinker *thinker = static_cast<DThinker*>(cls->CreateNew());
-		if (statnum && thinker->IsKindOf(RUNTIME_CLASS(DVisualThinker)))
+		if (thinker->IsKindOf(RUNTIME_CLASS(DVisualThinker)))
 		{
 			statnum = STAT_VISUALTHINKER;
 		}


### PR DESCRIPTION
Make the visual thinker statnum assignment check unconditional since statnum is no longer a pointer

- This fully completes this revert: https://github.com/ZDoom/gzdoom/commit/ca3b0737ea3cc2b11c7e1e2670dd56073cb4a096