### PR TITLE
Clear VisualThinkerHead on new level

### DIFF
--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -379,6 +379,7 @@ void FLevelLocals::ClearLevelData(bool fullgc)
 	if (levelMesh) delete levelMesh;
 	aabbTree = nullptr;
 	levelMesh = nullptr;
+	VisualThinkerHead = nullptr;
 	if (screen)
 		screen->SetAABBTree(nullptr);
 }


### PR DESCRIPTION
Fixes a crash that could occur if the list couldn't be deleted fast enough when changing levels.