### PR TITLE
Added variables keeping track of where the actor was last tick.

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1362,6 +1362,11 @@ public:
 	TDeletingArray<FLightDefaults *> UserLights;
 	int PrevPortalGroup;
 
+	// [inkoalawetrust] Last tic's position and orientation.
+	DVector3 OldTicPos;
+	DVector3 OldTicVel;
+	DRotator OldTicAngles;
+
 	// When was this actor spawned?
 	int SpawnTime;
 	uint32_t SpawnOrder;

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -397,6 +397,9 @@ void AActor::Serialize(FSerializer &arc)
 		A("WorldOffset", WorldOffset)
 		("modelData", modelData)
 		A("LandingSpeed", LandingSpeed)
+		A("OldTicPos",OldTicPos)
+		A("OldTicVel", OldTicVel)
+		A("OldTicAngles", OldTicAngles)
 
 		("unmorphtime", UnmorphTime)
 		("morphflags", MorphFlags)
@@ -4042,7 +4045,10 @@ void AActor::Tick ()
 			}
 		}
 
-		double oldz = Z();
+		// [inkoalawetrust] Where we were last tic.
+		OldTicVel = Vel;
+		OldTicAngles = Angles;
+		OldTicPos = Pos();
 
 		// [RH] Give the pain elemental vertical friction
 		// This used to be in APainElemental::Tick but in order to use

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -2135,6 +2135,11 @@ DEFINE_FIELD(AActor, UnmorphTime)
 DEFINE_FIELD(AActor, MorphFlags)
 DEFINE_FIELD(AActor, PremorphProperties)
 DEFINE_FIELD(AActor, MorphExitFlash)
+DEFINE_FIELD(AActor, OldTicPos)
+DEFINE_FIELD(AActor, OldTicVel)
+DEFINE_FIELD_NAMED(AActor, OldTicAngles.Yaw, OldTicAngle)
+DEFINE_FIELD_NAMED(AActor, OldTicAngles.Pitch, OldTicPitch)
+DEFINE_FIELD_NAMED(AActor, OldTicAngles.Roll, OldTicRoll)
 
 DEFINE_FIELD_X(FCheckPosition, FCheckPosition, thing);
 DEFINE_FIELD_X(FCheckPosition, FCheckPosition, pos);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -266,6 +266,11 @@ class Actor : Thinker native
 	native Vector2 AutomapOffsets;
 	native double LandingSpeed;
 
+	// [inkoalawetrust] Last tics' info.
+	native Vector3 OldTicPos;
+	native Vector3 OldTicVel;
+	native double OldTicAngle, OldTicPitch, OldTicRoll;
+
 	meta String Obituary;		// Player was killed by this actor
 	meta String HitObituary;		// Player was killed by this actor in melee
 	meta double DeathHeight;	// Height on normal death


### PR DESCRIPTION
Adds OldTicPos, OldTicVel, and OldTicAngle/Pitch/Roll. Allowing for tracking where an actor was last tic and where it was heading. 

Unlike the existing Prev and PrevAngles variables, these aren't bound to rendering interpolation, so they don't reset if movement interpolation is off. They are purely gameplay related. This makes them useful for things like predicting where the actor will head next and keeping a history of where any actor in the game has been.

The below example replaces the pinky with one that prints where it is in the current tic, and where it was in the last tic. Then lobs all pinkies on the map after 5 seconds to also show the velocity tracking.

[LastTicInfo.zip](https://github.com/user-attachments/files/18713637/LastTicInfo.zip)