### PR TITLE
Added PlayerRespawning event

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -871,6 +871,24 @@ void EventManager::PlayerSpawned(int num)
 		handler->PlayerSpawned(num);
 }
 
+bool EventManager::PlayerRespawning(int num)
+{
+	if (ShouldCallStatic(true))
+	{
+		bool res = staticEventManager.PlayerRespawning(num);
+		if (!res)
+			return false;
+	}
+
+	for (DStaticEventHandler* handler = FirstEventHandler; handler; handler = handler->next)
+	{
+		if (!handler->PlayerRespawning(num))
+			return false;
+	}
+
+	return true;
+}
+
 void EventManager::PlayerRespawned(int num)
 {
 	if (ShouldCallStatic(true)) staticEventManager.PlayerRespawned(num);
@@ -2129,6 +2147,22 @@ void DStaticEventHandler::PlayerSpawned(int num)
 		VMValue params[2] = { (DStaticEventHandler*)this, &e };
 		VMCall(func, params, 2, nullptr, 0);
 	}
+}
+
+bool DStaticEventHandler::PlayerRespawning(int num)
+{
+	int res = true;
+	IFVIRTUAL(DStaticEventHandler, PlayerRespawning)
+	{
+		// don't create excessive DObjects if not going to be processed anyway
+		if (isEmpty(func)) return res;
+		FPlayerEvent e = { num, false };
+		VMValue params[] = { (DStaticEventHandler*)this, &e };
+		VMReturn returns[] = { &res };
+		VMCall(func, params, 2, returns, 1);
+	}
+
+	return res;
 }
 
 void DStaticEventHandler::PlayerRespawned(int num)

--- a/src/events.h
+++ b/src/events.h
@@ -331,6 +331,7 @@ public:
 	//
 	void PlayerEntered(int num, bool fromhub);
 	void PlayerSpawned(int num);
+	bool PlayerRespawning(int num);
 	void PlayerRespawned(int num);
 	void PlayerDied(int num);
 	void PlayerDisconnected(int num);
@@ -524,6 +525,8 @@ struct EventManager
 	void PlayerEntered(int num, bool fromhub);
 	// this executes at the same time as ENTER scripts
 	void PlayerSpawned(int num);
+	// Executes when a player is attempting to respawn. Does not include resurrect cheat.
+	bool PlayerRespawning(int num);
 	// this executes when a player respawns. includes resurrect cheat.
 	void PlayerRespawned(int num);
 	// this executes when a player dies (partially duplicating worldthingdied, but whatever)

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1153,7 +1153,7 @@ void G_Ticker ()
 			}
 			if (players[i].playerstate == PST_REBORN || players[i].playerstate == PST_ENTER)
 			{
-				primaryLevel->DoReborn(i, false);
+				primaryLevel->DoReborn(i);
 			}
 		}
 	}
@@ -1766,7 +1766,7 @@ void FLevelLocals::QueueBody (AActor *body)
 // G_DoReborn
 //
 EXTERN_CVAR(Bool, sv_singleplayerrespawn)
-void FLevelLocals::DoReborn (int playernum, bool freshbot)
+void FLevelLocals::DoReborn (int playernum, bool force)
 {
 	if (!multiplayer && !(flags2 & LEVEL2_ALLOWRESPAWN) && !sv_singleplayerrespawn &&
 		!G_SkillProperty(SKILLP_PlayerRespawn))
@@ -1786,6 +1786,13 @@ void FLevelLocals::DoReborn (int playernum, bool freshbot)
 	}
 	else
 	{
+		// Check if the player should be allowed to actually respawn first.
+		if (!force && players[playernum].playerstate == PST_REBORN && !localEventManager->PlayerRespawning(playernum))
+		{
+			players[playernum].playerstate = PST_DEAD;
+			return;
+		}
+
 		bool isUnfriendly;
 
 		PlayerSpawnPickClass(playernum);

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -838,7 +838,7 @@ void FLevelLocals::ChangeLevel(const char *levelname, int position, int inflags,
 					player->mo->special1 = 0;
 				}
 				// ]]
-				DoReborn(i, false);
+				DoReborn(i, true);
 			}
 		}
 	}

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -253,7 +253,7 @@ public:
 	// g_Game
 	void PlayerReborn (int player);
 	bool CheckSpot (int playernum, FPlayerStart *mthing);
-	void DoReborn (int playernum, bool freshbot);
+	void DoReborn (int playernum, bool force = false);
 	void QueueBody (AActor *body);
 	double PlayersRangeFromSpot (FPlayerStart *spot);
 	FPlayerStart *SelectFarthestDeathmatchSpot (size_t selections);

--- a/src/playsim/bots/b_game.cpp
+++ b/src/playsim/bots/b_game.cpp
@@ -396,7 +396,7 @@ bool FCajunMaster::DoAddBot (FLevelLocals *Level, uint8_t *info, botskill_t skil
 	else
 		Printf ("%s joined the game\n", players[bnum].userinfo.GetName());
 
-	Level->DoReborn (bnum, true);
+	Level->DoReborn (bnum);
 	Level->localEventManager->PlayerEntered(bnum, false);
 	return true;
 }

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -184,6 +184,7 @@ class StaticEventHandler : Object native play version("2.4")
     //
     virtual void PlayerEntered(PlayerEvent e) {}
     virtual void PlayerSpawned(PlayerEvent e) {}
+    virtual bool PlayerRespawning(PlayerEvent e) { return true; }
     virtual void PlayerRespawned(PlayerEvent e) {}
     virtual void PlayerDied(PlayerEvent e) {}
     virtual void PlayerDisconnected(PlayerEvent e) {}


### PR DESCRIPTION
Allows denying player respawns for better control on special game modes e.g. Last Man Standing, Survival, etc. Currently the only way to properly do this is by overriding the player itself which isn't optimal for things that have no custom players or want to support other mods. The other solution is eating inputs which is unreliable. Does not prevent the resurrect cheat from working.