### PR TITLE
Made the BFG and EXPLOSIVE weapon flags usable again.

### DIFF
--- a/src/gamedata/a_weapons.h
+++ b/src/gamedata/a_weapons.h
@@ -159,5 +159,7 @@ enum
 	WIF_NODEATHINPUT =		0x00020000, // The weapon cannot be fired/reloaded/whatever when the player is dead
 	WIF_CHEATNOTWEAPON	=	0x00040000,	// Give cheat considers this not a weapon (used by Sigil)
 	WIF_NOAUTOSWITCHTO =	0x00080000, // cannot be switched to when autoswitching weapons.
+	WIF_BFG	=				0x00100000, // BFG tier weapon
+	WIF_EXPLOSIVE =			0x00200000, // Weapon is explosive
 };
 

--- a/wadsrc/static/zscript/actors/doom/weaponbfg.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponbfg.zs
@@ -14,6 +14,7 @@ class BFG9000 : DoomWeapon
 		Weapon.AmmoGive 40;
 		Weapon.AmmoType "Cell";
 		+WEAPON.NOAUTOFIRE;
+		+WEAPON.BFG;
 		Inventory.PickupMessage "$GOTBFG9000";
 		Tag "$TAG_BFG9000";
 	}

--- a/wadsrc/static/zscript/actors/doom/weaponrlaunch.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponrlaunch.zs
@@ -13,6 +13,7 @@ class RocketLauncher : DoomWeapon
 		Weapon.AmmoGive 2;
 		Weapon.AmmoType "RocketAmmo";
 		+WEAPON.NOAUTOFIRE
+		+WEAPON.EXPLOSIVE
 		Inventory.PickupMessage "$GOTLAUNCHER";
 		Tag "$TAG_ROCKETLAUNCHER";
 	}

--- a/wadsrc/static/zscript/actors/heretic/weaponphoenix.zs
+++ b/wadsrc/static/zscript/actors/heretic/weaponphoenix.zs
@@ -5,6 +5,7 @@ class PhoenixRod : Weapon
 	Default
 	{
 		+WEAPON.NOAUTOFIRE
+		+WEAPON.EXPLOSIVE
 		Weapon.SelectionOrder 2600;
 		Weapon.Kickback 150;
 		Weapon.YAdjust 15;
@@ -73,6 +74,8 @@ class PhoenixRodPowered : PhoenixRod
 	Default
 	{
 		+WEAPON.POWERED_UP
+		-WEAPON.EXPLOSIVE
+		+WEAPON.BFG
 		Weapon.SisterWeapon "PhoenixRod";
 		Weapon.AmmoGive 0;
 		Tag "$TAG_PHOENIXRODP";

--- a/wadsrc/static/zscript/actors/heretic/weaponskullrod.zs
+++ b/wadsrc/static/zscript/actors/heretic/weaponskullrod.zs
@@ -69,6 +69,7 @@ class SkullRodPowered : SkullRod
 	Default
 	{
 		+WEAPON.POWERED_UP
+		+WEAPON.EXPLOSIVE //[inkoalawetrust] It DOES have a form of AOE splash damage so I think it counts in spirit.
 		Weapon.AmmoUse1 5;
 		Weapon.AmmoGive1 0;
 		Weapon.SisterWeapon "SkullRod";

--- a/wadsrc/static/zscript/actors/hexen/clericflame.zs
+++ b/wadsrc/static/zscript/actors/hexen/clericflame.zs
@@ -14,6 +14,7 @@ class CWeapFlame : ClericWeapon
 		Weapon.AmmoType1 "Mana2";
 		Inventory.PickupMessage "$TXT_WEAPON_C3";
 		Tag "$TAG_CWEAPFLAME";
+		+WEAPON.EXPLOSIVE
 	}
 
 	States

--- a/wadsrc/static/zscript/actors/hexen/clericholy.zs
+++ b/wadsrc/static/zscript/actors/hexen/clericholy.zs
@@ -85,6 +85,7 @@ class CWeapWraithverge : ClericWeapon
 		Health 3;
 		Weapon.SelectionOrder 3000;
 		+WEAPON.PRIMARY_USES_BOTH;
+		+WEAPON.BFG;
 		+Inventory.NoAttenPickupSound
 		Weapon.AmmoUse1 18;
 		Weapon.AmmoUse2 18;

--- a/wadsrc/static/zscript/actors/hexen/fighterhammer.zs
+++ b/wadsrc/static/zscript/actors/hexen/fighterhammer.zs
@@ -10,6 +10,7 @@ class FWeapHammer : FighterWeapon
 		+BLOODSPLATTER
 		Weapon.SelectionOrder 900;
 		+WEAPON.AMMO_OPTIONAL
+		+WEAPON.EXPLOSIVE
 		Weapon.AmmoUse1 3;
 		Weapon.AmmoGive1 25;
 		Weapon.KickBack 150;

--- a/wadsrc/static/zscript/actors/hexen/fighterquietus.zs
+++ b/wadsrc/static/zscript/actors/hexen/fighterquietus.zs
@@ -83,6 +83,7 @@ class FWeapQuietus : FighterWeapon
 		Health 3;
 		Weapon.SelectionOrder 2900;
 		+WEAPON.PRIMARY_USES_BOTH;
+		+WEAPON.EXPLOSIVE
 		+Inventory.NoAttenPickupSound
 		Weapon.AmmoUse1 14;
 		Weapon.AmmoUse2 14;

--- a/wadsrc/static/zscript/actors/hexen/magestaff.zs
+++ b/wadsrc/static/zscript/actors/hexen/magestaff.zs
@@ -93,6 +93,7 @@ class MWeapBloodscourge : MageWeapon
 		Weapon.AmmoType1 "Mana1";
 		Weapon.AmmoType2 "Mana2";
 		+WEAPON.PRIMARY_USES_BOTH;
+		+WEAPON.BFG
 		+Inventory.NoAttenPickupSound
 		Inventory.PickupMessage "$TXT_WEAPON_M4";
 		Inventory.PickupSound "WeaponBuild";

--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -93,12 +93,12 @@ class Weapon : StateProvider
 	flagdef NoDeathInput: WeaponFlags, 17;		// The weapon cannot be fired/reloaded/whatever when the player is dead
 	flagdef CheatNotWeapon: WeaponFlags, 18;	// Give cheat considers this not a weapon (used by Sigil)
 	flagdef NoAutoSwitchTo : WeaponFlags, 19;	// do not auto switch to this weapon ever!
+	flagdef BFG: WeaponFlags, 20;				// This weapon is a BFG (i.e BFG9000 and the Wraithverge)
+	flagdef Explosive: WeaponFlags, 21;			// This weapon is explosive (i.e Doom and Strife's Rocket Launchers)
 
 	// no-op flags
 	flagdef NoLMS: none, 0;
 	flagdef Allow_With_Respawn_Invul: none, 0;
-	flagdef BFG: none, 0;
-	flagdef Explosive: none, 0;
 
 	Default
 	{

--- a/wadsrc/static/zscript/actors/strife/sigil.zs
+++ b/wadsrc/static/zscript/actors/strife/sigil.zs
@@ -13,6 +13,7 @@ class Sigil : Weapon
 		Health 1;
 		+FLOORCLIP
 		+WEAPON.CHEATNOTWEAPON
+		+WEAPON.BFG
 		Inventory.PickupSound "weapons/sigilcharge";
 		Tag "$TAG_SIGIL";
 		Inventory.Icon "I_SGL1";

--- a/wadsrc/static/zscript/actors/strife/weapongrenade.zs
+++ b/wadsrc/static/zscript/actors/strife/weapongrenade.zs
@@ -13,6 +13,7 @@ class StrifeGrenadeLauncher : StrifeWeapon
 		Inventory.Icon "GRNDA0";
 		Tag "$TAG_GLAUNCHER1";
 		Inventory.PickupMessage "$TXT_GLAUNCHER";
+		+WEAPON.EXPLOSIVE
 	}
 
 	States

--- a/wadsrc/static/zscript/actors/strife/weaponmauler.zs
+++ b/wadsrc/static/zscript/actors/strife/weaponmauler.zs
@@ -98,6 +98,7 @@ class Mauler2 : Mauler
 		Weapon.AmmoType1 "EnergyPod";
 		Weapon.SisterWeapon "Mauler";
 		Tag "$TAG_MAULER2";
+		+WEAPON.BFG;
 	}
 
 	States

--- a/wadsrc/static/zscript/actors/strife/weaponmissile.zs
+++ b/wadsrc/static/zscript/actors/strife/weaponmissile.zs
@@ -12,6 +12,7 @@ class MiniMissileLauncher : StrifeWeapon
 		Inventory.Icon "MMSLA0";
 		Tag "$TAG_MMLAUNCHER";
 		Inventory.PickupMessage "$TXT_MMLAUNCHER";
+		+WEAPON.EXPLOSIVE
 	}
 
 	States


### PR DESCRIPTION
- The BFG and EXPLOSIVE flags are now usable instead of being duds, so that such kinds of weapons can be properly marked.
- Marked the appropriate weapons with them for the 3 main supported games.

I looked at videos and info on the Doom wiki for all the non-Doom weapons to mark them appropriately (And some common sense, obviously Strife's mini missile launcher is explosive), I think this covers all the main Doom engine game weapons for those two flags.