### PR TITLE
Better flat visibility checks for Ortho projection.

### DIFF
--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -1196,6 +1196,9 @@ enum
 	WALLF_ABSLIGHTING_BOTTOM 	= WALLF_ABSLIGHTING_TIER << 2,	// Bottom tier light is absolute instead of relative
 
 	WALLF_DITHERTRANS			= 8192,	// Render with dithering transparency shader (gets reset every frame)
+	WALLF_DITHERTRANS_TOP		= WALLF_DITHERTRANS << 0,	// Top tier (gets reset every frame)
+	WALLF_DITHERTRANS_MID		= WALLF_DITHERTRANS << 1,	// Mid tier (gets reset every frame)
+	WALLF_DITHERTRANS_BOTTOM	= WALLF_DITHERTRANS << 2,	// Bottom tier (gets reset every frame)
 };
 
 struct side_t
@@ -1270,6 +1273,8 @@ struct side_t
 	seg_t **segs;	// all segs belonging to this sidedef in ascending order. Used for precise rendering
 	int numsegs;
 	int sidenum;
+
+	int dithertranscount;
 
 	int GetLightLevel (bool foggy, int baselight, int which, bool is3dlight=false, int *pfakecontrast_usedbygzdoom=NULL) const;
 

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -167,6 +167,7 @@ sector_t* RenderViewpoint(FRenderViewpoint& mainvp, AActor* camera, IntRect* bou
 		bool iso_ortho = (camera->ViewPos != NULL) && (camera->ViewPos->Flags & VPSF_ORTHOGRAPHIC);
 		if (iso_ortho && (camera->ViewPos->Offset.Length() > 0)) inv_iso_dist = 1.0/camera->ViewPos->Offset.Length();
 		di->VPUniforms.mProjectionMatrix = eye.GetProjection(fov, ratio, fovratio * inv_iso_dist, iso_ortho);
+		di->ProjectionMatrix2 = eye.GetProjection(fov, ratio, fovratio, false); // Regular ol' perspective projection matrix
 
 		// Stereo mode specific viewpoint adjustment
 		vp.Pos += eye.GetViewShift(vp.HWAngles.Yaw.Degrees());

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -297,6 +297,7 @@ void HWDrawInfo::AddLine (seg_t *seg, bool portalclip)
 			if (in_area == area_default) in_area = hw_CheckViewArea(seg->v1, seg->v2, seg->frontsector, seg->backsector);
 			backsector = hw_FakeFlat(seg->backsector, in_area, true);
 			if (hw_CheckClip(seg->sidedef, currentsector, backsector)) clipperr.SafeAddClipRange(startAngleR - paddingR, endAngleR + paddingR);
+			backsector = nullptr;
 		}
 	}
 
@@ -335,7 +336,7 @@ void HWDrawInfo::AddLine (seg_t *seg, bool portalclip)
 	if (!seg->backsector)
 	{
 		if(!Viewpoint.IsAllowedOoB())
-			if (!(seg->sidedef->Flags & WALLF_DITHERTRANS)) clipper.SafeAddClipRange(startAngle, endAngle);
+			if (!(seg->sidedef->Flags & WALLF_DITHERTRANS_MID)) clipper.SafeAddClipRange(startAngle, endAngle);
 	}
 	else if (!ispoly)	// Two-sided polyobjects never obstruct the view
 	{
@@ -362,7 +363,7 @@ void HWDrawInfo::AddLine (seg_t *seg, bool portalclip)
 
 			if (hw_CheckClip(seg->sidedef, currentsector, backsector))
 			{
-				if(!Viewpoint.IsAllowedOoB() && !(seg->sidedef->Flags & WALLF_DITHERTRANS))
+				if(!Viewpoint.IsAllowedOoB() && !(seg->sidedef->Flags & WALLF_DITHERTRANS_MID))
 					clipper.SafeAddClipRange(startAngle, endAngle);
 			}
 		}

--- a/src/rendering/hwrenderer/scene/hw_clipper.cpp
+++ b/src/rendering/hwrenderer/scene/hw_clipper.cpp
@@ -394,18 +394,10 @@ angle_t Clipper::PointToPseudoAngle(double x, double y)
 {
 	double vecx = x - viewpoint->Pos.X;
 	double vecy = y - viewpoint->Pos.Y;
-	if ((viewpoint->camera != NULL) && amRadar)
+	if (amRadar)
 	{
-		if (viewpoint->camera->tracer != NULL)
-		{
-			vecx = x - viewpoint->camera->tracer->X();
-			vecy = y - viewpoint->camera->tracer->Y();
-		}
-		else
-		{
-			vecx = x - viewpoint->camera->X();
-			vecy = y - viewpoint->camera->Y();
-		}
+		vecx = x - viewpoint->OffPos.X;
+		vecy = y - viewpoint->OffPos.Y;
 	}
 
 	if (vecx == 0 && vecy == 0)
@@ -467,7 +459,7 @@ angle_t Clipper::PointToPseudoPitch(double x, double y, double z)
 
 angle_t Clipper::PointToPseudoOrthoAngle(double x, double y)
 {
-	DVector3 disp = DVector3( x, y, 0 ) - viewpoint->camera->Pos();
+	DVector3 disp = DVector3(x, y, 0) - viewpoint->OffPos;
 	if (viewpoint->camera->ViewPos->Offset.XY().Length() == 0)
 	{
 		return AngleToPseudo( viewpoint->Angles.Yaw.BAMs() );
@@ -491,7 +483,7 @@ angle_t Clipper::PointToPseudoOrthoAngle(double x, double y)
 
 angle_t Clipper::PointToPseudoOrthoPitch(double x, double y, double z)
 {
-	DVector3 disp = DVector3( x, y, z ) - viewpoint->camera->Pos();
+	DVector3 disp = DVector3(x, y, z) - viewpoint->OffPos;
 	if (viewpoint->camera->ViewPos->Offset.XY().Length() > 0)
 	{
 		double yproj = viewpoint->PitchSin * disp.XY().Length() * deltaangle(disp.Angle(), viewpoint->Angles.Yaw).Cos();

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -717,7 +717,7 @@ static ETraceStatus TraceCallbackForDitherTransparency(FTraceResults& res, void*
 		}
 		break;
 	case TRACE_HitFloor:
-		if (res.Sector->subsectorcount > 0 && (*CurMapSections)[res.Sector->subsectors[0]->mapsection])
+		if (res.Sector->subsectorcount > 0 && (*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->floorplane.Normal()) < 0.0)
 		{
 			if (res.HitPos.Z == res.Sector->floorplane.ZatPoint(res.HitPos))
 			{
@@ -743,7 +743,7 @@ static ETraceStatus TraceCallbackForDitherTransparency(FTraceResults& res, void*
 		}
 		break;
 	case TRACE_HitCeiling:
-		if (res.Sector->subsectorcount > 0 && (*CurMapSections)[res.Sector->subsectors[0]->mapsection])
+		if (res.Sector->subsectorcount > 0 && (*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->ceilingplane.Normal()) < 0.0)
 		{
 			if (res.HitPos.Z == res.Sector->ceilingplane.ZatPoint(res.HitPos))
 			{
@@ -779,6 +779,7 @@ static ETraceStatus TraceCallbackForDitherTransparency(FTraceResults& res, void*
 
 void HWDrawInfo::SetDitherTransFlags(AActor* actor)
 {
+	// This should really be moved to a shader and have the GPU do some shape-tracing.
 	if (actor && actor->Sector)
 	{
 		FTraceResults results;

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -698,10 +698,50 @@ static ETraceStatus TraceCallbackForDitherTransparency(FTraceResults& res, void*
 		}
 		break;
 	case TRACE_HitFloor:
-		res.Sector->floorplane.dithertransflag = true;
+		if (res.HitPos.Z == res.Sector->floorplane.ZatPoint(res.HitPos))
+		{
+			res.Sector->floorplane.dithertransflag = true;
+		}
+		else if (res.Sector->e->XFloor.ffloors.Size()) // Maybe it was 3D floors
+		{
+			F3DFloor *rover;
+			int kk;
+			for (kk = 0; kk < (int)res.Sector->e->XFloor.ffloors.Size(); kk++)
+			{
+				rover = res.Sector->e->XFloor.ffloors[kk];
+				if ((rover->flags&(FF_EXISTS | FF_RENDERPLANES | FF_THISINSIDE)) == (FF_EXISTS | FF_RENDERPLANES))
+				{
+					if (res.HitPos.Z == rover->top.plane->ZatPoint(res.HitPos))
+					{
+						rover->top.plane->dithertransflag = true;
+						break; // Out of for loop
+					}
+				}
+			}
+		}
 		break;
 	case TRACE_HitCeiling:
-		res.Sector->ceilingplane.dithertransflag = true;
+		if (res.HitPos.Z == res.Sector->ceilingplane.ZatPoint(res.HitPos))
+		{
+			res.Sector->ceilingplane.dithertransflag = true;
+		}
+		else if (res.Sector->e->XFloor.ffloors.Size()) // Maybe it was 3D floors
+		{
+			F3DFloor *rover;
+			int kk;
+			for (kk = 0; kk < (int)res.Sector->e->XFloor.ffloors.Size(); kk++)
+			{
+				rover = res.Sector->e->XFloor.ffloors[kk];
+				if ((rover->flags&(FF_EXISTS | FF_RENDERPLANES | FF_THISINSIDE)) == (FF_EXISTS | FF_RENDERPLANES))
+				{
+					if (res.HitPos.Z == rover->bottom.plane->ZatPoint(res.HitPos))
+					{
+						rover->bottom.plane->dithertransflag = true;
+						break; // Out of for loop
+					}
+				}
+			}
+		}
 		break;
 	case TRACE_HitActor:
 	default:

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -150,6 +150,7 @@ struct HWDrawInfo
 	Clipper *rClipper; // Radar clipper
 	FRenderViewpoint Viewpoint;
 	HWViewpointUniforms VPUniforms;	// per-viewpoint uniform state
+	VSMatrix ProjectionMatrix2;
 	TArray<HWPortal *> Portals;
 	TArray<HWDecal *> Decals[2];	// the second slot is for mirrors which get rendered in a separate pass.
 	TArray<HUDSprite> hudsprites;	// These may just be stored by value.

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -518,7 +518,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 	//
 	//
 	//
-	if (((which & SSRF_RENDERFLOOR) && frontsector->floorplane.ZatPoint(vp.Pos) <= vp.Pos.Z && (!section || !(section->flags & FSection::DONTRENDERFLOOR)))&& !(vp.IsOrtho() && (vp.PitchSin < 0.0)))
+	if ((which & SSRF_RENDERFLOOR) && (vp.IsOrtho() ? vp.ViewVector3D.dot(frontsector->floorplane.Normal()) < 0.0 : frontsector->floorplane.ZatPoint(vp.Pos) <= vp.Pos.Z) && (!section || !(section->flags & FSection::DONTRENDERFLOOR)))
 	{
 		// process the original floor first.
 
@@ -576,7 +576,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 	//
 	// 
 	//
-	if (((which & SSRF_RENDERCEILING) && frontsector->ceilingplane.ZatPoint(vp.Pos) >= vp.Pos.Z && (!section || !(section->flags & FSection::DONTRENDERCEILING))) && !(vp.IsOrtho() && (vp.PitchSin > 0.0)))
+	if ((which & SSRF_RENDERCEILING) && (vp.IsOrtho() ? vp.ViewVector3D.dot(frontsector->ceilingplane.Normal()) < 0.0 : frontsector->ceilingplane.ZatPoint(vp.Pos) >= vp.Pos.Z) && (!section || !(section->flags & FSection::DONTRENDERCEILING)))
 	{
 		// process the original ceiling first.
 
@@ -661,7 +661,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 					double ff_top = rover->top.plane->ZatPoint(sector->centerspot);
 					if (ff_top < lastceilingheight)
 					{
-						if (vp.Pos.Z <= rover->top.plane->ZatPoint(vp.Pos))
+						if ((vp.IsOrtho() ? vp.ViewVector3D.dot(rover->top.plane->Normal()) > 0.0 : vp.Pos.Z <= rover->top.plane->ZatPoint(vp.Pos)))
 						{
 							SetFrom3DFloor(rover, true, !!(rover->flags&FF_FOG));
 							Colormap.FadeColor = frontsector->Colormap.FadeColor;
@@ -675,7 +675,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 					double ff_bottom = rover->bottom.plane->ZatPoint(sector->centerspot);
 					if (ff_bottom < lastceilingheight)
 					{
-						if (vp.Pos.Z <= rover->bottom.plane->ZatPoint(vp.Pos))
+						if ((vp.IsOrtho() ? vp.ViewVector3D.dot(rover->bottom.plane->Normal()) > 0.0 : vp.Pos.Z <= rover->bottom.plane->ZatPoint(vp.Pos)))
 						{
 							SetFrom3DFloor(rover, false, !(rover->flags&FF_FOG));
 							Colormap.FadeColor = frontsector->Colormap.FadeColor;
@@ -701,7 +701,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 					double ff_bottom = rover->bottom.plane->ZatPoint(sector->centerspot);
 					if (ff_bottom > lastfloorheight || (rover->flags&FF_FIX))
 					{
-						if (vp.Pos.Z >= rover->bottom.plane->ZatPoint(vp.Pos))
+						if ((vp.IsOrtho() ? vp.ViewVector3D.dot(rover->bottom.plane->Normal()) > 0.0 : vp.Pos.Z >= rover->bottom.plane->ZatPoint(vp.Pos)))
 						{
 							SetFrom3DFloor(rover, false, !(rover->flags&FF_FOG));
 							Colormap.FadeColor = frontsector->Colormap.FadeColor;
@@ -722,7 +722,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 					double ff_top = rover->top.plane->ZatPoint(sector->centerspot);
 					if (ff_top > lastfloorheight)
 					{
-						if (vp.Pos.Z >= rover->top.plane->ZatPoint(vp.Pos))
+						if ((vp.IsOrtho() ? vp.ViewVector3D.dot(rover->top.plane->Normal()) > 0.0 : vp.Pos.Z >= rover->top.plane->ZatPoint(vp.Pos)))
 						{
 							SetFrom3DFloor(rover, true, !!(rover->flags&FF_FOG));
 							Colormap.FadeColor = frontsector->Colormap.FadeColor;

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -270,6 +270,7 @@ struct HWSectorStackPortal : public HWScenePortalBase
 	TArray<subsector_t *> subsectors;
 protected:
 	bool Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clipper) override;
+	void DrawPortalStencil(FRenderState &state, int pass) override;
 	void Shutdown(HWDrawInfo *di, FRenderState &rstate) override;
 	virtual void * GetSource() const { return origin; }
 	virtual bool IsSky() { return true; }	// although this isn't a real sky it can be handled as one.

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -59,13 +59,14 @@ class HWPortal
 	TArray<unsigned int> mPrimIndices;
 	unsigned int mTopCap = ~0u, mBottomCap = ~0u;
 
-	void DrawPortalStencil(FRenderState &state, int pass);
+	virtual void DrawPortalStencil(FRenderState &state, int pass);
 
 public:
 	FPortalSceneState * mState;
 	TArray<HWWall> lines;
 	BoundingRect boundingBox;
 	int planesused = 0;
+	HWFlat flat;
 
     HWPortal(FPortalSceneState *s, bool local = false) : mState(s), boundingBox(false)
     {
@@ -295,6 +296,7 @@ struct HWPlaneMirrorPortal : public HWScenePortalBase
 protected:
 	bool Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clipper) override;
 	void Shutdown(HWDrawInfo *di, FRenderState &rstate) override;
+	void DrawPortalStencil(FRenderState &state, int pass) override;
 	virtual void * GetSource() const { return origin; }
 	virtual const char *GetName();
 	secplane_t * origin;

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -112,6 +112,8 @@ struct FPortalSceneState
 
 	int skyboxrecursion = 0;
 
+	VSMatrix tempmatrix;
+
 	void BeginScene()
 	{
 		UniqueSkies.Clear();
@@ -145,7 +147,7 @@ public:
 	virtual bool NeedDepthBuffer() { return true; }
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state)
 	{
-		if (Setup(di, state, di->mClipper))
+		if (Setup(di, state, (di->Viewpoint.IsAllowedOoB() ? di->rClipper : di->mClipper)))
 		{
 			di->DrawScene(DM_PORTAL);
 			Shutdown(di, state);

--- a/src/rendering/hwrenderer/scene/hw_sky.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sky.cpp
@@ -154,7 +154,7 @@ void HWWall::SkyPlane(HWWallDispatcher *di, sector_t *sector, int plane, bool al
 		case PORTS_PORTAL:
 		case PORTS_LINKEDPORTAL:
 		{
-			if (di->di && di->di->Viewpoint.IsAllowedOoB()) return;
+			if (di->di && di->di->Viewpoint.IsAllowedOoB()) return; // Almost works (with planemirrorportal stencil), but no quite
 			auto glport = sector->GetPortalGroup(plane);
 			if (glport != NULL)
 			{

--- a/src/rendering/hwrenderer/scene/hw_sky.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sky.cpp
@@ -130,7 +130,6 @@ void HWSkyInfo::init(HWDrawInfo *di, sector_t* sec, int skypos, int sky1, PalEnt
 void HWWall::SkyPlane(HWWallDispatcher *di, sector_t *sector, int plane, bool allowreflect)
 {
 	int ptype = -1;
-	if (di->di && di->di->Viewpoint.IsAllowedOoB()) return; // Couldn't prevent sky portal occlusion. Skybox is bad in ortho too.
 
 	FSectorPortal *sportal = sector->ValidatePortal(plane);
 	if (sportal != nullptr && sportal->mFlags & PORTSF_INSKYBOX) sportal = nullptr;	// no recursions, delete it here to simplify the following code
@@ -155,6 +154,7 @@ void HWWall::SkyPlane(HWWallDispatcher *di, sector_t *sector, int plane, bool al
 		case PORTS_PORTAL:
 		case PORTS_LINKEDPORTAL:
 		{
+			if (di->di && di->di->Viewpoint.IsAllowedOoB()) return;
 			auto glport = sector->GetPortalGroup(plane);
 			if (glport != NULL)
 			{

--- a/src/rendering/hwrenderer/scene/hw_sky.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sky.cpp
@@ -154,12 +154,15 @@ void HWWall::SkyPlane(HWWallDispatcher *di, sector_t *sector, int plane, bool al
 		case PORTS_PORTAL:
 		case PORTS_LINKEDPORTAL:
 		{
-			if (di->di && di->di->Viewpoint.IsAllowedOoB()) return; // Almost works (with planemirrorportal stencil), but no quite
+			if (di->di && di->di->Viewpoint.IsAllowedOoB())
+			{
+				secplane_t myplane = plane ? sector->ceilingplane : sector->floorplane;
+				if (di->di->Viewpoint.ViewVector3D.dot(myplane.Normal()) > 0.0) return;
+			}
 			auto glport = sector->GetPortalGroup(plane);
 			if (glport != NULL)
 			{
 				if (sector->PortalBlocksView(plane)) return;
-
 				if (di->di && screen->instack[1 - plane]) return;
 				ptype = PORTALTYPE_SECTORSTACK;
 				portal = glport;

--- a/src/rendering/hwrenderer/scene/hw_sky.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sky.cpp
@@ -157,7 +157,9 @@ void HWWall::SkyPlane(HWWallDispatcher *di, sector_t *sector, int plane, bool al
 			if (di->di && di->di->Viewpoint.IsAllowedOoB())
 			{
 				secplane_t myplane = plane ? sector->ceilingplane : sector->floorplane;
-				if (di->di->Viewpoint.ViewVector3D.dot(myplane.Normal()) > 0.0) return;
+				if (di->di->Viewpoint.IsOrtho() && di->di->Viewpoint.ViewVector3D.dot(myplane.Normal()) > 0.0) return;
+				else if (plane==1 && di->di->Viewpoint.Pos.Z >= myplane.ZatPoint(di->di->Viewpoint.Pos)) return;
+				else if (plane==0 && di->di->Viewpoint.Pos.Z <= myplane.ZatPoint(di->di->Viewpoint.Pos)) return;
 			}
 			auto glport = sector->GetPortalGroup(plane);
 			if (glport != NULL)

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -83,15 +83,31 @@ void SetSplitPlanes(FRenderState& state, const secplane_t& top, const secplane_t
 
 void HWWall::RenderWall(FRenderState &state, int textured)
 {
-	if (seg->sidedef->Flags & WALLF_DITHERTRANS) state.SetEffect(EFF_DITHERTRANS);
+	bool ditherT = (type == RENDERWALL_BOTTOM) && (seg->sidedef->Flags & WALLF_DITHERTRANS_BOTTOM);
+	ditherT |= (type == RENDERWALL_TOP) && (seg->sidedef->Flags & WALLF_DITHERTRANS_TOP);
+	ditherT |= seg->sidedef->Flags & WALLF_DITHERTRANS_MID;
+	if (ditherT)
+	{
+		state.SetEffect(EFF_DITHERTRANS);
+	}
 	assert(vertcount > 0);
 	state.SetLightIndex(dynlightindex);
 	state.Draw(DT_TriangleFan, vertindex, vertcount);
 	vertexcount += vertcount;
-	if (seg->sidedef->Flags & WALLF_DITHERTRANS)
+	if (ditherT)
 	{
 		state.SetEffect(EFF_NONE);
-		seg->sidedef->Flags &= ~WALLF_DITHERTRANS; // reset this every frame
+		switch(type) // reset this every frame
+		{
+		case RENDERWALL_TOP:
+			seg->sidedef->Flags &= ~WALLF_DITHERTRANS_TOP;
+			break;
+		case RENDERWALL_BOTTOM:
+			seg->sidedef->Flags &= ~WALLF_DITHERTRANS_BOTTOM;
+			break;
+		default:
+			if (seg->sidedef->dithertranscount-- <= 0) seg->sidedef->Flags &= ~WALLF_DITHERTRANS_MID;
+		}
 	}
 }
 

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -2181,8 +2181,6 @@ void HWWall::Process(HWWallDispatcher *di, seg_t *seg, sector_t * frontsector, s
 	}
 
 	bool isportal = seg->linedef->isVisualPortal() && seg->sidedef == seg->linedef->sidedef[0];
-	// Don't render portal insides if in orthographic mode
-	if (di->di) isportal &= !(di->di->Viewpoint.IsOrtho());
 
 	//return;
 	// [GZ] 3D middle textures are necessarily two-sided, even if they lack the explicit two-sided flag

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -644,7 +644,8 @@ void HWWall::PutPortal(HWWallDispatcher *di, int ptype, int plane)
 			break;
 
 		case PORTALTYPE_PLANEMIRROR:
-			if (portalState.PlaneMirrorMode * planemirror->fC() <= 0)
+			if (ddi->Viewpoint.IsOrtho() ? (ddi->Viewpoint.ViewVector3D.dot(planemirror->Normal()) < 0)
+				: (portalState.PlaneMirrorMode * planemirror->fC() <= 0))
 			{
 				planemirror = portalState.UniquePlaneMirrors.Get(planemirror);
 				portal = ddi->FindPortal(planemirror);

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -704,6 +704,9 @@ void FRenderViewpoint::SetViewAngle(const FViewWindow& viewWindow)
 	ViewVector.X = v.X;
 	ViewVector.Y = v.Y;
 	HWAngles.Yaw = FAngle::fromDeg(270.0 - Angles.Yaw.Degrees());
+	ViewVector3D.X = v.X * PitchCos;
+	ViewVector3D.Y = v.Y * PitchCos;
+	ViewVector3D.Z = -PitchSin;
 
 	if (IsOrtho() && (camera->ViewPos->Offset.XY().Length() > 0.0))
 	{

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -550,8 +550,12 @@ void R_InterpolateView(FRenderViewpoint& viewPoint, const player_t* const player
 			const int prevPortalGroup = viewLvl->PointInRenderSubsector(iView->Old.Pos)->sector->PortalGroup;
 			const int curPortalGroup = viewLvl->PointInRenderSubsector(iView->New.Pos)->sector->PortalGroup;
 
-			const DVector2 portalOffset = viewLvl->Displacements.getOffset(prevPortalGroup, curPortalGroup);
-			viewPoint.Pos = iView->Old.Pos * inverseTicFrac + (iView->New.Pos - portalOffset) * ticFrac;
+			if (viewPoint.IsAllowedOoB() && prevPortalGroup != curPortalGroup) viewPoint.Pos = iView->New.Pos;
+			else
+			{
+				const DVector2 portalOffset = viewLvl->Displacements.getOffset(prevPortalGroup, curPortalGroup);
+				viewPoint.Pos = iView->Old.Pos * inverseTicFrac + (iView->New.Pos - portalOffset) * ticFrac;
+			}
 			viewPoint.Path[0] = viewPoint.Path[1] = iView->New.Pos;
 		}
 	}
@@ -707,6 +711,18 @@ void FRenderViewpoint::SetViewAngle(const FViewWindow& viewWindow)
 	ViewVector3D.X = v.X * PitchCos;
 	ViewVector3D.Y = v.Y * PitchCos;
 	ViewVector3D.Z = -PitchSin;
+
+	if (IsOrtho() || IsAllowedOoB()) // These auto-ensure that camera and camera->ViewPos exist
+	{
+		if (camera->tracer != NULL)
+		{
+			OffPos = camera->tracer->Pos();
+		}
+		else
+		{
+			OffPos = Pos + ViewVector3D * camera->ViewPos->Offset.Length();
+		}
+	}
 
 	if (IsOrtho() && (camera->ViewPos->Offset.XY().Length() > 0.0))
 	{

--- a/src/rendering/r_utility.h
+++ b/src/rendering/r_utility.h
@@ -26,6 +26,7 @@ struct FRenderViewpoint
 	FRotator		HWAngles;		// Actual rotation angles for the hardware renderer
 	DVector2		ViewVector;		// HWR only: direction the camera is facing.
 	DVector3		ViewVector3D;	// 3D direction the camera is facing.
+	DVector3        OffPos;         // Viewpoint position to use for Ortho and OoB calculations
 	AActor			*ViewActor;		// either the same as camera or nullptr
 	FLevelLocals	*ViewLevel;		// The level this viewpoint is on.
 

--- a/src/rendering/r_utility.h
+++ b/src/rendering/r_utility.h
@@ -25,6 +25,7 @@ struct FRenderViewpoint
 	DRotator		Angles;			// Camera angles
 	FRotator		HWAngles;		// Actual rotation angles for the hardware renderer
 	DVector2		ViewVector;		// HWR only: direction the camera is facing.
+	DVector3		ViewVector3D;	// 3D direction the camera is facing.
 	AActor			*ViewActor;		// either the same as camera or nullptr
 	FLevelLocals	*ViewLevel;		// The level this viewpoint is on.
 


### PR DESCRIPTION
Using sign of dot-product between view vector and flat normal to determine orthographic-projection visibility for flats, instead of the default `ZatPoint()` height check.