### PR TITLE
Added NOAUTOOFFSKULLFLY flag

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -446,6 +446,7 @@ enum ActorFlag9
 	MF9_NOSECTORDAMAGE			= 0x00000020,	// [inkoalawetrust] Actor ignores any sector-based damage (i.e damaging floors, NOT crushers)
 	MF9_ISPUFF					= 0x00000040,	// [AA] Set on actors by P_SpawnPuff
 	MF9_FORCESECTORDAMAGE		= 0x00000080,	// [inkoalawetrust] Actor ALWAYS takes hurt floor damage if there's any. Even if the floor doesn't have SECMF_HURTMONSTERS.
+	MF9_NOAUTOOFFSKULLFLY		= 0x00000100,	// Don't automatically disable MF_SKULLFLY if velocity is 0.
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -2105,7 +2105,7 @@ static double P_XYMovement (AActor *mo, DVector2 scroll)
 
 	if (move.isZero())
 	{
-		if (mo->flags & MF_SKULLFLY)
+		if ((mo->flags & MF_SKULLFLY) && !(mo->flags9 & MF9_NOAUTOOFFSKULLFLY))
 		{
 			// the skull slammed into something
 			mo->flags &= ~MF_SKULLFLY;

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -354,6 +354,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF9, NOSECTORDAMAGE, AActor, flags9),
 	DEFINE_PROTECTED_FLAG(MF9, ISPUFF, AActor, flags9), //[AA] was spawned by SpawnPuff
 	DEFINE_FLAG(MF9, FORCESECTORDAMAGE, AActor, flags9),
+	DEFINE_FLAG(MF9, NOAUTOOFFSKULLFLY, AActor, flags9),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
Disables resetting MF_SKULLFLY and state when xy velocity is zero. This is pretty deeply ingrained into P_XYMovement so is very difficult to override from ZScript without replacing everything.