### PR TITLE
Added Behaviors Actor sub system

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1607,6 +1607,7 @@ void FLevelLocals::StartTravel ()
 			if (Players[i]->health > 0)
 			{
 				pawn->UnlinkFromWorld (nullptr);
+				pawn->UnlinkBehaviorsFromLevel();
 				int tid = pawn->tid;	// Save TID
 				pawn->SetTID(0);
 				pawn->tid = tid;		// Restore TID (but no longer linked into the hash chain)
@@ -1617,6 +1618,7 @@ void FLevelLocals::StartTravel ()
 				{
 					inv->ChangeStatNum (STAT_TRAVELLING);
 					inv->UnlinkFromWorld (nullptr);
+					inv->UnlinkBehaviorsFromLevel();
 					inv->DeleteAttachedLights();
 				}
 			}
@@ -1720,6 +1722,7 @@ int FLevelLocals::FinishTravel ()
 			pawndup->Destroy();
 		}
 		pawn->LinkToWorld (nullptr);
+		pawn->LinkBehaviorsToLevel();
 		pawn->ClearInterpolation();
 		pawn->ClearFOVInterpolation();
 		const int tid = pawn->tid;	// Save TID (actor isn't linked into the hash chain yet)
@@ -1733,6 +1736,7 @@ int FLevelLocals::FinishTravel ()
 			inv->ChangeStatNum (STAT_INVENTORY);
 			inv->LinkToWorld (nullptr);
 			P_FindFloorCeiling(inv, FFCF_ONLYSPAWNPOS);
+			inv->LinkBehaviorsToLevel();
 
 			IFVIRTUALPTRNAME(inv, NAME_Inventory, Travelled)
 			{

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -706,11 +706,35 @@ public:
 	DVisualThinker* VisualThinkerHead = nullptr;
 
 	// links to global game objects
+	TArray<DBehavior*> ActorBehaviors;
 	TArray<TObjPtr<AActor *>> CorpseQueue;
 	TObjPtr<DFraggleThinker *> FraggleScriptThinker = MakeObjPtr<DFraggleThinker*>(nullptr);
 	TObjPtr<DACSThinker*> ACSThinker = MakeObjPtr<DACSThinker*>(nullptr);
 
 	TObjPtr<DSpotState *> SpotState = MakeObjPtr<DSpotState*>(nullptr);
+
+	//==========================================================================
+	//
+	//
+	//==========================================================================
+
+	void AddActorBehavior(DBehavior& b)
+	{
+		if (b.Level == nullptr)
+		{
+			b.Level = this;
+			ActorBehaviors.Push(&b);
+		}
+	}
+
+	void RemoveActorBehavior(DBehavior& b)
+	{
+		if (b.Level == this)
+		{
+			b.Level = nullptr;
+			ActorBehaviors.Delete(ActorBehaviors.Find(&b));
+		}
+	}
 
 	//==========================================================================
 	//

--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -453,6 +453,7 @@ xx(Playermenu)
 
 // more stuff
 xx(Behavior)
+xx(BehaviorIterator)
 xx(ColorSet)
 xx(NeverSwitchOnPickup)
 xx(MoveBob)

--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -452,6 +452,7 @@ xx(Readthismenu)
 xx(Playermenu)
 
 // more stuff
+xx(Behavior)
 xx(ColorSet)
 xx(NeverSwitchOnPickup)
 xx(MoveBob)

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -991,7 +991,8 @@ void FLevelLocals::Serialize(FSerializer &arc, bool hubload)
 		("automap", automap)
 		("interpolator", interpolator)
 		("frozenstate", frozenstate)
-		("visualthinkerhead", VisualThinkerHead);
+		("visualthinkerhead", VisualThinkerHead)
+		("actorbehaviors", ActorBehaviors);
 
 
 	// Hub transitions must keep the current total time

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -380,6 +380,7 @@ void FLevelLocals::ClearLevelData(bool fullgc)
 	aabbTree = nullptr;
 	levelMesh = nullptr;
 	VisualThinkerHead = nullptr;
+	ActorBehaviors.Clear();
 	if (screen)
 		screen->SetAABBTree(nullptr);
 }

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -775,7 +775,7 @@ public:
 	void Serialize(FSerializer& arc) override;
 };
 
-class DBehavior : public DObject
+class DBehavior final : public DObject
 {
 	DECLARE_CLASS(DBehavior, DObject)
 	HAS_OBJECT_POINTERS

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1456,6 +1456,9 @@ public:
 	void TickBehaviors();
 	void MoveBehaviors(AActor& from);
 	void ClearBehaviors();
+	// Internal only, mostly for traveling.
+	void UnlinkBehaviorsFromLevel();
+	void LinkBehaviorsToLevel();
 
 	bool HasSpecialDeathStates () const;
 

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1451,6 +1451,10 @@ public:
 		auto b = Behaviors.CheckKey(type);
 		return b != nullptr ? b->Get() : nullptr;
 	}
+	bool IsValidBehavior(const DBehavior& b) const
+	{
+		return !(b.ObjectFlags & OF_EuthanizeMe) && b.Owner.ForceGet() == this;
+	}
 	DBehavior* AddBehavior(PClass& type);
 	bool RemoveBehavior(FName type);
 	void TickBehaviors();

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1439,7 +1439,7 @@ public:
 		auto b = Behaviors.CheckKey(type.TypeName);
 		return b != nullptr && *b != nullptr && !((*b)->ObjectFlags & OF_EuthanizeMe) ? *b : nullptr;
 	}
-	DObject* AddBehavior(const PClass& type);
+	DObject* AddBehavior(PClass& type);
 	bool RemoveBehavior(const PClass& type);
 	void TickBehaviors();
 	void MoveBehaviors(AActor& from);

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1384,7 +1384,7 @@ public:
 	// landing speed from a jump with normal gravity (squats the player's view)
 	// (note: this is put into AActor instead of the PlayerPawn because non-players also use the value)
 	double LandingSpeed;
-	TMap<FName, DBehavior*> Behaviors;
+	TMap<FName, TObjPtr<DBehavior*>> Behaviors;
 
 
 	// ThingIDs
@@ -1446,16 +1446,16 @@ public:
 		return GetClass()->FindState(numnames, names, exact);
 	}
 
-	DBehavior* FindBehavior(const PClass& type) const
+	DBehavior* FindBehavior(FName type) const
 	{
-		auto b = Behaviors.CheckKey(type.TypeName);
-		return b != nullptr && *b != nullptr && !((*b)->ObjectFlags & OF_EuthanizeMe) ? *b : nullptr;
+		auto b = Behaviors.CheckKey(type);
+		return b != nullptr ? b->Get() : nullptr;
 	}
 	DBehavior* AddBehavior(PClass& type);
-	bool RemoveBehavior(const PClass& type);
+	bool RemoveBehavior(FName type);
 	void TickBehaviors();
 	void MoveBehaviors(AActor& from);
-	void ClearBehaviors();
+	void ClearBehaviors(PClass* type = nullptr);
 	// Internal only, mostly for traveling.
 	void UnlinkBehaviorsFromLevel();
 	void LinkBehaviorsToLevel();

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -775,6 +775,18 @@ public:
 	void Serialize(FSerializer& arc) override;
 };
 
+class DBehavior : public DObject
+{
+	DECLARE_CLASS(DBehavior, DObject)
+	HAS_OBJECT_POINTERS
+public:
+	TObjPtr<AActor*> Owner;
+	FLevelLocals* Level;
+
+	void Serialize(FSerializer& arc) override;
+	void OnDestroy() override;
+};
+
 const double MinVel = EQUAL_EPSILON;
 
 // Map Object definition.
@@ -1372,7 +1384,7 @@ public:
 	// landing speed from a jump with normal gravity (squats the player's view)
 	// (note: this is put into AActor instead of the PlayerPawn because non-players also use the value)
 	double LandingSpeed;
-	TMap<FName, DObject*> Behaviors;
+	TMap<FName, DBehavior*> Behaviors;
 
 
 	// ThingIDs
@@ -1434,12 +1446,12 @@ public:
 		return GetClass()->FindState(numnames, names, exact);
 	}
 
-	DObject* FindBehavior(const PClass& type) const
+	DBehavior* FindBehavior(const PClass& type) const
 	{
 		auto b = Behaviors.CheckKey(type.TypeName);
 		return b != nullptr && *b != nullptr && !((*b)->ObjectFlags & OF_EuthanizeMe) ? *b : nullptr;
 	}
-	DObject* AddBehavior(PClass& type);
+	DBehavior* AddBehavior(PClass& type);
 	bool RemoveBehavior(const PClass& type);
 	void TickBehaviors();
 	void MoveBehaviors(AActor& from);

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -790,6 +790,7 @@ public:
 
 	virtual void OnDestroy() override;
 	virtual void Serialize(FSerializer &arc) override;
+	virtual size_t PropagateMark() override;
 	virtual void PostSerialize() override;
 	virtual void PostBeginPlay() override;		// Called immediately before the actor's first tick
 	virtual void Tick() override;
@@ -1371,6 +1372,7 @@ public:
 	// landing speed from a jump with normal gravity (squats the player's view)
 	// (note: this is put into AActor instead of the PlayerPawn because non-players also use the value)
 	double LandingSpeed;
+	TMap<FName, DObject*> Behaviors;
 
 
 	// ThingIDs
@@ -1431,6 +1433,17 @@ public:
 	{
 		return GetClass()->FindState(numnames, names, exact);
 	}
+
+	DObject* FindBehavior(const PClass& type) const
+	{
+		auto b = Behaviors.CheckKey(type.TypeName);
+		return b != nullptr && *b != nullptr && !((*b)->ObjectFlags & OF_EuthanizeMe) ? *b : nullptr;
+	}
+	DObject* AddBehavior(const PClass& type);
+	bool RemoveBehavior(const PClass& type);
+	void TickBehaviors();
+	void MoveBehaviors(AActor& from);
+	void ClearBehaviors();
 
 	bool HasSpecialDeathStates () const;
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -666,10 +666,10 @@ void AActor::MoveBehaviors(AActor& from)
 		}
 
 		b->Owner = this;
-		if (b->Level != b->Owner->Level)
+		if (b->Level != Level)
 		{
 			b->Level->RemoveActorBehavior(*b);
-			b->Owner->Level->AddActorBehavior(*b);
+			Level->AddActorBehavior(*b);
 		}
 	}
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -644,7 +644,7 @@ void AActor::MoveBehaviors(AActor& from)
 			continue;
 		}
 
-		auto owner = b->PointerVar<AActor>(NAME_Owner);
+		auto& owner = b->PointerVar<AActor>(NAME_Owner);
 		owner = this;
 	}
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -717,6 +717,44 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, ClearBehaviors, ClearBehaviors)
 	return 0;
 }
 
+void AActor::UnlinkBehaviorsFromLevel()
+{
+	TArray<FName> toRemove = {};
+
+	TMap<FName, DBehavior*>::Iterator it = { Behaviors };
+	TMap<FName, DBehavior*>::Pair* pair = nullptr;
+	while (it.NextPair(pair))
+	{
+		auto b = pair->Value;
+		if (b == nullptr || (b->ObjectFlags & OF_EuthanizeMe))
+			toRemove.Push(pair->Key);
+		else
+			b->Level->RemoveActorBehavior(*b);
+	}
+
+	for (auto& type : toRemove)
+		RemoveBehavior(*PClass::FindClass(type));
+}
+
+void AActor::LinkBehaviorsToLevel()
+{
+	TArray<FName> toRemove = {};
+
+	TMap<FName, DBehavior*>::Iterator it = { Behaviors };
+	TMap<FName, DBehavior*>::Pair* pair = nullptr;
+	while (it.NextPair(pair))
+	{
+		auto b = pair->Value;
+		if (b == nullptr || (b->ObjectFlags & OF_EuthanizeMe))
+			toRemove.Push(pair->Key);
+		else
+			Level->AddActorBehavior(*b);
+	}
+
+	for (auto& type : toRemove)
+		RemoveBehavior(*PClass::FindClass(type));
+}
+
 //==========================================================================
 //
 // AActor::InStateSequence

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -528,7 +528,7 @@ DObject* AActor::AddBehavior(PClass& type)
 	}
 	else
 	{
-		IFOVERRIDENVIRTUALPTRNAME(b, NAME_Behavior, Readded)
+		IFOVERRIDENVIRTUALPTRNAME(b, NAME_Behavior, Reinitialize)
 		{
 			VMValue params[] = { b };
 			VMCall(func, params, 1, nullptr, 0);

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -542,7 +542,7 @@ DBehavior* AActor::AddBehavior(PClass& type)
 			VMValue params[] = { b };
 			VMCall(func, params, 1, nullptr, 0);
 
-			if (b->ObjectFlags & OF_EuthanizeMe)
+			if (!IsValidBehavior(*b))
 			{
 				RemoveBehavior(type.TypeName);
 				return nullptr;
@@ -556,7 +556,7 @@ DBehavior* AActor::AddBehavior(PClass& type)
 			VMValue params[] = { b };
 			VMCall(func, params, 1, nullptr, 0);
 
-			if (b->ObjectFlags & OF_EuthanizeMe)
+			if (!IsValidBehavior(*b))
 			{
 				RemoveBehavior(type.TypeName);
 				return nullptr;
@@ -600,7 +600,7 @@ void AActor::TickBehaviors()
 
 	for (auto& b : toTick)
 	{
-		if ((b->ObjectFlags & OF_EuthanizeMe) || b->Owner != this)
+		if (!IsValidBehavior(*b))
 		{
 			toRemove.Push(b->GetClass()->TypeName);
 			continue;
@@ -611,7 +611,7 @@ void AActor::TickBehaviors()
 			VMValue params[] = { b };
 			VMCall(func, params, 1, nullptr, 0);
 
-			if (b->ObjectFlags & OF_EuthanizeMe)
+			if (!IsValidBehavior(*b))
 				toRemove.Push(b->GetClass()->TypeName);
 		}
 	}
@@ -646,12 +646,16 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, FindBehavior, FindBehavior)
 
 void AActor::MoveBehaviors(AActor& from)
 {
+	if (&from == this)
+		return;
+
 	// Clean these up properly before transferring.
 	ClearBehaviors();
 
 	Behaviors.TransferFrom(from.Behaviors);
 
 	TArray<FName> toRemove = {};
+	TArray<DBehavior*> toTransfer = {};
 	
 	// Clean up any empty behaviors that remained as well while
 	// changing the owner.
@@ -671,6 +675,26 @@ void AActor::MoveBehaviors(AActor& from)
 		{
 			b->Level->RemoveActorBehavior(*b);
 			Level->AddActorBehavior(*b);
+		}
+
+		toTransfer.Push(b);
+	}
+
+	for (auto& b : toTransfer)
+	{
+		if (!IsValidBehavior(*b))
+		{
+			toRemove.Push(b->GetClass()->TypeName);
+			continue;
+		}
+
+		IFOVERRIDENVIRTUALPTRNAME(b, NAME_Behavior, TransferredOwner)
+		{
+			VMValue params[] = { b, &from };
+			VMCall(func, params, 2, nullptr, 0);
+
+			if (!IsValidBehavior(*b))
+				toRemove.Push(b->GetClass()->TypeName);
 		}
 	}
 
@@ -5985,6 +6009,8 @@ AActor *FLevelLocals::SpawnPlayer (FPlayerStart *mthing, int playernum, int flag
 	const auto heldWeap = state == PST_REBORN && (dmflags3 & DF3_REMEMBER_LAST_WEAP) ? p->ReadyWeapon : nullptr;
 	if (state == PST_REBORN || state == PST_ENTER)
 	{
+		if (state == PST_REBORN && oldactor != nullptr)
+			p->mo->MoveBehaviors(*oldactor);
 		PlayerReborn (playernum);
 	}
 	else if (oldactor != NULL && oldactor->player == p && !(flags & SPF_TEMPPLAYER))

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -181,6 +181,14 @@ IMPLEMENT_POINTERS_START(AActor)
 	IMPLEMENT_POINTER(boneComponentData)
 IMPLEMENT_POINTERS_END
 
+IMPLEMENT_CLASS(DBehavior, false, true)
+IMPLEMENT_POINTERS_START(DBehavior)
+	IMPLEMENT_POINTER(Owner)
+IMPLEMENT_POINTERS_END
+
+DEFINE_FIELD(DBehavior, Owner)
+DEFINE_FIELD(DBehavior, Level)
+
 //==========================================================================
 //
 // Make sure Actors can never have their networking disabled.
@@ -206,8 +214,8 @@ void AActor::EnableNetworking(const bool enable)
 
 size_t AActor::PropagateMark()
 {
-	TMap<FName, DObject*>::Iterator it = { Behaviors };
-	TMap<FName, DObject*>::Pair* pair = nullptr;
+	TMap<FName, DBehavior*>::Iterator it = { Behaviors };
+	TMap<FName, DBehavior*>::Pair* pair = nullptr;
 	while (it.NextPair(pair))
 		GC::Mark(pair->Value);
 
@@ -469,6 +477,21 @@ void AActor::PostSerialize()
 //
 //==========================================================================
 
+void DBehavior::Serialize(FSerializer& arc)
+{
+	Super::Serialize(arc);
+	arc("owner", Owner)
+		("level", Level);
+}
+
+void DBehavior::OnDestroy()
+{
+	if (Level != nullptr)
+		Level->RemoveActorBehavior(*this);
+
+	Super::OnDestroy();
+}
+
 bool AActor::RemoveBehavior(const PClass& type)
 {
 	if (Behaviors.CheckKey(type.TypeName))
@@ -494,11 +517,11 @@ static int RemoveBehavior(AActor* self, PClass* type)
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, RemoveBehavior, RemoveBehavior)
 {
 	PARAM_SELF_PROLOGUE(AActor);
-	PARAM_CLASS_NOT_NULL(type, DObject);
+	PARAM_CLASS_NOT_NULL(type, DBehavior);
 	ACTION_RETURN_BOOL(self->RemoveBehavior(*type));
 }
 
-DObject* AActor::AddBehavior(PClass& type)
+DBehavior* AActor::AddBehavior(PClass& type)
 {
 	if (type.bAbstract || !type.IsDescendantOf(NAME_Behavior))
 		return nullptr;
@@ -506,14 +529,13 @@ DObject* AActor::AddBehavior(PClass& type)
 	auto b = FindBehavior(type);
 	if (b == nullptr)
 	{
-		b = type.CreateNew();
+		b = dyn_cast<DBehavior>(type.CreateNew());
 		if (b == nullptr)
 			return nullptr;
 
-		auto& owner = b->PointerVar<AActor>(NAME_Owner);
-		owner = this;
-
+		b->Owner = this;
 		Behaviors[type.TypeName] = b;
+		Level->AddActorBehavior(*b);
 		IFOVERRIDENVIRTUALPTRNAME(b, NAME_Behavior, Initialize)
 		{
 			VMValue params[] = { b };
@@ -544,7 +566,7 @@ DObject* AActor::AddBehavior(PClass& type)
 	return b;
 }
 
-static DObject* AddBehavior(AActor* self, PClass* type)
+static DBehavior* AddBehavior(AActor* self, PClass* type)
 {
 	return self->AddBehavior(*type);
 }
@@ -552,17 +574,17 @@ static DObject* AddBehavior(AActor* self, PClass* type)
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, AddBehavior, AddBehavior)
 {
 	PARAM_SELF_PROLOGUE(AActor);
-	PARAM_CLASS_NOT_NULL(type, DObject);
+	PARAM_CLASS_NOT_NULL(type, DBehavior);
 	ACTION_RETURN_OBJECT(self->AddBehavior(*type));
 }
 
 void AActor::TickBehaviors()
 {
 	TArray<FName> toRemove = {};
-	TArray<DObject*> toTick = {};
+	TArray<DBehavior*> toTick = {};
 
-	TMap<FName, DObject*>::Iterator it = { Behaviors };
-	TMap<FName, DObject*>::Pair* pair = nullptr;
+	TMap<FName, DBehavior*>::Iterator it = { Behaviors };
+	TMap<FName, DBehavior*>::Pair* pair = nullptr;
 	while (it.NextPair(pair))
 	{
 		auto b = pair->Value;
@@ -577,8 +599,7 @@ void AActor::TickBehaviors()
 
 	for (auto& b : toTick)
 	{
-		auto& owner = b->PointerVar<AActor>(NAME_Owner);
-		if (owner != this)
+		if (b->Owner != this)
 		{
 			toRemove.Push(pair->Key);
 			continue;
@@ -610,7 +631,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, TickBehaviors, TickBehaviors)
 	return 0;
 }
 
-static DObject* FindBehavior(AActor* self, PClass* type)
+static DBehavior* FindBehavior(AActor* self, PClass* type)
 {
 	return self->FindBehavior(*type);
 }
@@ -618,7 +639,7 @@ static DObject* FindBehavior(AActor* self, PClass* type)
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, FindBehavior, FindBehavior)
 {
 	PARAM_SELF_PROLOGUE(AActor);
-	PARAM_CLASS_NOT_NULL(type, DObject);
+	PARAM_CLASS_NOT_NULL(type, DBehavior);
 	ACTION_RETURN_OBJECT(self->FindBehavior(*type));
 }
 
@@ -633,8 +654,8 @@ void AActor::MoveBehaviors(AActor& from)
 	
 	// Clean up any empty behaviors that remained as well while
 	// changing the owner.
-	TMap<FName, DObject*>::Iterator it = { Behaviors };
-	TMap<FName, DObject*>::Pair* pair = nullptr;
+	TMap<FName, DBehavior*>::Iterator it = { Behaviors };
+	TMap<FName, DBehavior*>::Pair* pair = nullptr;
 	while (it.NextPair(pair))
 	{
 		auto b = pair->Value;
@@ -644,8 +665,12 @@ void AActor::MoveBehaviors(AActor& from)
 			continue;
 		}
 
-		auto& owner = b->PointerVar<AActor>(NAME_Owner);
-		owner = this;
+		b->Owner = this;
+		if (b->Level != b->Owner->Level)
+		{
+			b->Level->RemoveActorBehavior(*b);
+			b->Owner->Level->AddActorBehavior(*b);
+		}
 	}
 
 	for (auto& type : toRemove)
@@ -669,8 +694,8 @@ void AActor::ClearBehaviors()
 {
 	TArray<FName> toRemove = {};
 
-	TMap<FName, DObject*>::Iterator it = { Behaviors };
-	TMap<FName, DObject*>::Pair* pair = nullptr;
+	TMap<FName, DBehavior*>::Iterator it = { Behaviors };
+	TMap<FName, DBehavior*>::Pair* pair = nullptr;
 	while (it.NextPair(pair))
 		toRemove.Push(pair->Key);
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -498,7 +498,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, RemoveBehavior, RemoveBehavior)
 	ACTION_RETURN_BOOL(self->RemoveBehavior(*type));
 }
 
-DObject* AActor::AddBehavior(const PClass& type)
+DObject* AActor::AddBehavior(PClass& type)
 {
 	if (type.bAbstract || !type.IsDescendantOf(NAME_Behavior))
 		return nullptr;
@@ -506,7 +506,7 @@ DObject* AActor::AddBehavior(const PClass& type)
 	auto b = FindBehavior(type);
 	if (b == nullptr)
 	{
-		b = Create<DObject>();
+		b = type.CreateNew();
 		if (b == nullptr)
 			return nullptr;
 
@@ -559,6 +559,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, AddBehavior, AddBehavior)
 void AActor::TickBehaviors()
 {
 	TArray<FName> toRemove = {};
+	TArray<DObject*> toTick = {};
 
 	TMap<FName, DObject*>::Iterator it = { Behaviors };
 	TMap<FName, DObject*>::Pair* pair = nullptr;
@@ -571,6 +572,11 @@ void AActor::TickBehaviors()
 			continue;
 		}
 
+		toTick.Push(b);
+	}
+
+	for (auto& b : toTick)
+	{
 		auto& owner = b->PointerVar<AActor>(NAME_Owner);
 		if (owner != this)
 		{

--- a/src/scripting/backend/codegen_doom.cpp
+++ b/src/scripting/backend/codegen_doom.cpp
@@ -1034,6 +1034,10 @@ FxExpression *FxCastForEachLoop::Resolve(FCompileContext &ctx)
 	{
 		fieldName = "Thinker";
 	}
+	else if (itType->TypeName == NAME_BehaviorIterator)
+	{
+		fieldName = "Behavior";
+	}
 	else
 	{
 		ScriptPosition.Message(MSG_ERROR, "foreach(Type var : it ) - 'it' must be an actor or thinker iterator, but is a %s",Expr->ValueType->DescriptiveName());
@@ -1218,6 +1222,7 @@ bool IsGameSpecificForEachLoop(FxForEachLoop * loop)
 			 || ((PObjectPointer*)vt)->PointedClass()->TypeName == NAME_BlockThingsIterator
 			 || ((PObjectPointer*)vt)->PointedClass()->TypeName == NAME_ActorIterator
 			 || ((PObjectPointer*)vt)->PointedClass()->TypeName == NAME_ThinkerIterator
+			 || ((PObjectPointer*)vt)->PointedClass()->TypeName == NAME_BehaviorIterator
 			));
 }
 
@@ -1232,7 +1237,7 @@ FxExpression * ResolveGameSpecificForEachLoop(FxForEachLoop * loop)
 		delete loop;
 		return blockIt;
 	}
-	else if(cname == NAME_ActorIterator || cname == NAME_ThinkerIterator)
+	else if(cname == NAME_ActorIterator || cname == NAME_ThinkerIterator || cname == NAME_BehaviorIterator)
 	{
 		auto castIt = new FxCastForEachLoop(NAME_None, loop->loopVarName, loop->Array, loop->Code, loop->ScriptPosition);
 		loop->Array = loop->Code = nullptr;
@@ -1324,13 +1329,14 @@ bool IsGameSpecificTypedForEachLoop(FxTypedForEachLoop * loop)
 	return (vt->isObjectPointer() && (
 		((PObjectPointer*)vt)->PointedClass()->TypeName == NAME_ActorIterator
 		|| ((PObjectPointer*)vt)->PointedClass()->TypeName == NAME_ThinkerIterator
+		|| ((PObjectPointer*)vt)->PointedClass()->TypeName == NAME_BehaviorIterator
 		));
 }
 
 FxExpression * ResolveGameSpecificTypedForEachLoop(FxTypedForEachLoop * loop)
 {
 	assert(loop->Expr->ValueType->isObjectPointer());
-	assert(((PObjectPointer*)loop->Expr->ValueType)->PointedClass()->TypeName == NAME_ActorIterator || ((PObjectPointer*)loop->Expr->ValueType)->PointedClass()->TypeName == NAME_ThinkerIterator);
+	assert(((PObjectPointer*)loop->Expr->ValueType)->PointedClass()->TypeName == NAME_ActorIterator || ((PObjectPointer*)loop->Expr->ValueType)->PointedClass()->TypeName == NAME_ThinkerIterator || ((PObjectPointer*)loop->Expr->ValueType)->PointedClass()->TypeName == NAME_BehaviorIterator);
 
 	FxExpression * castIt = new FxCastForEachLoop(loop->className, loop->varName, loop->Expr, loop->Code, loop->ScriptPosition);
 	loop->Expr = loop->Code = nullptr;

--- a/src/scripting/backend/codegen_doom.cpp
+++ b/src/scripting/backend/codegen_doom.cpp
@@ -936,12 +936,18 @@ static DObject *BuiltinNewDoom(PClass *cls, int outerside, int backwardscompatib
 	// Creating actors here must be outright prohibited,
 	if (cls->IsDescendantOf(NAME_Actor))
 	{
-		ThrowAbortException(X_OTHER, "Cannot create actors with 'new'");
+		ThrowAbortException(X_OTHER, "Cannot create actors with 'new'. Use Actor.Spawn instead.");
 		return nullptr;
 	}
 	if (cls->IsDescendantOf(NAME_VisualThinker)) // Same for VisualThinkers.
 	{
 		ThrowAbortException(X_OTHER, "Cannot create VisualThinker or inheriting classes with 'new'. Use 'VisualThinker.Spawn' instead.");
+		return nullptr;
+	}
+	// These don't make sense without an owning Actor so don't allow creating them.
+	if (cls->IsDescendantOf(NAME_Behavior))
+	{
+		ThrowAbortException(X_OTHER, "Behaviors must be added to existing Actors and cannot be created with 'new'");
 		return nullptr;
 	}
 	if ((vm_warnthinkercreation || !backwardscompatible) && cls->IsDescendantOf(NAME_Thinker))

--- a/src/scripting/vmiterators.cpp
+++ b/src/scripting/vmiterators.cpp
@@ -420,11 +420,14 @@ public:
 		Reinit();
 	}
 
-	DBehaviorIterator(const FLevelLocals& level, PClass* type)
+	DBehaviorIterator(const FLevelLocals& level, PClass* type, PClass* ownerType)
 	{
 		for (auto& b : level.ActorBehaviors)
 		{
 			if (b == nullptr || (b->ObjectFlags & OF_EuthanizeMe))
+				continue;
+
+			if (ownerType != nullptr && !b->Owner->IsKindOf(ownerType))
 				continue;
 
 			if (type == nullptr || b->IsKindOf(type))
@@ -466,16 +469,17 @@ DEFINE_ACTION_FUNCTION_NATIVE(DBehaviorIterator, CreateFrom, CreateBehaviorItFro
 	ACTION_RETURN_OBJECT(CreateBehaviorItFromActor(mobj, type));
 }
 
-static DBehaviorIterator* CreateBehaviorIt(PClass* type)
+static DBehaviorIterator* CreateBehaviorIt(PClass* type, PClass* ownerType)
 {
-	return Create<DBehaviorIterator>(*primaryLevel, type);
+	return Create<DBehaviorIterator>(*primaryLevel, type, ownerType);
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DBehaviorIterator, Create, CreateBehaviorIt)
 {
 	PARAM_PROLOGUE;
 	PARAM_CLASS(type, DBehavior);
-	ACTION_RETURN_OBJECT(CreateBehaviorIt(type));
+	PARAM_CLASS(ownerType, AActor);
+	ACTION_RETURN_OBJECT(CreateBehaviorIt(type, ownerType));
 }
 
 static DBehavior* NextBehavior(DBehaviorIterator* self)

--- a/src/serializer_doom.cpp
+++ b/src/serializer_doom.cpp
@@ -226,6 +226,33 @@ FSerializer& FDoomSerializer::StatePointer(const char* key, void* ptraddr, bool 
 }
 
 
+FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, DObject*>& value, TMap<FName, DObject*>* def)
+{
+	if (!arc.BeginObject(key))
+		return arc;
+
+	if (arc.isWriting())
+	{
+		TMap<FName, DObject*>::Iterator it = { value };
+		TMap<FName, DObject*>::Pair* pair = nullptr;
+		while (it.NextPair(pair))
+			arc(pair->Key.GetChars(), pair->Value);
+	}
+	else
+	{
+		const char* k = nullptr;
+		while ((k = arc.GetKey()) != nullptr)
+		{
+			DObject* obj = nullptr;
+			arc(k, obj);
+			value[k] = obj;
+		}
+	}
+
+	arc.EndObject();
+	return arc;
+}
+
 
 template<> FSerializer &Serialize(FSerializer &ar, const char *key, FPolyObj *&value, FPolyObj **defval)
 {

--- a/src/serializer_doom.cpp
+++ b/src/serializer_doom.cpp
@@ -226,15 +226,15 @@ FSerializer& FDoomSerializer::StatePointer(const char* key, void* ptraddr, bool 
 }
 
 
-FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, DObject*>& value, TMap<FName, DObject*>* def)
+FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, DBehavior*>& value, TMap<FName, DBehavior*>* def)
 {
 	if (!arc.BeginObject(key))
 		return arc;
 
 	if (arc.isWriting())
 	{
-		TMap<FName, DObject*>::Iterator it = { value };
-		TMap<FName, DObject*>::Pair* pair = nullptr;
+		TMap<FName, DBehavior*>::Iterator it = { value };
+		TMap<FName, DBehavior*>::Pair* pair = nullptr;
 		while (it.NextPair(pair))
 			arc(pair->Key.GetChars(), pair->Value);
 	}
@@ -243,7 +243,7 @@ FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, DObject*>&
 		const char* k = nullptr;
 		while ((k = arc.GetKey()) != nullptr)
 		{
-			DObject* obj = nullptr;
+			DBehavior* obj = nullptr;
 			arc(k, obj);
 			value[k] = obj;
 		}

--- a/src/serializer_doom.cpp
+++ b/src/serializer_doom.cpp
@@ -226,17 +226,21 @@ FSerializer& FDoomSerializer::StatePointer(const char* key, void* ptraddr, bool 
 }
 
 
-FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, DBehavior*>& value, TMap<FName, DBehavior*>* def)
+FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, TObjPtr<DBehavior*>>& value, TMap<FName, TObjPtr<DBehavior*>>* def)
 {
 	if (!arc.BeginObject(key))
 		return arc;
 
 	if (arc.isWriting())
 	{
-		TMap<FName, DBehavior*>::Iterator it = { value };
-		TMap<FName, DBehavior*>::Pair* pair = nullptr;
+		TMap<FName, TObjPtr<DBehavior*>>::Iterator it = { value };
+		TMap<FName, TObjPtr<DBehavior*>>::Pair* pair = nullptr;
 		while (it.NextPair(pair))
-			arc(pair->Key.GetChars(), pair->Value);
+		{
+			auto b = pair->Value.Get();
+			if (b != nullptr)
+				arc(pair->Key.GetChars(), b);
+		}
 	}
 	else
 	{

--- a/src/serializer_doom.h
+++ b/src/serializer_doom.h
@@ -3,6 +3,7 @@
 #include "serializer.h"
 
 class player_t;
+class DBehavior;
 struct sector_t;
 struct line_t;
 struct side_t;
@@ -43,7 +44,7 @@ FSerializer &Serialize(FSerializer &arc, const char *key, ticcmd_t &sid, ticcmd_
 FSerializer &Serialize(FSerializer &arc, const char *key, usercmd_t &cmd, usercmd_t *def);
 FSerializer &Serialize(FSerializer &arc, const char *key, FInterpolator &rs, FInterpolator *def);
 FSerializer& Serialize(FSerializer& arc, const char* key, struct FStandaloneAnimation& value, struct FStandaloneAnimation* defval);
-FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, DObject*>& value, TMap<FName, DObject*>* def);
+FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, DBehavior*>& value, TMap<FName, DBehavior*>* def);
 
 template<> FSerializer &Serialize(FSerializer &arc, const char *key, FPolyObj *&value, FPolyObj **defval);
 template<> FSerializer &Serialize(FSerializer &arc, const char *key, sector_t *&value, sector_t **defval);

--- a/src/serializer_doom.h
+++ b/src/serializer_doom.h
@@ -44,7 +44,7 @@ FSerializer &Serialize(FSerializer &arc, const char *key, ticcmd_t &sid, ticcmd_
 FSerializer &Serialize(FSerializer &arc, const char *key, usercmd_t &cmd, usercmd_t *def);
 FSerializer &Serialize(FSerializer &arc, const char *key, FInterpolator &rs, FInterpolator *def);
 FSerializer& Serialize(FSerializer& arc, const char* key, struct FStandaloneAnimation& value, struct FStandaloneAnimation* defval);
-FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, DBehavior*>& value, TMap<FName, DBehavior*>* def);
+FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, TObjPtr<DBehavior*>>& value, TMap<FName, TObjPtr<DBehavior*>>* def);
 
 template<> FSerializer &Serialize(FSerializer &arc, const char *key, FPolyObj *&value, FPolyObj **defval);
 template<> FSerializer &Serialize(FSerializer &arc, const char *key, sector_t *&value, sector_t **defval);

--- a/src/serializer_doom.h
+++ b/src/serializer_doom.h
@@ -43,6 +43,7 @@ FSerializer &Serialize(FSerializer &arc, const char *key, ticcmd_t &sid, ticcmd_
 FSerializer &Serialize(FSerializer &arc, const char *key, usercmd_t &cmd, usercmd_t *def);
 FSerializer &Serialize(FSerializer &arc, const char *key, FInterpolator &rs, FInterpolator *def);
 FSerializer& Serialize(FSerializer& arc, const char* key, struct FStandaloneAnimation& value, struct FStandaloneAnimation* defval);
+FSerializer& Serialize(FSerializer& arc, const char* key, TMap<FName, DObject*>& value, TMap<FName, DObject*>* def);
 
 template<> FSerializer &Serialize(FSerializer &arc, const char *key, FPolyObj *&value, FPolyObj **defval);
 template<> FSerializer &Serialize(FSerializer &arc, const char *key, sector_t *&value, sector_t **defval);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -78,8 +78,16 @@ class Behavior play abstract
 	readonly Actor Owner;
 
 	virtual void Initialize() {}
-	virtual void Readded() {}
+	virtual void Reinitialize() {}
 	virtual void Tick() {}
+}
+
+class BehaviorIterator native abstract final
+{
+	native static BehaviorIterator CreateFrom(Actor mobj, class<Behavior> type = null);
+
+	native Behavior Next();
+	native void Reinit();
 }
 
 class Actor : Thinker native

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -86,7 +86,7 @@ class Behavior native play abstract
 class BehaviorIterator native abstract final
 {
 	native static BehaviorIterator CreateFrom(Actor mobj, class<Behavior> type = null);
-	native static BehaviorIterator Create(class<Behavior> type = null);
+	native static BehaviorIterator Create(class<Behavior> type = null, class<Actor> ownerType = null);
 
 	native Behavior Next();
 	native void Reinit();

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -522,7 +522,7 @@ class Actor : Thinker native
 	native bool RemoveBehavior(class<Behavior> type);
 	native Behavior AddBehavior(class<Behavior> type);
 	native void TickBehaviors();
-	native void ClearBehaviors();
+	native void ClearBehaviors(class<Behavior> type = null);
 	native void MoveBehaviors(Actor from);
 
 	native clearscope bool isFrozen() const;

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -80,6 +80,7 @@ class Behavior native play abstract
 
 	virtual void Initialize() {}
 	virtual void Reinitialize() {}
+	virtual void TransferredOwner(Actor oldOwner) {}
 	virtual void Tick() {}
 }
 

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -73,9 +73,10 @@ class ViewPosition native
 	native readonly int Flags;
 }
 
-class Behavior play abstract
+class Behavior native play abstract
 {
-	readonly Actor Owner;
+	native readonly Actor Owner;
+	native readonly LevelLocals Level;
 
 	virtual void Initialize() {}
 	virtual void Reinitialize() {}
@@ -85,6 +86,7 @@ class Behavior play abstract
 class BehaviorIterator native abstract final
 {
 	native static BehaviorIterator CreateFrom(Actor mobj, class<Behavior> type = null);
+	native static BehaviorIterator Create(class<Behavior> type = null);
 
 	native Behavior Next();
 	native void Reinit();

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -73,7 +73,7 @@ class ViewPosition native
 	native readonly int Flags;
 }
 
-class Behavior native play abstract
+class Behavior native play abstract version("4.15")
 {
 	native readonly Actor Owner;
 	native readonly LevelLocals Level;
@@ -84,7 +84,7 @@ class Behavior native play abstract
 	virtual void Tick() {}
 }
 
-class BehaviorIterator native abstract final
+class BehaviorIterator native abstract final version("4.15")
 {
 	native static BehaviorIterator CreateFrom(Actor mobj, class<Behavior> type = null);
 	native static BehaviorIterator Create(class<Behavior> type = null, class<Actor> ownerType = null);
@@ -519,12 +519,12 @@ class Actor : Thinker native
 		return sin(fb * (180./32)) * 8;
 	}
 
-	native clearscope Behavior FindBehavior(class<Behavior> type) const;
-	native bool RemoveBehavior(class<Behavior> type);
-	native Behavior AddBehavior(class<Behavior> type);
-	native void TickBehaviors();
-	native void ClearBehaviors(class<Behavior> type = null);
-	native void MoveBehaviors(Actor from);
+	native version("4.15") clearscope Behavior FindBehavior(class<Behavior> type) const;
+	native version("4.15") bool RemoveBehavior(class<Behavior> type);
+	native version("4.15") Behavior AddBehavior(class<Behavior> type);
+	native version("4.15") void TickBehaviors();
+	native version("4.15") void ClearBehaviors(class<Behavior> type = null);
+	native version("4.15") void MoveBehaviors(Actor from);
 
 	native clearscope bool isFrozen() const;
 	virtual native void BeginPlay();

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -73,6 +73,14 @@ class ViewPosition native
 	native readonly int Flags;
 }
 
+class Behavior play abstract
+{
+	readonly Actor Owner;
+
+	virtual void Initialize() {}
+	virtual void Readded() {}
+	virtual void Tick() {}
+}
 
 class Actor : Thinker native
 {
@@ -499,6 +507,13 @@ class Actor : Thinker native
 	{
 		return sin(fb * (180./32)) * 8;
 	}
+
+	native clearscope Behavior FindBehavior(class<Behavior> type) const;
+	native bool RemoveBehavior(class<Behavior> type);
+	native Behavior AddBehavior(class<Behavior> type);
+	native void TickBehaviors();
+	native void ClearBehaviors();
+	native void MoveBehaviors(Actor from);
 
 	native clearscope bool isFrozen() const;
 	virtual native void BeginPlay();


### PR DESCRIPTION
These allow for arbitrary behaviors to be attached to Actors in a way that doesn't require the use of Inventory tokens. The list can't be freely modified nor can it have duplicates meaning it has far better deterministic behavior than using Inventory items for this purpose since they can go poof at just about any time.

One of the strengths of these is that you can iterate across _all_ Behaviors and not just across the behaviors of individual Actors. This allows you to easily apply sweeping events/changes across all of them similar to an interface.