### PR TITLE
Exposed DPlat, DDoor, and more of DCeiling to ZScript.

### DIFF
--- a/src/playsim/mapthinkers/a_ceiling.cpp
+++ b/src/playsim/mapthinkers/a_ceiling.cpp
@@ -72,6 +72,31 @@ void DCeiling::Serialize(FSerializer &arc)
 		.Enum("crushmode", m_CrushMode);
 }
 
+DEFINE_FIELD(DCeiling, m_Type)
+DEFINE_FIELD(DCeiling, m_BottomHeight)
+DEFINE_FIELD(DCeiling, m_TopHeight)
+DEFINE_FIELD(DCeiling, m_Speed)
+DEFINE_FIELD(DCeiling, m_Speed1)
+DEFINE_FIELD(DCeiling, m_Speed2)
+DEFINE_FIELD(DCeiling, m_Silent)
+DEFINE_FIELD(DCeiling, m_CrushMode)
+
+DEFINE_ACTION_FUNCTION(DCeiling, getCrush)
+{
+	PARAM_SELF_PROLOGUE(DCeiling);
+	ACTION_RETURN_INT(self->getCrush());
+}
+DEFINE_ACTION_FUNCTION(DCeiling, getDirection)
+{
+	PARAM_SELF_PROLOGUE(DCeiling);
+	ACTION_RETURN_INT(self->getDirection());
+}
+DEFINE_ACTION_FUNCTION(DCeiling, getOldDirection)
+{
+	PARAM_SELF_PROLOGUE(DCeiling);
+	ACTION_RETURN_INT(self->getOldDirection());
+}
+
 //============================================================================
 //
 // 

--- a/src/playsim/mapthinkers/a_ceiling.h
+++ b/src/playsim/mapthinkers/a_ceiling.h
@@ -47,6 +47,14 @@ public:
 		crushSlowdown = 2
 	};
 
+	ECeiling	m_Type;
+	double	 	m_BottomHeight;
+	double	 	m_TopHeight;
+	double	 	m_Speed;
+	double		m_Speed1;		// [RH] dnspeed of crushers
+	double		m_Speed2;		// [RH] upspeed of crushers
+	ECrushMode	m_CrushMode;
+	int			m_Silent;
 
 	void Construct(sector_t *sec);
 	void Construct(sector_t *sec, double speed1, double speed2, int silent);
@@ -56,17 +64,10 @@ public:
 
 	int getCrush() const { return m_Crush; }
 	int getDirection() const { return m_Direction; }
+	int getOldDirection() const { return m_OldDirection; }
 
 protected:
-	ECeiling	m_Type;
-	double	 	m_BottomHeight;
-	double	 	m_TopHeight;
-	double	 	m_Speed;
-	double		m_Speed1;		// [RH] dnspeed of crushers
-	double		m_Speed2;		// [RH] upspeed of crushers
 	int 		m_Crush;
-	ECrushMode	m_CrushMode;
-	int			m_Silent;
 	int 		m_Direction;	// 1 = up, 0 = waiting, -1 = down
 
 	// [RH] Need these for BOOM-ish transferring ceilings

--- a/src/playsim/mapthinkers/a_doors.cpp
+++ b/src/playsim/mapthinkers/a_doors.cpp
@@ -40,6 +40,7 @@
 #include "g_levellocals.h"
 #include "animations.h"
 #include "texturemanager.h"
+#include "vm.h"
 
 //============================================================================
 //
@@ -63,6 +64,17 @@ void DDoor::Serialize(FSerializer &arc)
 		("topcountdown", m_TopCountdown)
 		("lighttag", m_LightTag);
 }
+
+DEFINE_FIELD(DDoor, m_Type)
+DEFINE_FIELD(DDoor, m_TopDist)
+DEFINE_FIELD(DDoor, m_BotSpot)
+DEFINE_FIELD(DDoor, m_BotDist)
+DEFINE_FIELD(DDoor, m_OldFloorDist)
+DEFINE_FIELD(DDoor, m_Speed)
+DEFINE_FIELD(DDoor, m_Direction)
+DEFINE_FIELD(DDoor, m_TopWait)
+DEFINE_FIELD(DDoor, m_TopCountdown)
+DEFINE_FIELD(DDoor, m_LightTag)
 
 //============================================================================
 //

--- a/src/playsim/mapthinkers/a_doors.h
+++ b/src/playsim/mapthinkers/a_doors.h
@@ -17,16 +17,10 @@ public:
 		doorWaitClose,
 	};
 
-	void Construct(sector_t *sector);
-	void Construct(sector_t *sec, EVlDoor type, double speed, int delay, int lightTag, int topcountdown);
-
-	void Serialize(FSerializer &arc);
-	void Tick ();
-protected:
 	EVlDoor		m_Type;
 	double	 	m_TopDist;
 	double		m_BotDist, m_OldFloorDist;
-	vertex_t	*m_BotSpot;
+	vertex_t* m_BotSpot;
 	double	 	m_Speed;
 
 	// 1 = up, 0 = waiting at top, -1 = down
@@ -40,6 +34,12 @@ protected:
 
 	int			m_LightTag;
 
+	void Construct(sector_t *sector);
+	void Construct(sector_t *sec, EVlDoor type, double speed, int delay, int lightTag, int topcountdown);
+
+	void Serialize(FSerializer &arc);
+	void Tick ();
+protected:
 	void DoorSound (bool raise, class DSeqNode *curseq=NULL) const;
 
 private:

--- a/src/playsim/mapthinkers/a_floor.cpp
+++ b/src/playsim/mapthinkers/a_floor.cpp
@@ -903,6 +903,12 @@ void DElevator::Serialize(FSerializer &arc)
 		("interp_ceiling", m_Interp_Ceiling);
 }
 
+DEFINE_FIELD(DElevator, m_Type)
+DEFINE_FIELD(DElevator, m_Direction)
+DEFINE_FIELD(DElevator, m_FloorDestDist)
+DEFINE_FIELD(DElevator, m_CeilingDestDist)
+DEFINE_FIELD(DElevator, m_Speed)
+
 //==========================================================================
 //
 //
@@ -973,7 +979,7 @@ void DElevator::Tick ()
 		}
 	}
 
-	if (res == EMoveResult::pastdest)	// if destination height acheived
+	if (res == EMoveResult::pastdest)	// if destination height achieved
 	{
 		// make floor stop sound
 		SN_StopSequence (m_Sector, CHAN_FLOOR);

--- a/src/playsim/mapthinkers/a_floor.cpp
+++ b/src/playsim/mapthinkers/a_floor.cpp
@@ -96,6 +96,22 @@ void DFloor::Serialize(FSerializer &arc)
 		("instant", m_Instant);
 }
 
+DEFINE_FIELD(DFloor, m_Type)
+DEFINE_FIELD(DFloor, m_Crush)
+DEFINE_FIELD(DFloor, m_Direction)
+DEFINE_FIELD(DFloor, m_NewSpecial)
+DEFINE_FIELD(DFloor, m_Texture)
+DEFINE_FIELD(DFloor, m_FloorDestDist)
+DEFINE_FIELD(DFloor, m_Speed)
+DEFINE_FIELD(DFloor, m_ResetCount)
+DEFINE_FIELD(DFloor, m_OrgDist)
+DEFINE_FIELD(DFloor, m_Delay)
+DEFINE_FIELD(DFloor, m_PauseTime)
+DEFINE_FIELD(DFloor, m_StepTime)
+DEFINE_FIELD(DFloor, m_PerStepTime)
+DEFINE_FIELD(DFloor, m_Hexencrush)
+DEFINE_FIELD(DFloor, m_Instant)
+
 //==========================================================================
 //
 // MOVE A FLOOR TO ITS DESTINATION (UP OR DOWN)

--- a/src/playsim/mapthinkers/a_floor.h
+++ b/src/playsim/mapthinkers/a_floor.h
@@ -105,6 +105,13 @@ public:
 		elevateLower
 	};
 
+	EElevator	m_Type;
+	int			m_Direction;
+	double		m_FloorDestDist;
+	double		m_CeilingDestDist;
+	double		m_Speed;
+
+
 	void Construct(sector_t *sec);
 
 	void OnDestroy() override;
@@ -112,11 +119,6 @@ public:
 	void Tick ();
 
 protected:
-	EElevator	m_Type;
-	int			m_Direction;
-	double		m_FloorDestDist;
-	double		m_CeilingDestDist;
-	double		m_Speed;
 	TObjPtr<DInterpolation*> m_Interp_Ceiling;
 	TObjPtr<DInterpolation*> m_Interp_Floor;
 

--- a/src/playsim/mapthinkers/a_plats.cpp
+++ b/src/playsim/mapthinkers/a_plats.cpp
@@ -36,6 +36,7 @@
 #include "serializer.h"
 #include "p_spec.h"
 #include "g_levellocals.h"
+#include "vm.h"
 
 static FRandom pr_doplat ("DoPlat");
 
@@ -61,6 +62,17 @@ void DPlat::Serialize(FSerializer &arc)
 		("crush", m_Crush)
 		("tag", m_Tag);
 }
+
+DEFINE_FIELD(DPlat, m_Type)
+DEFINE_FIELD(DPlat, m_Speed)
+DEFINE_FIELD(DPlat, m_Low)
+DEFINE_FIELD(DPlat, m_High)
+DEFINE_FIELD(DPlat, m_Wait)
+DEFINE_FIELD(DPlat, m_Count)
+DEFINE_FIELD(DPlat, m_Status)
+DEFINE_FIELD(DPlat, m_OldStatus)
+DEFINE_FIELD(DPlat, m_Crush)
+DEFINE_FIELD(DPlat, m_Tag)
 
 //-----------------------------------------------------------------------------
 //

--- a/src/playsim/mapthinkers/a_plats.h
+++ b/src/playsim/mapthinkers/a_plats.h
@@ -38,8 +38,6 @@ public:
 	bool IsLift() const { return m_Type == platDownWaitUpStay || m_Type == platDownWaitUpStayStone; }
 	void Construct(sector_t *sector);
 
-protected:
-
 	double	 	m_Speed;
 	double	 	m_Low;
 	double	 	m_High;
@@ -50,6 +48,7 @@ protected:
 	int			m_Crush;
 	int 		m_Tag;
 	EPlatType	m_Type;
+protected:
 
 	void PlayPlatSound (const char *sound);
 	const char *GetSoundByType () const;

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -768,6 +768,37 @@ class Floor : MovingFloor native
 		genFloorChg
 	};
 
+	enum EStair
+	{
+		buildUp,
+		buildDown
+	};
+
+	enum EStairType
+	{
+		stairUseSpecials = 1,
+		stairSync = 2,
+		stairCrush = 4,
+	};
+	
+	native readonly EFloor			m_Type;
+	native readonly int				m_Crush;
+	native readonly bool			m_Hexencrush;
+	native readonly bool			m_Instant;
+	native readonly int				m_Direction;
+	native readonly SecSpecial		m_NewSpecial;
+	native readonly TextureID		m_Texture;
+	native readonly double			m_FloorDestDist;
+	native readonly double			m_Speed;
+
+	// [RH] New parameters used to reset and delay stairs
+	native readonly double			m_OrgDist;
+	native readonly int				m_ResetCount;
+	native readonly int				m_Delay;
+	native readonly int				m_PauseTime;
+	native readonly int				m_StepTime;
+	native readonly int				m_PerStepTime;
+
 	deprecated("3.8", "Use Level.CreateFloor() instead") static bool CreateFloor(sector sec, int floortype, line ln, double speed, double height = 0, int crush = -1, int change = 0, bool crushmode = false, bool hereticlower = false)
 	{
 		return level.CreateFloor(sec, floortype, ln, speed, height, crush, change, crushmode, hereticlower);

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -649,6 +649,42 @@ class MovingFloor : Mover native
 class MovingCeiling : Mover native
 {}
 
+class Door : MovingCeiling native
+{
+	enum EVlDoor
+	{
+		doorClose,
+		doorOpen,
+		doorRaise,
+		doorWaitRaise,
+		doorCloseWaitOpen,
+		doorWaitClose,
+	};
+
+	native readonly EVlDoor	m_Type;
+	native readonly double	m_TopDist;
+	native readonly double	m_BotDist, m_OldFloorDist;
+	native readonly Vertex	m_BotSpot;
+	native readonly double	m_Speed;
+	
+	// 1 = up, 0 = waiting at top, -1 = down
+	enum EDirection
+	{
+		dirUp,
+		dirWait,
+		dirDown
+	}
+	native readonly int		m_Direction;
+
+	// tics to wait at the top
+	native readonly int		m_TopWait;
+	// (keep in case a door going down is reset)
+	// when it reaches 0, start going down
+	native readonly int		m_TopCountdown;
+
+	native readonly int		m_LightTag;
+}
+
 class Floor : MovingFloor native
 {
 	// only here so that some constants and functions can be added. Not directly usable yet.

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -675,16 +675,16 @@ class Plat : MovingFloor native
 
 	bool IsLift() const { return m_Type == platDownWaitUpStay || m_Type == platDownWaitUpStayStone; }
 
-	native double m_Speed;
-	native double m_Low;
-	native double m_High;
-	native int m_Wait;
-	native int m_Count;
-	native EPlatState m_Status;
+	native readonly double m_Speed;
+	native readonly double m_Low;
+	native readonly double m_High;
+	native readonly int m_Wait;
+	native readonly int m_Count;
+	native readonly EPlatState m_Status;
 	native readonly EPlatState m_OldStatus;
-	native int m_Crush;
-	native int m_Tag;
-	native EPlatType m_Type;
+	native readonly int m_Crush;
+	native readonly int m_Tag;
+	native readonly EPlatType m_Type;
 }
 
 class MovingCeiling : Mover native
@@ -711,9 +711,9 @@ class Door : MovingCeiling native
 	// 1 = up, 0 = waiting at top, -1 = down
 	enum EDirection
 	{
-		dirUp,
+		dirDown = -1,
 		dirWait,
-		dirDown
+		dirUp,
 	}
 	native readonly int		m_Direction;
 
@@ -813,7 +813,29 @@ class Ceiling : MovingCeiling native
 		crushHexen = 1,
 		crushSlowdown = 2
 	}
-	
+
+	// 1 = up, 0 = waiting, -1 = down
+	enum EDirection
+	{
+		dirDown = -1,
+		dirWait,
+		dirUp,
+	}
+
+	native readonly ECeiling	m_Type;
+	native readonly double	 	m_BottomHeight;
+	native readonly double	 	m_TopHeight;
+	native readonly double	 	m_Speed;
+	native readonly double		m_Speed1;		// [RH] dnspeed of crushers
+	native readonly double		m_Speed2;		// [RH] upspeed of crushers
+	native readonly ECrushMode	m_CrushMode;
+	native readonly int			m_Silent;
+
+	bool IsCrusher() const { return m_Type == ceilCrushAndRaise || m_Type == ceilLowerAndCrush || m_Type == ceilCrushRaiseAndStay; }
+	native int getCrush() const;
+	native int getDirection() const;
+	native int getOldDirection() const;
+
 	deprecated("3.8", "Use Level.CreateCeiling() instead") static bool CreateCeiling(sector sec, int type, line ln, double speed, double speed2, double height = 0, int crush = -1, int silent = 0, int change = 0, int crushmode = crushDoom)
 	{
 		return level.CreateCeiling(sec, type, ln, speed, speed2, height, crush, silent, change, crushmode);

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -643,6 +643,25 @@ class SectorEffect : Thinker native
 class Mover : SectorEffect native
 {}
 
+class Elevator : Mover native
+{
+	enum EElevator
+	{
+		elevateUp,
+		elevateDown,
+		elevateCurrent,
+		// [RH] For FloorAndCeiling_Raise/Lower
+		elevateRaise,
+		elevateLower
+	};
+
+	native readonly EElevator	m_Type;
+	native readonly int			m_Direction;
+	native readonly double		m_FloorDestDist;
+	native readonly double		m_CeilingDestDist;
+	native readonly double		m_Speed;
+}
+
 class MovingFloor : Mover native
 {}
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -646,6 +646,47 @@ class Mover : SectorEffect native
 class MovingFloor : Mover native
 {}
 
+class Plat : MovingFloor native
+{
+	enum EPlatState
+	{
+		up,
+		down,
+		waiting,
+		in_stasis
+	};
+
+	enum EPlatType
+	{
+		platPerpetualRaise,
+		platDownWaitUpStay,
+		platDownWaitUpStayStone,
+		platUpWaitDownStay,
+		platUpNearestWaitDownStay,
+		platDownByValue,
+		platUpByValue,
+		platUpByValueStay,
+		platRaiseAndStay,
+		platToggle,
+		platDownToNearestFloor,
+		platDownToLowestCeiling,
+		platRaiseAndStayLockout,
+	};
+
+	bool IsLift() const { return m_Type == platDownWaitUpStay || m_Type == platDownWaitUpStayStone; }
+
+	native double m_Speed;
+	native double m_Low;
+	native double m_High;
+	native int m_Wait;
+	native int m_Count;
+	native EPlatState m_Status;
+	native readonly EPlatState m_OldStatus;
+	native int m_Crush;
+	native int m_Tag;
+	native EPlatType m_Type;
+}
+
 class MovingCeiling : Mover native
 {}
 


### PR DESCRIPTION
This PR exposes DDoor and DPlat to ZScript, alongside some of their getter methods. And also exposes the rest of DCeiling's fields. Everything is read-only. Allowing for mods to get more information on what a sector is currently doing.

Below is an example gun called "DebugPistol", when alt-fired it will print info about the attached lift or door thinkers in the sector you're standing on, if there's any. And also print the name of any thinkers stored in the sectors' ceiling/floordata.
[SectorThinkerPrinter.zip](https://github.com/user-attachments/files/18927248/SectorThinkerPrinter.zip)