### PR TITLE
Added spawn origin flags.

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2417,6 +2417,7 @@ void Net_DoCommand (int type, uint8_t **stream, int player)
 						AActor *spawned = Spawn (primaryLevel, typeinfo, spawnpos, ALLOW_REPLACE);
 						if (spawned != NULL)
 						{
+							spawned->SpawnFlags |= MTF_CONSOLETHING;
 							if (type == DEM_SUMMONFRIEND || type == DEM_SUMMONFRIEND2 || type == DEM_SUMMONMBF)
 							{
 								if (spawned->CountsAsKill()) 

--- a/src/doomdata.h
+++ b/src/doomdata.h
@@ -424,6 +424,11 @@ enum EMapThingFlags
 	MTF_NOINFIGHTING	= 0x100000,
 	MTF_NOCOUNT			= 0x200000,	// Removes COUNTKILL/COUNTITEM
 
+	// Thing spawn origins, what created this thing?
+	MTF_MAPTHING		= 0x400000, // Map spawned
+	MTF_CONSOLETHING	= 0x800000, // Console spawned (i.e summon)
+	MTF_NONSPAWNTHING	= (MTF_MAPTHING|MTF_CONSOLETHING), // [inkoalawetrust]: Rachael didn't want a dedicated MTF_SPAWNTHING flag taking up the field, so check if the other 2 flags aren't true instead.
+
 	// BOOM and DOOM compatible versions of some of the above
 
 	BTF_NOTSINGLE		= 0x0010,	// (TF_COOPERATIVE|TF_DEATHMATCH)

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -5006,6 +5006,7 @@ void AActor::LevelSpawned ()
 	{
 		flags &= ~MF_DROPPED;
 	}
+	SpawnFlags |= MTF_MAPTHING;
 	HandleSpawnFlags ();
 }
 

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1008,6 +1008,11 @@ enum EMapThingFlags
 	MTF_SECRET			= 0x080000,	// Secret pickup
 	MTF_NOINFIGHTING	= 0x100000,
 	MTF_NOCOUNT			= 0x200000,	// Removes COUNTKILL/COUNTITEM
+
+	// Thing spawn origins, what created this thing?
+	MTF_MAPTHING		= 0x400000, // Map spawned
+	MTF_CONSOLETHING	= 0x800000, // Console spawned (i.e summon)
+	MTF_NONSPAWNTHING	= (MTF_MAPTHING|MTF_CONSOLETHING), // [inkoalawetrust]: Rachael didn't want a dedicated MTF_SPAWNTHING flag taking up the field, so check if the other 2 flags aren't true instead.
 };
 
 enum ESkillProperty


### PR DESCRIPTION
Added new spawn flags that allow for checking if an actor was spawned by the level, the console, or ACS/DECORATE/ZScript.

The below example mod replaces the vanilla Demon with one that prints a console message based on which of these flags is true on it, or if neither are (Which means that it must've been scripte spawned, if not from the console or level itself). It also spawns a pinky at the world origin after 5 seconds in-game.

[SpawnFlagExample.zip](https://github.com/user-attachments/files/18699245/SpawnFlagExample.zip)
