### PR TITLE
Added SetBloodColor

### DIFF
--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -52,6 +52,7 @@ public:
 	FRenderStyle RenderStyle;
 	side_t *Side = nullptr;
 	sector_t *Sector = nullptr;
+	bool bIsBlood;
 
 protected:
 	virtual DBaseDecal *CloneSelf(const FDecalTemplate *tpl, double x, double y, double z, side_t *wall, F3DFloor * ffloor) const;
@@ -73,8 +74,8 @@ public:
 	}
 	void Construct(side_t *wall, const FDecalTemplate *templ);
 
-	static DBaseDecal *StaticCreate(FLevelLocals *Level, const char *name, const DVector3 &pos, side_t *wall, F3DFloor * ffloor, PalEntry color = 0, FTranslationID translation = NO_TRANSLATION);
-	static DBaseDecal *StaticCreate(FLevelLocals *Level, const FDecalTemplate *tpl, const DVector3 &pos, side_t *wall, F3DFloor * ffloor, PalEntry color = 0, FTranslationID translation = NO_TRANSLATION, bool permanent = false);
+	static DBaseDecal *StaticCreate(FLevelLocals *Level, const char *name, const DVector3 &pos, side_t *wall, F3DFloor * ffloor, PalEntry color = 0, FTranslationID translation = NO_TRANSLATION, bool isBlood = false);
+	static DBaseDecal *StaticCreate(FLevelLocals *Level, const FDecalTemplate *tpl, const DVector3 &pos, side_t *wall, F3DFloor * ffloor, PalEntry color = 0, FTranslationID translation = NO_TRANSLATION, bool isBlood = false, bool permanent = false);
 
 	void BeginPlay ();
 	void Expired() override;

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5278,7 +5278,7 @@ void P_TraceBleed(int damage, const DVector3 &pos, AActor *actor, DAngle angle, 
 				auto bloodTrans = (bloodcolor != 0 ? actor->BloodTranslation : NO_TRANSLATION);
 
 				DImpactDecal::StaticCreate(actor->Level, bloodType, bleedtrace.HitPos,
-					bleedtrace.Line->sidedef[bleedtrace.Side], bleedtrace.ffloor, bloodcolor, bloodTrans);
+					bleedtrace.Line->sidedef[bleedtrace.Side], bleedtrace.ffloor, bloodcolor, bloodTrans, true);
 			}
 		}
 	}

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -408,6 +408,9 @@ void AActor::Serialize(FSerializer &arc)
 		SerializeTerrain(arc, "floorterrain", floorterrain, &def->floorterrain);
 		SerializeArgs(arc, "args", args, def->args, special);
 
+		// Recreate this when loading since it doesn't serialize properly anyway.
+		if (arc.isReading() && BloodTranslation != NO_TRANSLATION)
+			BloodTranslation = CreateBloodTranslation(BloodColor);
 }
 
 #undef A

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1732,6 +1732,22 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, CopyBloodColor, CopyBloodColor)
 	return 0;
 }
 
+static void SetBloodColor(AActor* self, int color)
+{
+	PalEntry col = color;
+	self->BloodColor = col;
+	self->BloodColor.a = 255;
+	self->BloodTranslation = CreateBloodTranslation(col);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(AActor, SetBloodColor, SetBloodColor)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_INT(color);
+	SetBloodColor(self, color);
+	return 0;
+}
+
 //=====================================================================================
 //
 // Inventory exports

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1303,6 +1303,7 @@ class Actor : Thinker native
 	native void A_SprayDecal(String name, double dist = 172, vector3 offset = (0, 0, 0), vector3 direction = (0, 0, 0), bool useBloodColor = false, color decalColor = 0, TranslationID translation = 0);
 	native void A_SetMugshotState(String name);
 	native void CopyBloodColor(Actor other);
+	native void SetBloodColor(Color col);
 
 	native void A_RearrangePointers(int newtarget, int newmaster = AAPTR_DEFAULT, int newtracer = AAPTR_DEFAULT, int flags=0);
 	native void A_TransferPointer(int ptr_source, int ptr_recipient, int sourcefield, int recipientfield=AAPTR_DEFAULT, int flags=0);


### PR DESCRIPTION
Allows for Actor blood colors to be changed on the fly instead of needing to use dummy Actor classes to create translations. Serializing has been improved such that anything with a blood translation will simply recreate it on load (including for decals).