### PR TITLE
Updated VisualThinker render linkage

### DIFF
--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -427,11 +427,6 @@ public:
 	DThinker *CreateThinker(PClass *cls, int statnum = STAT_DEFAULT)
 	{
 		DThinker *thinker = static_cast<DThinker*>(cls->CreateNew());
-		if (thinker->IsKindOf(RUNTIME_CLASS(DVisualThinker)))
-		{
-			statnum = STAT_VISUALTHINKER;
-		}
-
 		assert(thinker->IsKindOf(RUNTIME_CLASS(DThinker)));
 		thinker->ObjectFlags |= OF_JustSpawned;
 		Thinkers.Link(thinker, statnum);
@@ -708,6 +703,7 @@ public:
 	int			ImpactDecalCount;
 
 	FDynamicLight *lights;
+	DVisualThinker* VisualThinkerHead = nullptr;
 
 	// links to global game objects
 	TArray<TObjPtr<AActor *>> CorpseQueue;

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -990,7 +990,8 @@ void FLevelLocals::Serialize(FSerializer &arc, bool hubload)
 		("scrolls", Scrolls)
 		("automap", automap)
 		("interpolator", interpolator)
-		("frozenstate", frozenstate);
+		("frozenstate", frozenstate)
+		("visualthinkerhead", VisualThinkerHead);
 
 
 	// Hub transitions must keep the current total time

--- a/src/playsim/dthinker.cpp
+++ b/src/playsim/dthinker.cpp
@@ -810,11 +810,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DThinker, ChangeStatNum, ChangeStatNum)
 	PARAM_SELF_PROLOGUE(DThinker);
 	PARAM_INT(stat);
 
-	// do not allow ZScript to reposition thinkers in or out of particle ticking.
-	if (stat != STAT_VISUALTHINKER && !dynamic_cast<DVisualThinker*>(self))
-	{
-		ChangeStatNum(self, stat);
-	}
+	ChangeStatNum(self, stat);
 	return 0;
 }
 

--- a/src/playsim/p_visualthinker.h
+++ b/src/playsim/p_visualthinker.h
@@ -26,7 +26,11 @@ class DVisualThinker : public DThinker
 {
 	DECLARE_CLASS(DVisualThinker, DThinker);
 	void UpdateSector(subsector_t * newSubsector);
+
+	DVisualThinker* _next, * _prev;
 public:
+	static const int DEFAULT_STAT = STAT_VISUALTHINKER;
+
 	DVector3		Prev;
 	DVector2		Scale,
 					Offset;
@@ -41,9 +45,9 @@ public:
 	// internal only variables
 	particle_t		PT;
 
-	DVisualThinker();
 	void Construct();
 	void OnDestroy() override;
+	DVisualThinker* GetNext() const;
 
 	static DVisualThinker* NewVisualThinker(FLevelLocals* Level, PClass* type);
 	void SetTranslation(FName trname);

--- a/wadsrc/static/zscript/visualthinker.zs
+++ b/wadsrc/static/zscript/visualthinker.zs
@@ -33,7 +33,7 @@ Class VisualThinker : Thinker native
 	native protected void UpdateSector(); // needs to be called if the thinker is set to a non-ticking statnum and the position is modified (or if Tick is overriden and doesn't call Super.Tick())
 	native protected void UpdateSpriteInfo(); // needs to be called every time the texture is updated if the thinker uses SPF_LOCAL_ANIM and is set to a non-ticking statnum (or if Tick is overriden and doesn't call Super.Tick())
 
-	static VisualThinker Spawn(Class<VisualThinker> type, TextureID tex, Vector3 pos, Vector3 vel, double alpha = 1.0, int flags = 0,
+	static VisualThinker Spawn(Class<VisualThinker> type, TextureID tex, Vector3 pos, Vector3 vel = (0,0,0), double alpha = 1.0, int flags = 0,
 						  double roll = 0.0, Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal, TranslationID trans = 0, int VisualThinkerFlags = 0)
 	{
 		if (!Level)	return null;


### PR DESCRIPTION
Now uses its own self-managed linked list with its level tracking the head pointer. Allows for VisualThinkers to be moved to any desired stat instead of being stuck in STAT_VISUALTHINKER.