### PR TITLE
Custom obituaries for player self kills

### DIFF
--- a/src/playsim/p_interaction.cpp
+++ b/src/playsim/p_interaction.cpp
@@ -244,7 +244,16 @@ void ClientObituary (AActor *self, AActor *inflictor, AActor *attacker, int dmgf
 	{
 		if (attacker == self)
 		{
-			message = "$OB_KILLEDSELF";
+			messagename = "$OB_KILLEDSELF";
+
+			IFVIRTUALPTR(self, AActor, GetSelfObituary)
+			{
+				VMValue params[] = { self, inflictor, mod.GetIndex() };
+				VMReturn rett(&ret);
+				VMCall(func, params, countof(params), &rett, 1);
+				if (ret.IsNotEmpty()) message = ret.GetChars();
+			}
+
 		}
 		else
 		{

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -268,6 +268,7 @@ class Actor : Thinker native
 
 	meta String Obituary;		// Player was killed by this actor
 	meta String HitObituary;		// Player was killed by this actor in melee
+	meta String SelfObituary;	// Player killed himself using this actor
 	meta double DeathHeight;	// Height on normal death
 	meta double BurnHeight;		// Height on burning death
 	meta int GibHealth;			// Negative health below which this monster dies an extreme death
@@ -294,6 +295,7 @@ class Actor : Thinker native
 	Property prefix: none;
 	Property Obituary: Obituary;
 	Property HitObituary: HitObituary;
+	Property SelfObituary: SelfObituary;
 	Property MeleeDamage: MeleeDamage;
 	Property MeleeSound: MeleeSound;
 	Property MissileHeight: MissileHeight;
@@ -666,6 +668,11 @@ class Actor : Thinker native
 			return HitObituary;
 		}
 		return Obituary;
+	}
+
+	virtual String GetSelfObituary(Actor inflictor, Name mod)
+	{
+		return SelfObituary;
 	}
 	
 	virtual int OnDrain(Actor victim, int damage, Name dmgtype)

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -317,6 +317,22 @@ class PlayerPawn : Actor
 			return message;
 		}
 	}
+
+	override String GetSelfObituary(Actor inflictor, Name mod)
+	{
+		String message;
+
+		if (inflictor && inflictor != self)
+		{
+			message = inflictor.GetSelfObituary(inflictor, mod);
+		}
+		if (message.Length() == 0)
+		{
+			message = SelfObituary;
+		}
+
+		return message;
+	}
 	
 	//----------------------------------------------------------------------------
 	//


### PR DESCRIPTION
Adds a SelfObituary property and a virtual function GetSelfObituary to Actor and PlayerPawn. Also modifies ClientObituary to use them.
Allows mod creators to define obituaries for different conditions, like the player dying to his own grenades.
This is my first pull request so I don't know if I can edit Doom actors to add example self obituaries, especially in this case where I would need to add new strings, so I made this quick example file instead. It adds self obituaries to Doom rockets, barrels and also adds a 'VeryStrongPistol' that damages the player with "recoil".
[selfobituarytest.zip](https://github.com/user-attachments/files/18815256/selfobituarytest.zip)

