### PR TITLE
Fixed ammo and backpack with local items on

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/ammo.zs
+++ b/wadsrc/static/zscript/actors/inventory/ammo.zs
@@ -138,6 +138,9 @@ class Ammo : Inventory
 
 	override Inventory CreateCopy (Actor other)
 	{
+		if (IsCreatingLocalCopy())
+			return Super.CreateCopy(other);
+
 		Inventory copy;
 		int amount = Amount;
 
@@ -250,6 +253,9 @@ class BackpackItem : Inventory
 
 	override Inventory CreateCopy (Actor other)
 	{
+		if (IsCreatingLocalCopy())
+			return Super.CreateCopy(other);
+			
 		// Find every unique type of ammoitem. Give it to the player if
 		// he doesn't have it already, and double its maximum capacity.
 		uint end = AllActorClasses.Size();


### PR DESCRIPTION
Now avoids duplicate calling CreateCopy