### PR TITLE
Analog binds

### DIFF
--- a/src/common/console/c_buttons.cpp
+++ b/src/common/console/c_buttons.cpp
@@ -39,6 +39,7 @@
 #include "printf.h"
 #include "cmdlib.h"
 #include "c_console.h"
+#include "m_joy.h"
 
 ButtonMap buttonMap;
 
@@ -150,6 +151,23 @@ void ButtonMap::ResetButtonStates ()
 //
 //=============================================================================
 
+void ButtonMap::GetAxes ()
+{
+	float joyaxes[NUM_KEYS];
+	I_GetAxes(joyaxes);
+
+	for (auto &btn : Buttons)
+	{
+		btn.AddAxes(joyaxes);
+	}
+}
+
+//=============================================================================
+//
+//
+//
+//=============================================================================
+
 bool FButtonStatus::PressKey (int keynum)
 {
 	int i, open;
@@ -238,6 +256,37 @@ bool FButtonStatus::ReleaseKey (int keynum)
 	}
 	// Returns true if releasing this key caused the button to go up.
 	return wasdown && !bDown;
+}
+
+//=============================================================================
+//
+//
+//
+//=============================================================================
+
+void FButtonStatus::AddAxes (float joyaxes[NUM_KEYS])
+{
+	int i, open;
+
+	bIsAxis = false;
+	Axis = 0.0f;
+
+	for (i = 0; i < MAX_KEYS; i++)
+	{
+		if (Keys[i] == 0)
+		{
+			break;
+		}
+
+		float axis_value = joyaxes[ Keys[i] ];
+		if (axis_value > 0.0f)
+		{
+			bIsAxis = true;
+			Axis += axis_value;
+		}
+	}
+
+	Axis = clamp<float>(Axis, 0.0f, 1.0f);
 }
 
 //=============================================================================

--- a/src/common/engine/m_joy.cpp
+++ b/src/common/engine/m_joy.cpp
@@ -162,18 +162,6 @@ bool M_LoadJoystickConfig(IJoystickConfig *joy)
 		{
 			joy->SetAxisScale(i, (float)atof(value));
 		}
-
-		mysnprintf(key + axislen, countof(key) - axislen, "map");
-		value = GameConfig->GetValueForKey(key);
-		if (value)
-		{
-			EJoyAxis gameaxis = (EJoyAxis)atoi(value);
-			if (gameaxis < JOYAXIS_None || gameaxis >= NUM_JOYAXIS)
-			{
-				gameaxis = JOYAXIS_None;
-			}
-			joy->SetAxisMap(i, gameaxis);
-		}
 	}
 	return true;
 }
@@ -225,12 +213,6 @@ void M_SaveJoystickConfig(IJoystickConfig *joy)
 			{
 				mysnprintf(key + axislen, countof(key) - axislen, "scale");
 				mysnprintf(value, countof(value), "%g", joy->GetAxisScale(i));
-				GameConfig->SetValueForKey(key, value);
-			}
-			if (!joy->IsAxisMapDefault(i))
-			{
-				mysnprintf(key + axislen, countof(key) - axislen, "map");
-				mysnprintf(value, countof(value), "%d", joy->GetAxisMap(i));
 				GameConfig->SetValueForKey(key, value);
 			}
 		}

--- a/src/common/engine/m_joy.h
+++ b/src/common/engine/m_joy.h
@@ -4,18 +4,7 @@
 #include "basics.h"
 #include "tarray.h"
 #include "c_cvars.h"
-
-enum EJoyAxis
-{
-	JOYAXIS_None = -1,
-	JOYAXIS_Yaw,
-	JOYAXIS_Pitch,
-	JOYAXIS_Forward,
-	JOYAXIS_Side,
-	JOYAXIS_Up,
-//	JOYAXIS_Roll,		// Ha ha. No roll for you.
-	NUM_JOYAXIS,
-};
+#include "keydef.h"
 
 // Generic configuration interface for a controller.
 struct IJoystickConfig
@@ -28,12 +17,10 @@ struct IJoystickConfig
 
 	virtual int GetNumAxes() = 0;
 	virtual float GetAxisDeadZone(int axis) = 0;
-	virtual EJoyAxis GetAxisMap(int axis) = 0;
 	virtual const char *GetAxisName(int axis) = 0;
 	virtual float GetAxisScale(int axis) = 0;
 
 	virtual void SetAxisDeadZone(int axis, float zone) = 0;
-	virtual void SetAxisMap(int axis, EJoyAxis gameaxis) = 0;
 	virtual void SetAxisScale(int axis, float scale) = 0;
 
 	virtual bool GetEnabled() = 0;
@@ -46,7 +33,6 @@ struct IJoystickConfig
 	// Used by the saver to not save properties that are at their defaults.
 	virtual bool IsSensitivityDefault() = 0;
 	virtual bool IsAxisDeadZoneDefault(int axis) = 0;
-	virtual bool IsAxisMapDefault(int axis) = 0;
 	virtual bool IsAxisScaleDefault(int axis) = 0;
 
 	virtual void SetDefaultConfig() = 0;
@@ -64,7 +50,7 @@ int Joy_XYAxesToButtons(double x, double y);
 double Joy_RemoveDeadZone(double axisval, double deadzone, uint8_t *buttons);
 
 // These ought to be provided by a system-specific i_input.cpp.
-void I_GetAxes(float axes[NUM_JOYAXIS]);
+void I_GetAxes(float axes[NUM_KEYS]);
 void I_GetJoysticks(TArray<IJoystickConfig *> &sticks);
 IJoystickConfig *I_UpdateDeviceList();
 extern void UpdateJoystickMenu(IJoystickConfig *);

--- a/src/common/menu/joystickmenu.cpp
+++ b/src/common/menu/joystickmenu.cpp
@@ -88,7 +88,7 @@ DEFINE_ACTION_FUNCTION(IJoystickConfig, GetAxisMap)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(IJoystickConfig);
 	PARAM_INT(axis);
-	ACTION_RETURN_INT(self->GetAxisMap(axis));
+	ACTION_RETURN_INT(0);
 }
 
 DEFINE_ACTION_FUNCTION(IJoystickConfig, SetAxisMap)
@@ -96,7 +96,7 @@ DEFINE_ACTION_FUNCTION(IJoystickConfig, SetAxisMap)
 	PARAM_SELF_STRUCT_PROLOGUE(IJoystickConfig);
 	PARAM_INT(axis);
 	PARAM_INT(map);
-	self->SetAxisMap(axis, (EJoyAxis)map);
+	//self->SetAxisMap(axis, (EJoyAxis)map);
 	return 0;
 }
 

--- a/src/common/platform/win32/i_input.cpp
+++ b/src/common/platform/win32/i_input.cpp
@@ -639,14 +639,15 @@ void I_StartFrame ()
 	}
 }
 
-void I_GetAxes(float axes[NUM_JOYAXIS])
+void I_GetAxes(float axes[NUM_KEYS])
 {
 	int i;
 
-	for (i = 0; i < NUM_JOYAXIS; ++i)
+	for (i = 0; i < NUM_KEYS; ++i)
 	{
-		axes[i] = 0;
+		axes[i] = 0.0f;
 	}
+
 	if (use_joystick)
 	{
 		for (i = 0; i < NUM_JOYDEVICES; ++i)

--- a/src/common/platform/win32/i_input.h
+++ b/src/common/platform/win32/i_input.h
@@ -118,7 +118,7 @@ protected:
 class FJoystickCollection : public FInputDevice
 {
 public:
-	virtual void AddAxes(float axes[NUM_JOYAXIS]) = 0;
+	virtual void AddAxes(float axes[NUM_KEYS]) = 0;
 	virtual void GetDevices(TArray<IJoystickConfig *> &sticks) = 0;
 	virtual IJoystickConfig *Rescan() = 0;
 };

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -210,7 +210,9 @@ CVAR (Bool,		freelook,		true,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always mlook?
 CVAR (Bool,		lookstrafe,		false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always strafe with mouse?
 CVAR (Float,	m_forward,		1.f,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
 CVAR (Float,	m_side,			2.f,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
- 
+
+CVAR (Bool, cl_analogstraferun, false, CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
+
 int 			turnheld;								// for accelerative turning 
 
 EXTERN_CVAR (Bool, invertmouse)
@@ -730,6 +732,30 @@ void G_BuildTiccmd (ticcmd_t *cmd)
 	{
 		axis_pitch = axis_forward;
 		axis_forward = 0.0f;
+	}
+
+	if (cl_analogstraferun)
+	{
+		// Rescale diagonal analog input from roughly [0.77, 0.77] to [1.0, 1.0],
+		// which enables analog sticks to be able to strafe run like a keyboard can.
+
+		// Disabled by default because it's inaccurate to how Linux Doom itself
+		// handled analog input, some analog sticks may be able to actually reach 1.0,
+		// some might remap a D-Pad to the stick, so on...
+
+		const float sqrtOf2Frac = 0.41421356237309504880; // sqrt(2)'s fractional value
+
+		float move_min = min<float>(fabs(axis_side), fabs(axis_forward));
+		float move_max = max<float>(fabs(axis_side), fabs(axis_forward));
+
+		float scale = 1.0f;
+		if (move_max > EQUAL_EPSILON)
+		{
+			scale += (move_min / move_max) * sqrtOf2Frac;
+		}
+
+		axis_forward = std::clamp(axis_forward * scale, 0.f, 1.f);
+		axis_side = std::clamp(axis_side * scale, 0.f, 1.f);
 	}
 
 	if (axis_pitch != 0)

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -609,6 +609,9 @@ void G_BuildTiccmd (ticcmd_t *cmd)
 
 	cmd->consistancy = consistancy[consoleplayer][(maketic/ticdup)%BACKUPTICS];
 
+	// Update axis polling for the button map
+	buttonMap.GetAxes();
+
 	strafe = buttonMap.ButtonDown(Button_Strafe);
 	speed = buttonMap.ButtonDown(Button_Speed) ^ (int)cl_run;
 
@@ -617,7 +620,7 @@ void G_BuildTiccmd (ticcmd_t *cmd)
 	// [RH] only use two stage accelerative turning on the keyboard
 	//		and not the joystick, since we treat the joystick as
 	//		the analog device it is.
-	if (buttonMap.ButtonDown(Button_Left) || buttonMap.ButtonDown(Button_Right))
+	if (buttonMap.DigitalButtonDown(Button_Left) || buttonMap.DigitalButtonDown(Button_Right))
 		turnheld += ticdup;
 	else
 		turnheld = 0;
@@ -625,9 +628,9 @@ void G_BuildTiccmd (ticcmd_t *cmd)
 	// let movement keys cancel each other out
 	if (strafe)
 	{
-		if (buttonMap.ButtonDown(Button_Right))
+		if (buttonMap.DigitalButtonDown(Button_Right))
 			side += sidemove[speed];
-		if (buttonMap.ButtonDown(Button_Left))
+		if (buttonMap.DigitalButtonDown(Button_Left))
 			side -= sidemove[speed];
 	}
 	else
@@ -637,48 +640,48 @@ void G_BuildTiccmd (ticcmd_t *cmd)
 		if (turnheld < SLOWTURNTICS)
 			tspeed += 2;		// slow turn
 		
-		if (buttonMap.ButtonDown(Button_Right))
+		if (buttonMap.DigitalButtonDown(Button_Right))
 		{
 			G_AddViewAngle (*angleturn[tspeed]);
 		}
-		if (buttonMap.ButtonDown(Button_Left))
+		if (buttonMap.DigitalButtonDown(Button_Left))
 		{
 			G_AddViewAngle (-*angleturn[tspeed]);
 		}
 	}
 
-	if (buttonMap.ButtonDown(Button_LookUp))
+	if (buttonMap.DigitalButtonDown(Button_LookUp))
 	{
 		G_AddViewPitch (lookspeed[speed]);
 	}
-	if (buttonMap.ButtonDown(Button_LookDown))
+	if (buttonMap.DigitalButtonDown(Button_LookDown))
 	{
 		G_AddViewPitch (-lookspeed[speed]);
 	}
 
-	if (buttonMap.ButtonDown(Button_MoveUp))
+	if (buttonMap.DigitalButtonDown(Button_MoveUp))
 		fly += flyspeed[speed];
-	if (buttonMap.ButtonDown(Button_MoveDown))
+	if (buttonMap.DigitalButtonDown(Button_MoveDown))
 		fly -= flyspeed[speed];
 
 	if (buttonMap.ButtonDown(Button_Klook))
 	{
-		if (buttonMap.ButtonDown(Button_Forward))
+		if (buttonMap.DigitalButtonDown(Button_Forward))
 			G_AddViewPitch (lookspeed[speed]);
-		if (buttonMap.ButtonDown(Button_Back))
+		if (buttonMap.DigitalButtonDown(Button_Back))
 			G_AddViewPitch (-lookspeed[speed]);
 	}
 	else
 	{
-		if (buttonMap.ButtonDown(Button_Forward))
+		if (buttonMap.DigitalButtonDown(Button_Forward))
 			forward += forwardmove[speed];
-		if (buttonMap.ButtonDown(Button_Back))
+		if (buttonMap.DigitalButtonDown(Button_Back))
 			forward -= forwardmove[speed];
 	}
 
-	if (buttonMap.ButtonDown(Button_MoveRight))
+	if (buttonMap.DigitalButtonDown(Button_MoveRight))
 		side += sidemove[speed];
-	if (buttonMap.ButtonDown(Button_MoveLeft))
+	if (buttonMap.DigitalButtonDown(Button_MoveLeft))
 		side -= sidemove[speed];
 
 	// buttons
@@ -710,35 +713,37 @@ void G_BuildTiccmd (ticcmd_t *cmd)
 	if (buttonMap.ButtonDown(Button_ShowScores))	cmd->ucmd.buttons |= BT_SHOWSCORES;
 	if (speed) cmd->ucmd.buttons |= BT_RUN;
 
-	// Handle joysticks/game controllers.
-	float joyaxes[NUM_JOYAXIS];
-
-	I_GetAxes(joyaxes);
-
 	// Remap some axes depending on button state.
+	float axis_yaw = buttonMap.AnalogButtonDown(Button_Left) - buttonMap.AnalogButtonDown(Button_Right);
+	float axis_pitch = buttonMap.AnalogButtonDown(Button_LookUp) - buttonMap.AnalogButtonDown(Button_LookDown);
+	float axis_forward = buttonMap.AnalogButtonDown(Button_Forward) - buttonMap.AnalogButtonDown(Button_Back);
+	float axis_side = buttonMap.AnalogButtonDown(Button_MoveLeft) - buttonMap.AnalogButtonDown(Button_MoveRight);
+	float axis_up = buttonMap.AnalogButtonDown(Button_MoveUp) - buttonMap.AnalogButtonDown(Button_MoveDown);
+
 	if (buttonMap.ButtonDown(Button_Strafe) || (buttonMap.ButtonDown(Button_Mlook) && lookstrafe))
 	{
-		joyaxes[JOYAXIS_Side] = joyaxes[JOYAXIS_Yaw];
-		joyaxes[JOYAXIS_Yaw] = 0;
+		axis_side = axis_yaw;
+		axis_yaw = 0.0f;
 	}
+
 	if (buttonMap.ButtonDown(Button_Mlook))
 	{
-		joyaxes[JOYAXIS_Pitch] = joyaxes[JOYAXIS_Forward];
-		joyaxes[JOYAXIS_Forward] = 0;
+		axis_pitch = axis_forward;
+		axis_forward = 0.0f;
 	}
 
-	if (joyaxes[JOYAXIS_Pitch] != 0)
+	if (axis_pitch != 0)
 	{
-		G_AddViewPitch(joyint(joyaxes[JOYAXIS_Pitch] * 2048));
+		G_AddViewPitch(joyint(axis_pitch * 2048));
 	}
-	if (joyaxes[JOYAXIS_Yaw] != 0)
+	if (axis_yaw != 0)
 	{
-		G_AddViewAngle(joyint(-1280 * joyaxes[JOYAXIS_Yaw]));
+		G_AddViewAngle(joyint(-1280 * axis_yaw));
 	}
 
-	side -= joyint(sidemove[speed] * joyaxes[JOYAXIS_Side]);
-	forward += joyint(joyaxes[JOYAXIS_Forward] * forwardmove[speed]);
-	fly += joyint(joyaxes[JOYAXIS_Up] * 2048);
+	side -= joyint(sidemove[speed] * axis_side);
+	forward += joyint(axis_forward * forwardmove[speed]);
+	fly += joyint(axis_up * 2048);
 
 	// Handle mice.
 	if (!buttonMap.ButtonDown(Button_Mlook) && !freelook)

--- a/wadsrc/static/zscript/engine/ui/menu/joystickmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/joystickmenu.zs
@@ -334,8 +334,6 @@ class OptionMenuItemJoyConfigMenu : OptionMenuItemSubmenu
 					it = new("OptionMenuItemStaticText").Init(" ", false);
 					opt.mItems.Push(it);
 
-					it = new("OptionMenuItemJoyMap").Init(joy.GetAxisName(i), i, "JoyAxisMapNames", false, joy);
-					opt.mItems.Push(it);
 					it = new("OptionMenuSliderJoyScale").Init("$JOYMNU_OVRSENS", i, 0, 4, 0.1, 3, joy);
 					opt.mItems.Push(it);
 					it = new("OptionMenuItemInverter").Init("$JOYMNU_INVERT", i, false, joy);


### PR DESCRIPTION
Removed the separated "axis map" from the gamepad menu. Analog input now piggy-backs off of binds, so you can bind analog movement directly in the controls menu.

Additionally, added a new client console variable, `cl_analogstraferun`. This rescales analog stick movement when moving diagonally to reach [1.0, 1.0], instead of [0.77, 0.77]. Turned off by default, because this does not match Linux Doom's axis behavior, and some weird devices may not play well with it.

I'm doing this for my IWAD's engine branch, since it makes control setup more accessible & straight-forward for new players. It probably needs additional work for inclusion in GZDoom.

## Notes
- cl_analogstraferun has not been added to the menus yet. I'm not actually sure what all needs done for this, or where it should go; does localization need finished for this?
- Backwards compatibility with ZScript is "handled" by dummying out the existing joystick menu action functions to either be NOPs, or return 0. The old menu item class has been left alone, and the menu code simply doesn't create it anymore. Is that OK? Is doing that too much for a GZDoom patch? Should deprecation warnings be placed on anything? etc...
- This tosses around a float array of `NUM_KEYS` size a lot. This feels quite wasteful to me, since only a small fraction of the total keys can have analog input. I've thought about adding a unique lookup table to convert a axis representation integer into the actual key, but I didn't do it because this was more straight-forward for maintenance if new keys need to be added. Thoughts? (I didn't search the codebase for another dictionary-style class I could use, so maybe the answer's straight-forward.)
- Probably needs testing with a lot of controllers! I've tested with a bunch that I have, but there's some very weird controllers out there.