### PR TITLE
Allow external handling of internal ACS functions from other ports

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -158,6 +158,7 @@ void I_ShutdownInput();
 void SetConsoleNotifyBuffer();
 void I_UpdateDiscordPresence(bool SendPresence, const char* curstatus, const char* appid, const char* steamappid);
 bool M_SetSpecialMenu(FName& menu, int param);	// game specific checks
+void SetHandledACSFunctions();
 
 const FIWADInfo *D_FindIWAD(TArray<FString> &wadfiles, const char *iwad, const char *basewad);
 void InitWidgetResources(const char* basewad);
@@ -3086,6 +3087,7 @@ static int FileSystemPrintf(FSMessageLevel level, const char* fmt, ...)
 static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allwads, std::vector<std::string>& pwads)
 {
 	NetworkEntityManager::InitializeNetworkEntities();
+	SetHandledACSFunctions();
 
 	if (!restart)
 	{

--- a/src/events.h
+++ b/src/events.h
@@ -345,6 +345,7 @@ public:
 	// 
 	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3, bool manual, bool ui);
 	void NetCommandProcess(FNetworkCommand& cmd);
+	void ACSFunctionProcess(int func, const TArray<int>* args, int& res);
 
 	//
 	void CheckReplacement(PClassActor* replacee, PClassActor** replacement, bool* final);
@@ -539,6 +540,8 @@ struct EventManager
 	void Console(int player, FString name, int arg1, int arg2, int arg3, bool manual, bool ui);
 	// This reads from ZScript network commands.
 	void NetCommand(FNetworkCommand& cmd);
+	// Custom handling for known but unsupported ACS events.
+	int ProcessACSFunction(int func, const TArray<int>* args);
 
 	// called when looking up the replacement for an actor class
 	bool CheckReplacement(PClassActor* replacee, PClassActor** replacement);

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -144,6 +144,71 @@ struct ReplacedEvent native version("3.7")
 	native bool IsFinal;
 }
 
+enum EACSFunction
+{
+    ACSF_ResetMap = 100,
+    ACSF_PlayerIsSpectator,
+
+    ACSF_GetTeamProperty = 103,
+    ACSF_GetPlayerLivesLeft,
+    ACSF_SetPlayerLivesLeft,
+    ACSF_KickFromGame,
+    ACSF_GetGamemodeState,
+    ACSF_SetDBEntry,
+    ACSF_GetDBEntry,
+    ACSF_SetDBEntryString,
+    ACSF_GetDBEntryString,
+    ACSF_IncrementDBEntry,
+    ACSF_PlayerIsLoggedIn,
+    ACSF_GetPlayerAccountName,
+    ACSF_SortDBEntries,
+    ACSF_CountDBResults,
+    ACSF_FreeDBResults,
+    ACSF_GetDBResultKeyString,
+    ACSF_GetDBResultValueString,
+    ACSF_GetDBResultValue,
+    ACSF_GetDBEntryRank,
+    ACSF_RequestScriptPuke,
+    ACSF_BeginDBTransaction,
+    ACSF_EndDBTransaction,
+    ACSF_GetDBEntries,
+    ACSF_NamedRequestScriptPuke,
+
+    ACSF_SetDeadSpectator = 130,
+    ACSF_SetActivatorToPlayer,
+    ACSF_SetCurrentGamemode,
+    ACSF_GetCurrentGamemode,
+    ACSF_SetGamemodeLimit,
+
+    ACSF_SetPlayerChasecam = 136,
+    ACSF_GetPlayerChasecam,
+    ACSF_SetPlayerScore,
+    ACSF_GetPlayerScore,
+    ACSF_InDemoMode,
+
+    ACSF_SendNetworkString = 146,
+    ACSF_NamedSendNetworkString,
+    ACSF_GetChatMessage,
+    ACSF_GetMapRotationSize,
+    ACSF_GetMapRotationInfo,
+    ACSF_GetCurrentMapPosition,
+    ACSF_GetEventResult,
+    ACSF_GetActorSectorLocation,
+    ACSF_ChangeTeamScore,
+    ACSF_SetGameplaySettings,
+    ACSF_SetCustomPlayerValue,
+    ACSF_GetCustomPlayerValue,
+    ACSF_ResetCustomDataToDefault,
+    ACSF_LumpOpen,
+    ACSF_LumpRead,
+    ACSF_LumpReadString,
+
+    ACSF_LumpGetInfo = 166,
+    ACSF_LumpClose,
+
+    ACSF_SetAirFriction = 302,
+}
+
 class StaticEventHandler : Object native play version("2.4")
 {
     // static event handlers CAN register other static event handlers.
@@ -200,6 +265,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual ui void InterfaceProcess(ConsoleEvent e) {}
     virtual void NetworkProcess(ConsoleEvent e) {}
     version("4.12") virtual void NetworkCommandProcess(NetworkCommand cmd) {}
+    version("4.15") virtual int ACSFunctionProcess(EACSFunction func, Array<int> args) { return 0; }
     
     //
     virtual void CheckReplacement(ReplaceEvent e) {}


### PR DESCRIPTION
This is a feature geared towards allowing mods to handle certain ACS functions that will never be ported to GZDoom due to how they're handled internally. For example, Zandronum's multiplayer gamemodes can be recreated entirely via ZScript giving no reason to bake them in; however, Zandronum maps that rely on these ACS functions will be unusable. This is a huge barrier for gamemodes like Invasion because while all classes and gamemode handling can be ported properly, the ACS functions will never be able to. This PR allows you to hook up these ACS functions to your own custom API, finally resolving the largest hurdle to compatibility with other ports.

I'm going to mark this as a draft for now since I want to discuss realistically what should and shouldn't be allowed to be handled. While some functionality is a given (gamemode getters/setters), others are less clear like the database functionality. While technically GZDoom doesn't support this and someone could easily set up their own database handling by hooking into these functions, it's also possible it'll be added in the future and hooking these functions up to that would be much smarter. Other functions can easily be baked into GZDoom, they just need to be merged over correctly.

The current list of handled functions is not complete and is likely to change. I mostly want to get this up now to gather some thoughts on it before fully committing since I'm also not sure how smart it is to expose the internals of ACS like this.