### PR TITLE
ZScript improvements

### DIFF
--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -12748,16 +12748,15 @@ ExpEmit FxFunctionPtrCast::Emit(VMFunctionBuilder *build)
 FxLocalVariableDeclaration::FxLocalVariableDeclaration(PType *type, FName name, FxExpression *initval, int varflags, const FScriptPosition &p)
 	:FxExpression(EFX_LocalVariableDeclaration, p)
 {
-	// Local FVector isn't different from Vector
-	if (type == TypeFVector2) type = TypeVector2;
-	else if (type == TypeFVector3) type = TypeVector3;
-	else if (type == TypeFVector4) type = TypeVector4;
-	else if (type == TypeFQuaternion) type = TypeQuaternion;
+	if(type != type->GetLocalType())
+	{
+		ScriptPosition.Message(MSG_WARNING, "Type '%s' not allowed in local variables, changing to '%s'", type->DescriptiveName(), type->GetLocalType()->DescriptiveName());
+	}
 
-	ValueType = type;
+	ValueType = type->GetLocalType();
 	VarFlags = varflags;
 	Name = name;
-	RegCount = type->RegCount;
+	RegCount = ValueType->RegCount;
 	Init = initval;
 	clearExpr = nullptr;
 }

--- a/src/common/scripting/core/types.cpp
+++ b/src/common/scripting/core/types.cpp
@@ -401,6 +401,7 @@ void PType::StaticInit()
 	TypeFVector2->RegType = REGT_FLOAT;
 	TypeFVector2->RegCount = 2;
 	TypeFVector2->isOrdered = true;
+	TypeFVector2->SetLocalType(TypeVector2);
 
 	TypeFVector3 = new PStruct(NAME_FVector3, nullptr);
 	TypeFVector3->AddField(NAME_X, TypeFloat32);
@@ -415,6 +416,7 @@ void PType::StaticInit()
 	TypeFVector3->RegType = REGT_FLOAT;
 	TypeFVector3->RegCount = 3;
 	TypeFVector3->isOrdered = true;
+	TypeFVector3->SetLocalType(TypeVector3);
 
 	TypeFVector4 = new PStruct(NAME_FVector4, nullptr);
 	TypeFVector4->AddField(NAME_X, TypeFloat32);
@@ -431,6 +433,7 @@ void PType::StaticInit()
 	TypeFVector4->RegType = REGT_FLOAT;
 	TypeFVector4->RegCount = 4;
 	TypeFVector4->isOrdered = true;
+	TypeFVector4->SetLocalType(TypeVector4);
 
 
 	TypeQuaternion = new PStruct(NAME_Quat, nullptr);
@@ -464,6 +467,7 @@ void PType::StaticInit()
 	TypeFQuaternion->RegType = REGT_FLOAT;
 	TypeFQuaternion->RegCount = 4;
 	TypeFQuaternion->isOrdered = true;
+	TypeFQuaternion->SetLocalType(TypeQuaternion);
 
 
 	Namespaces.GlobalNamespace->Symbols.AddSymbol(Create<PSymbolType>(NAME_sByte, TypeSInt8));

--- a/src/common/scripting/core/types.cpp
+++ b/src/common/scripting/core/types.cpp
@@ -359,6 +359,7 @@ void PType::StaticInit()
 	TypeVector2->RegType = REGT_FLOAT;
 	TypeVector2->RegCount = 2;
 	TypeVector2->isOrdered = true;
+	TypeVector2->mDescriptiveName = "Vector2";
 
 	TypeVector3 = new PStruct(NAME_Vector3, nullptr);
 	TypeVector3->AddField(NAME_X, TypeFloat64);
@@ -373,6 +374,7 @@ void PType::StaticInit()
 	TypeVector3->RegType = REGT_FLOAT;
 	TypeVector3->RegCount = 3;
 	TypeVector3->isOrdered = true;
+	TypeVector3->mDescriptiveName = "Vector3";
 
 	TypeVector4 = new PStruct(NAME_Vector4, nullptr);
 	TypeVector4->AddField(NAME_X, TypeFloat64);
@@ -389,6 +391,7 @@ void PType::StaticInit()
 	TypeVector4->RegType = REGT_FLOAT;
 	TypeVector4->RegCount = 4;
 	TypeVector4->isOrdered = true;
+	TypeVector4->mDescriptiveName = "Vector4";
 
 
 	TypeFVector2 = new PStruct(NAME_FVector2, nullptr);
@@ -401,6 +404,7 @@ void PType::StaticInit()
 	TypeFVector2->RegType = REGT_FLOAT;
 	TypeFVector2->RegCount = 2;
 	TypeFVector2->isOrdered = true;
+	TypeFVector2->mDescriptiveName = "FVector2";
 	TypeFVector2->SetLocalType(TypeVector2);
 
 	TypeFVector3 = new PStruct(NAME_FVector3, nullptr);
@@ -416,6 +420,7 @@ void PType::StaticInit()
 	TypeFVector3->RegType = REGT_FLOAT;
 	TypeFVector3->RegCount = 3;
 	TypeFVector3->isOrdered = true;
+	TypeFVector3->mDescriptiveName = "FVector3";
 	TypeFVector3->SetLocalType(TypeVector3);
 
 	TypeFVector4 = new PStruct(NAME_FVector4, nullptr);
@@ -433,6 +438,7 @@ void PType::StaticInit()
 	TypeFVector4->RegType = REGT_FLOAT;
 	TypeFVector4->RegCount = 4;
 	TypeFVector4->isOrdered = true;
+	TypeFVector4->mDescriptiveName = "FVector4";
 	TypeFVector4->SetLocalType(TypeVector4);
 
 
@@ -450,6 +456,7 @@ void PType::StaticInit()
 	TypeQuaternion->moveOp = OP_MOVEV4;
 	TypeQuaternion->RegType = REGT_FLOAT;
 	TypeQuaternion->RegCount = 4;
+	TypeQuaternion->mDescriptiveName = "Quat";
 	TypeQuaternion->isOrdered = true;
 
 	TypeFQuaternion = new PStruct(NAME_FQuat, nullptr);
@@ -467,6 +474,7 @@ void PType::StaticInit()
 	TypeFQuaternion->RegType = REGT_FLOAT;
 	TypeFQuaternion->RegCount = 4;
 	TypeFQuaternion->isOrdered = true;
+	TypeFQuaternion->mDescriptiveName = "FQuat";
 	TypeFQuaternion->SetLocalType(TypeQuaternion);
 
 

--- a/src/common/scripting/core/types.h
+++ b/src/common/scripting/core/types.h
@@ -110,6 +110,11 @@ public:
 	EScopeFlags ScopeFlags = (EScopeFlags)0;
 	bool            SizeKnown = true;
 
+	PType * LocalType = nullptr;
+
+	PType * SetLocalType(PType * LocalType) { this->LocalType = LocalType; return this; }
+	PType * GetLocalType() { return LocalType ? LocalType : this; }
+
 	PType(unsigned int size = 1, unsigned int align = 1);
 	virtual ~PType();
 	virtual bool isNumeric() { return false; }

--- a/src/common/scripting/core/types.h
+++ b/src/common/scripting/core/types.h
@@ -111,6 +111,8 @@ public:
 	bool            SizeKnown = true;
 
 	bool			TypeInternal = false;
+	bool			TypeDeprecated = false; // mVersion is deprecation version, not minimum version
+	FString			mDeprecationMessage;
 
 	PType * LocalType = nullptr;
 

--- a/src/common/scripting/core/types.h
+++ b/src/common/scripting/core/types.h
@@ -110,6 +110,8 @@ public:
 	EScopeFlags ScopeFlags = (EScopeFlags)0;
 	bool            SizeKnown = true;
 
+	bool			TypeInternal = false;
+
 	PType * LocalType = nullptr;
 
 	PType * SetLocalType(PType * LocalType) { this->LocalType = LocalType; return this; }

--- a/src/common/scripting/frontend/zcc-parse.lemon
+++ b/src/common/scripting/frontend/zcc-parse.lemon
@@ -80,6 +80,7 @@ static void SetNodeLine(ZCC_TreeNode *name, int line)
 		ZCC_Identifier *Replaces;
 		ZCC_Identifier *Sealed;
 		VersionInfo Version;
+		FString *DeprecationMessage;
 	};
 
 	struct StateOpts {
@@ -232,6 +233,7 @@ class_head(X) ::= EXTEND CLASS(T) IDENTIFIER(A).
 	head->Version = {0, 0};
 	head->Type = nullptr;
 	head->Symbol = nullptr;
+	head->DeprecationMessage = nullptr;
 	X = head;
 }
 
@@ -247,6 +249,7 @@ class_head(X) ::= CLASS(T) IDENTIFIER(A) class_ancestry(B) class_flags(C).
 	head->Version = C.Version;
 	head->Type = nullptr;
 	head->Symbol = nullptr;
+	head->DeprecationMessage = C.DeprecationMessage;
 	X = head;
 }
 
@@ -255,15 +258,24 @@ class_ancestry(X) ::= .						{ X = NULL; }
 class_ancestry(X) ::= COLON dottable_id(A).	{ X = A; /*X-overwrites-A*/ }
 
 %type class_flags{ClassFlagsBlock}
-class_flags(X) ::= .										{ X.Flags = 0; X.Replaces = NULL; X.Version = {0,0}; X.Sealed = NULL; }
-class_flags(X) ::= class_flags(A) ABSTRACT.					{ X.Flags = A.Flags | ZCC_Abstract; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed = A.Sealed; }
-class_flags(X) ::= class_flags(A) FINAL.					{ X.Flags = A.Flags | ZCC_Final; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed =  A.Sealed;}
-class_flags(X) ::= class_flags(A) NATIVE.					{ X.Flags = A.Flags | ZCC_Native; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed =  A.Sealed; }
-class_flags(X) ::= class_flags(A) UI.						{ X.Flags = A.Flags | ZCC_UIFlag; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed =  A.Sealed; }
-class_flags(X) ::= class_flags(A) PLAY.						{ X.Flags = A.Flags | ZCC_Play; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed =  A.Sealed; }
-class_flags(X) ::= class_flags(A) REPLACES dottable_id(B).	{ X.Flags = A.Flags; X.Replaces = B; X.Version = A.Version; X.Sealed = A.Sealed; }
-class_flags(X) ::= class_flags(A) VERSION LPAREN STRCONST(C) RPAREN.	{ X.Flags = A.Flags | ZCC_Version; X.Replaces = A.Replaces; X.Version = C.String->GetChars(); X.Sealed =  A.Sealed; }
-class_flags(X) ::= class_flags(A) SEALED LPAREN states_opt(B) RPAREN.		{ X.Flags = A.Flags | ZCC_Sealed; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed = B; }
+class_flags(X) ::= .										{ X.Flags = 0; X.Replaces = NULL; X.Version = {0,0}; X.Sealed = NULL; X.DeprecationMessage = NULL; }
+class_flags(X) ::= class_flags(A) ABSTRACT.					{ X.Flags = A.Flags | ZCC_Abstract; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed = A.Sealed; X.DeprecationMessage = A.DeprecationMessage; }
+class_flags(X) ::= class_flags(A) FINAL.					{ X.Flags = A.Flags | ZCC_Final; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed = A.Sealed; X.DeprecationMessage = A.DeprecationMessage; }
+class_flags(X) ::= class_flags(A) NATIVE.					{ X.Flags = A.Flags | ZCC_Native; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed = A.Sealed; X.DeprecationMessage = A.DeprecationMessage; }
+class_flags(X) ::= class_flags(A) UI.						{ X.Flags = A.Flags | ZCC_UIFlag; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed = A.Sealed; X.DeprecationMessage = A.DeprecationMessage; }
+class_flags(X) ::= class_flags(A) PLAY.						{ X.Flags = A.Flags | ZCC_Play; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed = A.Sealed; X.DeprecationMessage = A.DeprecationMessage; }
+class_flags(X) ::= class_flags(A) REPLACES dottable_id(B).	{ X.Flags = A.Flags; X.Replaces = B; X.Version = A.Version; X.Sealed = A.Sealed; X.DeprecationMessage = A.DeprecationMessage; }
+class_flags(X) ::= class_flags(A) VERSION LPAREN STRCONST(C) RPAREN.	{ X.Flags = A.Flags | ZCC_Version; X.Replaces = A.Replaces; X.Version = C.String->GetChars(); X.Sealed = A.Sealed; X.DeprecationMessage = A.DeprecationMessage; }
+class_flags(X) ::= class_flags(A) SEALED LPAREN states_opt(B) RPAREN.		{ X.Flags = A.Flags | ZCC_Sealed; X.Replaces = A.Replaces; X.Version = A.Version; X.Sealed = B; X.DeprecationMessage = A.DeprecationMessage; }
+
+class_flags(X) ::= class_flags(A) DEPRECATED LPAREN STRCONST(C) opt_deprecation_message(D) RPAREN.
+{
+	X.Flags = A.Flags | ZCC_Deprecated;
+	X.Replaces = A.Replaces;
+	X.Version = C.String->GetChars();
+	X.Sealed =  A.Sealed;
+	X.DeprecationMessage = D.String;
+}
 
 /*----- Dottable Identifier -----*/
 // This can be either a single identifier or two identifiers connected by a .
@@ -412,6 +424,7 @@ struct_def(X) ::= STRUCT(T) IDENTIFIER(A) struct_flags(S) LBRACE opt_struct_body
 	def->Symbol = nullptr;
 	def->Version = S.Version;
 	def->Flags = S.Flags;
+	def->DeprecationMessage = S.DeprecationMessage;
 	X = def;
 }
 
@@ -422,18 +435,27 @@ struct_def(X) ::= EXTEND STRUCT(T) IDENTIFIER(A) LBRACE opt_struct_body(B) RBRAC
 	def->Body = B;
 	def->Type = nullptr;
 	def->Symbol = nullptr;
+	def->Version = {0, 0};
 	def->Flags = ZCC_Extension;
+	def->DeprecationMessage = nullptr;
 	X = def;
 }
 
 %type struct_flags{ClassFlagsBlock}
-struct_flags(X) ::= .										{ X.Flags = 0; X.Version = {0, 0}; }
-struct_flags(X) ::= struct_flags(A) UI.						{ X.Flags = A.Flags | ZCC_UIFlag; }
-struct_flags(X) ::= struct_flags(A) PLAY.					{ X.Flags = A.Flags | ZCC_Play; }
-struct_flags(X) ::= struct_flags(A) CLEARSCOPE.				{ X.Flags = A.Flags | ZCC_ClearScope; }
-struct_flags(X) ::= struct_flags(A) NATIVE.					{ X.Flags = A.Flags | ZCC_Native; }
-struct_flags(X) ::= struct_flags(A) INTERNAL.				{ X.Flags = A.Flags | ZCC_Internal; }
-struct_flags(X) ::= struct_flags(A) VERSION LPAREN STRCONST(C) RPAREN.	{ X.Flags = A.Flags | ZCC_Version; X.Version = C.String->GetChars(); }
+struct_flags(X) ::= .										{ X.Flags = 0; X.Version = {0, 0}; X.DeprecationMessage = NULL; }
+struct_flags(X) ::= struct_flags(A) UI.						{ X.Flags = A.Flags | ZCC_UIFlag; X.Version = A.Version; X.DeprecationMessage = A.DeprecationMessage; }
+struct_flags(X) ::= struct_flags(A) PLAY.					{ X.Flags = A.Flags | ZCC_Play; X.Version = A.Version; X.DeprecationMessage = A.DeprecationMessage; }
+struct_flags(X) ::= struct_flags(A) CLEARSCOPE.				{ X.Flags = A.Flags | ZCC_ClearScope; X.Version = A.Version; X.DeprecationMessage = A.DeprecationMessage; }
+struct_flags(X) ::= struct_flags(A) NATIVE.					{ X.Flags = A.Flags | ZCC_Native; X.Version = A.Version; X.DeprecationMessage = A.DeprecationMessage; }
+struct_flags(X) ::= struct_flags(A) INTERNAL.				{ X.Flags = A.Flags | ZCC_Internal; X.Version = A.Version; X.DeprecationMessage = A.DeprecationMessage; }
+struct_flags(X) ::= struct_flags(A) VERSION LPAREN STRCONST(C) RPAREN.	{ X.Flags = A.Flags | ZCC_Version; X.Version = C.String->GetChars(); X.DeprecationMessage = A.DeprecationMessage; }
+
+struct_flags(X) ::= struct_flags(A) DEPRECATED LPAREN STRCONST(C) opt_deprecation_message(D) RPAREN.
+{
+	X.Flags = A.Flags | ZCC_Deprecated;
+	X.Version = C.String->GetChars();
+	X.DeprecationMessage = D.String;
+}
 
 opt_struct_body(X) ::= .								{ X = NULL; }
 opt_struct_body(X) ::= struct_body(X).

--- a/src/common/scripting/frontend/zcc-parse.lemon
+++ b/src/common/scripting/frontend/zcc-parse.lemon
@@ -432,6 +432,7 @@ struct_flags(X) ::= struct_flags(A) UI.						{ X.Flags = A.Flags | ZCC_UIFlag; }
 struct_flags(X) ::= struct_flags(A) PLAY.					{ X.Flags = A.Flags | ZCC_Play; }
 struct_flags(X) ::= struct_flags(A) CLEARSCOPE.				{ X.Flags = A.Flags | ZCC_ClearScope; }
 struct_flags(X) ::= struct_flags(A) NATIVE.					{ X.Flags = A.Flags | ZCC_Native; }
+struct_flags(X) ::= struct_flags(A) INTERNAL.				{ X.Flags = A.Flags | ZCC_Internal; }
 struct_flags(X) ::= struct_flags(A) VERSION LPAREN STRCONST(C) RPAREN.	{ X.Flags = A.Flags | ZCC_Version; X.Version = C.String->GetChars(); }
 
 opt_struct_body(X) ::= .								{ X = NULL; }

--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -760,7 +760,14 @@ void ZCCCompiler::CreateStructTypes()
 
 		if (s->strct->Flags & ZCC_Internal)
 		{
-			s->strct->Type->TypeInternal = true;
+			if(fileSystem.GetFileContainer(Lump) == 0)
+			{
+				s->strct->Type->TypeInternal = true;
+			}
+			else
+			{
+				Error(s->strct, "Internal structs are only allowed in the root pk3");
+			}
 		}
 
 		auto &sf = s->Type()->ScopeFlags;

--- a/src/common/scripting/frontend/zcc_compile.h
+++ b/src/common/scripting/frontend/zcc_compile.h
@@ -134,7 +134,7 @@ protected:
 	FString FlagsToString(uint32_t flags);
 	PType *DetermineType(PType *outertype, ZCC_TreeNode *field, FName name, ZCC_Type *ztype, bool allowarraytypes, bool formember);
 	PType *ResolveArraySize(PType *baseType, ZCC_Expression *arraysize, PContainerType *cls, bool *nosize);
-	PType *ResolveUserType(ZCC_BasicType *type, ZCC_Identifier *id, PSymbolTable *sym, bool nativetype);
+	PType *ResolveUserType(PType *outertype, ZCC_BasicType *type, ZCC_Identifier *id, PSymbolTable *sym, bool nativetype);
 	static FString UserTypeName(ZCC_BasicType *type);
 	TArray<ZCC_StructWork *> OrderStructs();
 	void AddStruct(TArray<ZCC_StructWork *> &new_order, ZCC_StructWork *struct_def);

--- a/src/common/scripting/frontend/zcc_parser.h
+++ b/src/common/scripting/frontend/zcc_parser.h
@@ -243,6 +243,7 @@ struct ZCC_Struct : ZCC_NamedNode
 	ZCC_TreeNode *Body;
 	PContainerType *Type;
 	VersionInfo Version;
+	FString *DeprecationMessage;
 };
 
 struct ZCC_Property : ZCC_NamedNode

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -189,7 +189,7 @@ struct Vector3
 }
 */
 
-struct _ native	// These are the global variables, the struct is only here to avoid extending the parser for this.
+struct _ native internal	// These are the global variables, the struct is only here to avoid extending the parser for this.
 {
 	native readonly Array<class> AllClasses;
     native internal readonly Map<Name , Service> AllServices;
@@ -903,7 +903,7 @@ enum EmptyTokenType
 
 // Although String is a builtin type, this is a convenient way to attach methods to it.
 // All of these methods are available on strings
-struct StringStruct native
+struct StringStruct native internal
 {
 	native static vararg String Format(String fmt, ...);
 	native vararg void AppendFormat(String fmt, ...);
@@ -952,7 +952,7 @@ struct Translation version("2.4")
 }
 
 // Convenient way to attach functions to Quat
-struct QuatStruct native
+struct QuatStruct native internal
 {
 	native static Quat SLerp(Quat from, Quat to, double t);
 	native static Quat NLerp(Quat from, Quat to, double t);

--- a/wadsrc/static/zscript/engine/dictionary.zs
+++ b/wadsrc/static/zscript/engine/dictionary.zs
@@ -5,7 +5,7 @@
  *
  * @note keys are case-sensitive.
  */
-class Dictionary
+class Dictionary deprecated("4.15", "Use Map<String, String> instead")
 {
 	native static Dictionary Create();
 
@@ -38,7 +38,7 @@ class Dictionary
  * DictionaryIterator is not serializable. To make DictionaryIterator a class
  * member, use `transient` keyword.
  */
-class DictionaryIterator
+class DictionaryIterator deprecated("4.15", "Use Map<String, String> instead")
 {
 	native static DictionaryIterator Create(Dictionary dict);
 

--- a/wadsrc/static/zscript/engine/dynarrays.zs
+++ b/wadsrc/static/zscript/engine/dynarrays.zs
@@ -1,7 +1,7 @@
 // The VM uses 7 integral data types, so for dynamic array support we need one specific set of functions for each of these types.
 // Do not use these structs directly, they are incomplete and only needed to create prototypes for the needed functions.
 
-struct DynArray_I8 native
+struct DynArray_I8 native internal
 {
 	native readonly int Size;
 	
@@ -21,7 +21,7 @@ struct DynArray_I8 native
 	native void Clear ();
 }
 
-struct DynArray_I16 native
+struct DynArray_I16 native internal
 {
 	native readonly int Size;
 
@@ -41,7 +41,7 @@ struct DynArray_I16 native
 	native void Clear ();
 }
 
-struct DynArray_I32 native
+struct DynArray_I32 native internal
 {
 	native readonly int Size;
 
@@ -62,7 +62,7 @@ struct DynArray_I32 native
 	native void Clear ();
 }
 
-struct DynArray_F32 native
+struct DynArray_F32 native internal
 {
 	native readonly int Size;
 	
@@ -82,7 +82,7 @@ struct DynArray_F32 native
 	native void Clear ();
 }
 
-struct DynArray_F64 native
+struct DynArray_F64 native internal
 {
 	native readonly int Size;
 	
@@ -102,7 +102,7 @@ struct DynArray_F64 native
 	native void Clear ();
 }
 
-struct DynArray_Ptr native
+struct DynArray_Ptr native internal
 {
 	native readonly int Size;
 	
@@ -122,7 +122,7 @@ struct DynArray_Ptr native
 	native void Clear ();
 }
 
-struct DynArray_Obj native
+struct DynArray_Obj native internal
 {
 	native readonly int Size;
 	
@@ -142,7 +142,7 @@ struct DynArray_Obj native
 	native void Clear ();
 }
 
-struct DynArray_String native
+struct DynArray_String native internal
 {
 	native readonly int Size;
 

--- a/wadsrc/static/zscript/engine/maps.zs
+++ b/wadsrc/static/zscript/engine/maps.zs
@@ -1,5 +1,5 @@
 
-struct Map_I32_I8 native
+struct Map_I32_I8 native internal
 {
     native void Copy(Map_I32_I8 other);
     native void Move(Map_I32_I8 other);
@@ -18,7 +18,7 @@ struct Map_I32_I8 native
     native void Remove(int key);
 }
 
-struct MapIterator_I32_I8 native
+struct MapIterator_I32_I8 native internal
 {
     native bool Init(Map_I32_I8 other);
     native bool ReInit();
@@ -31,7 +31,7 @@ struct MapIterator_I32_I8 native
     native void SetValue(int value);
 }
 
-struct Map_I32_I16 native
+struct Map_I32_I16 native internal
 {
     native void Copy(Map_I32_I16 other);
     native void Move(Map_I32_I16 other);
@@ -50,7 +50,7 @@ struct Map_I32_I16 native
     native void Remove(int key);
 }
 
-struct MapIterator_I32_I16 native
+struct MapIterator_I32_I16 native internal
 {
     native bool Init(Map_I32_I16 other);
     native bool ReInit();
@@ -63,7 +63,7 @@ struct MapIterator_I32_I16 native
     native void SetValue(int value);
 }
 
-struct Map_I32_I32 native
+struct Map_I32_I32 native internal
 {
     native void Copy(Map_I32_I32 other);
     native void Move(Map_I32_I32 other);
@@ -82,7 +82,7 @@ struct Map_I32_I32 native
     native void Remove(int key);
 }
 
-struct MapIterator_I32_I32 native
+struct MapIterator_I32_I32 native internal
 {
     native bool Init(Map_I32_I32 other);
     native bool ReInit();
@@ -95,7 +95,7 @@ struct MapIterator_I32_I32 native
     native void SetValue(int value);
 }
 
-struct Map_I32_F32 native
+struct Map_I32_F32 native internal
 {
     native void Copy(Map_I32_F32 other);
     native void Move(Map_I32_F32 other);
@@ -114,7 +114,7 @@ struct Map_I32_F32 native
     native void Remove(int key);
 }
 
-struct MapIterator_I32_F32 native
+struct MapIterator_I32_F32 native internal
 {
     native bool Init(Map_I32_F32 other);
     native bool ReInit();
@@ -127,7 +127,7 @@ struct MapIterator_I32_F32 native
     native void SetValue(double value);
 }
 
-struct Map_I32_F64 native
+struct Map_I32_F64 native internal
 {
     native void Copy(Map_I32_F64 other);
     native void Move(Map_I32_F64 other);
@@ -146,7 +146,7 @@ struct Map_I32_F64 native
     native void Remove(int key);
 }
 
-struct MapIterator_I32_F64 native
+struct MapIterator_I32_F64 native internal
 {
     native bool Init(Map_I32_F64 other);
     native bool ReInit();
@@ -159,7 +159,7 @@ struct MapIterator_I32_F64 native
     native void SetValue(double value);
 }
 
-struct Map_I32_Obj native
+struct Map_I32_Obj native internal
 {
     native void Copy(Map_I32_Obj other);
     native void Move(Map_I32_Obj other);
@@ -178,7 +178,7 @@ struct Map_I32_Obj native
     native void Remove(int key);
 }
 
-struct MapIterator_I32_Obj native
+struct MapIterator_I32_Obj native internal
 {
     native bool Init(Map_I32_Obj other);
     native bool ReInit();
@@ -191,7 +191,7 @@ struct MapIterator_I32_Obj native
     native void SetValue(Object value);
 }
 
-struct Map_I32_Ptr native
+struct Map_I32_Ptr native internal
 {
     native void Copy(Map_I32_Ptr other);
     native void Move(Map_I32_Ptr other);
@@ -210,7 +210,7 @@ struct Map_I32_Ptr native
     native void Remove(int key);
 }
 
-struct MapIterator_I32_Ptr native
+struct MapIterator_I32_Ptr native internal
 {
     native bool Init(Map_I32_Ptr other);
     native bool Next();
@@ -220,7 +220,7 @@ struct MapIterator_I32_Ptr native
     native void SetValue(voidptr value);
 }
 
-struct Map_I32_Str native
+struct Map_I32_Str native internal
 {
     native void Copy(Map_I32_Str other);
     native void Move(Map_I32_Str other);
@@ -239,7 +239,7 @@ struct Map_I32_Str native
     native void Remove(int key);
 }
 
-struct MapIterator_I32_Str native
+struct MapIterator_I32_Str native internal
 {
     native bool Init(Map_I32_Str other);
     native bool ReInit();
@@ -254,7 +254,7 @@ struct MapIterator_I32_Str native
 
 // ---------------
 
-struct Map_Str_I8 native
+struct Map_Str_I8 native internal
 {
     native void Copy(Map_Str_I8 other);
     native void Move(Map_Str_I8 other);
@@ -273,7 +273,7 @@ struct Map_Str_I8 native
     native void Remove(String key);
 }
 
-struct MapIterator_Str_I8 native
+struct MapIterator_Str_I8 native internal
 {
     native bool Init(Map_Str_I8 other);
     native bool ReInit();
@@ -286,7 +286,7 @@ struct MapIterator_Str_I8 native
     native void SetValue(int value);
 }
 
-struct Map_Str_I16 native
+struct Map_Str_I16 native internal
 {
     native void Copy(Map_Str_I16 other);
     native void Move(Map_Str_I16 other);
@@ -305,7 +305,7 @@ struct Map_Str_I16 native
     native void Remove(String key);
 }
 
-struct MapIterator_Str_I16 native
+struct MapIterator_Str_I16 native internal
 {
     native bool Init(Map_Str_I16 other);
     native bool ReInit();
@@ -318,7 +318,7 @@ struct MapIterator_Str_I16 native
     native void SetValue(int value);
 }
 
-struct Map_Str_I32 native
+struct Map_Str_I32 native internal
 {
     native void Copy(Map_Str_I32 other);
     native void Move(Map_Str_I32 other);
@@ -337,7 +337,7 @@ struct Map_Str_I32 native
     native void Remove(String key);
 }
 
-struct MapIterator_Str_I32 native
+struct MapIterator_Str_I32 native internal
 {
     native bool Init(Map_Str_I32 other);
     native bool ReInit();
@@ -350,7 +350,7 @@ struct MapIterator_Str_I32 native
     native void SetValue(int value);
 }
 
-struct Map_Str_F32 native
+struct Map_Str_F32 native internal
 {
     native void Copy(Map_Str_F32 other);
     native void Move(Map_Str_F32 other);
@@ -369,7 +369,7 @@ struct Map_Str_F32 native
     native void Remove(String key);
 }
 
-struct MapIterator_Str_F32 native
+struct MapIterator_Str_F32 native internal
 {
     native bool Init(Map_Str_F32 other);
     native bool ReInit();
@@ -382,7 +382,7 @@ struct MapIterator_Str_F32 native
     native void SetValue(double value);
 }
 
-struct Map_Str_F64 native
+struct Map_Str_F64 native internal
 {
     native void Copy(Map_Str_F64 other);
     native void Move(Map_Str_F64 other);
@@ -401,7 +401,7 @@ struct Map_Str_F64 native
     native void Remove(String key);
 }
 
-struct MapIterator_Str_F64 native
+struct MapIterator_Str_F64 native internal
 {
     native bool Init(Map_Str_F64 other);
     native bool ReInit();
@@ -414,7 +414,7 @@ struct MapIterator_Str_F64 native
     native void SetValue(double value);
 }
 
-struct Map_Str_Obj native
+struct Map_Str_Obj native internal
 {
     native void Copy(Map_Str_Obj other);
     native void Move(Map_Str_Obj other);
@@ -433,7 +433,7 @@ struct Map_Str_Obj native
     native void Remove(String key);
 }
 
-struct MapIterator_Str_Obj native
+struct MapIterator_Str_Obj native internal
 {
     native bool Init(Map_Str_Obj other);
     native bool ReInit();
@@ -446,7 +446,7 @@ struct MapIterator_Str_Obj native
     native void SetValue(Object value);
 }
 
-struct Map_Str_Ptr native
+struct Map_Str_Ptr native internal
 {
     native void Copy(Map_Str_Ptr other);
     native void Move(Map_Str_Ptr other);
@@ -465,7 +465,7 @@ struct Map_Str_Ptr native
     native void Remove(String key);
 }
 
-struct MapIterator_Str_Ptr native
+struct MapIterator_Str_Ptr native internal
 {
     native bool Init(Map_Str_Ptr other);
     native bool ReInit();
@@ -478,7 +478,7 @@ struct MapIterator_Str_Ptr native
     native void SetValue(voidptr value);
 }
 
-struct Map_Str_Str native
+struct Map_Str_Str native internal
 {
     native void Copy(Map_Str_Str other);
     native void Move(Map_Str_Str other);
@@ -497,7 +497,7 @@ struct Map_Str_Str native
     native void Remove(String key);
 }
 
-struct MapIterator_Str_Str native
+struct MapIterator_Str_Str native internal
 {
     native bool Init(Map_Str_Str other);
     native bool ReInit();


### PR DESCRIPTION
* show warning messages when using FVectors in local variables
* allow classes to be marked as internal to disallow directly referencing backing types (ex. StringStruct/DynArray_*/Map_*_*/etc)
* allow deprecation of classes/structs, deprecate Dictionary