### PR TITLE
Lobby Overhaul

### DIFF
--- a/libraries/ZWidget/include/zwidget/widgets/listview/listview.h
+++ b/libraries/ZWidget/include/zwidget/widgets/listview/listview.h
@@ -12,7 +12,12 @@ class ListView : public Widget
 public:
 	ListView(Widget* parent = nullptr);
 
-	void AddItem(const std::string& text);
+	void SetColumnWidths(const std::vector<double>& widths);
+	void AddItem(const std::string& text, int index = -1, int column = 0);
+	void UpdateItem(const std::string& text, int index, int column = 0);
+	void RemoveItem(int index = -1);
+	size_t GetItemAmount() const { return items.size(); }
+	size_t GetColumnAmount() const { return columnwidths.size(); }
 	int GetSelectedItem() const { return selectedItem; }
 	void SetSelectedItem(int index);
 	void ScrollToItem(int index);
@@ -34,6 +39,7 @@ protected:
 
 	Scrollbar* scrollbar = nullptr;
 
-	std::vector<std::string> items;
+	std::vector<std::vector<std::string>> items;
+	std::vector<double> columnwidths;
 	int selectedItem = 0;
 };

--- a/libraries/ZWidget/src/widgets/listview/listview.cpp
+++ b/libraries/ZWidget/src/widgets/listview/listview.cpp
@@ -8,11 +8,90 @@ ListView::ListView(Widget* parent) : Widget(parent)
 
 	scrollbar = new Scrollbar(this);
 	scrollbar->FuncScroll = [=]() { OnScrollbarScroll(); };
+
+	SetColumnWidths({ 0.0 });
 }
 
-void ListView::AddItem(const std::string& text)
+void ListView::SetColumnWidths(const std::vector<double>& widths)
 {
-	items.push_back(text);
+	columnwidths = widths;
+
+	bool updated = false;
+	const size_t newWidth = columnwidths.size();
+	for (std::vector<std::string>& column : items)
+	{
+		while (column.size() < newWidth)
+		{
+			updated = true;
+			column.push_back("");
+		}
+		while (column.size() > newWidth)
+		{
+			updated = true;
+			column.erase(column.end());
+		}
+	}
+
+	if (updated)
+		Update();
+}
+
+void ListView::AddItem(const std::string& text, int index, int column)
+{
+	if (column < 0 || column >= columnwidths.size())
+		return;
+
+	std::vector<std::string> newEntry;
+	for (size_t i = 0u; i < columnwidths.size(); ++i)
+		newEntry.push_back("");
+
+	newEntry[column] = text;
+	if (index >= 0)
+	{
+		if (index >= items.size())
+		{
+			newEntry[column] = "";
+			while (items.size() < index)
+				items.push_back(newEntry);
+
+			newEntry[column] = text;
+			items.push_back(newEntry);
+		}
+		else
+		{
+			items.insert(items.begin() + index, newEntry);
+		}
+	}
+	else
+	{
+		items.push_back(newEntry);
+	}
+	scrollbar->SetRanges(GetHeight(), items.size() * 20.0);
+	Update();
+}
+
+void ListView::UpdateItem(const std::string& text, int index, int column)
+{
+	if (index < 0 || index >= items.size() || column < 0 || column >= columnwidths.size())
+		return;
+
+	items[index][column] = text;
+	Update();
+}
+
+void ListView::RemoveItem(int index)
+{
+	if (!items.size() || index >= items.size())
+		return;
+
+	if (index < 0)
+		index = items.size() - 1;
+
+	if (selectedItem == index)
+		SetSelectedItem(0);
+
+	items.erase(items.begin() + index);
+	scrollbar->SetRanges(GetHeight(), items.size() * 20.0);
 	Update();
 }
 
@@ -68,7 +147,7 @@ void ListView::OnPaint(Canvas* canvas)
 	double h = 20.0;
 
 	int index = 0;
-	for (const std::string& item : items)
+	for (const std::vector<std::string>& item : items)
 	{
 		double itemY = y;
 		if (itemY + h >= 0.0 && itemY < GetHeight())
@@ -77,7 +156,12 @@ void ListView::OnPaint(Canvas* canvas)
 			{
 				canvas->fillRect(Rect::xywh(x - 2.0, itemY, w, h), Colorf::fromRgba8(100, 100, 100));
 			}
-			canvas->drawText(Point(x, y + 15.0), Colorf::fromRgba8(255, 255, 255), item);
+			double cx = x;
+			for (size_t entry = 0u; entry < item.size(); ++entry)
+			{
+				canvas->drawText(Point(cx, y + 15.0), Colorf::fromRgba8(255, 255, 255), item[entry]);
+				cx += columnwidths[entry];
+			}
 		}
 		y += h;
 		index++;

--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -76,13 +76,8 @@
 #include "printf.h"
 #include "i_interface.h"
 #include "c_cvars.h"
-
-
+#include "version.h"
 #include "i_net.h"
-
-// As per http://support.microsoft.com/kb/q192599/ the standard
-// size for network buffers is 8k.
-#define TRANSMIT_SIZE		8000
 
 /* [Petteri] Get more portable: */
 #ifndef __WIN32__
@@ -103,14 +98,83 @@ typedef int SOCKET;
 
 #ifdef __WIN32__
 typedef int socklen_t;
+const char* neterror(void);
+#else
+#define neterror() strerror(errno)
 #endif
 
-constexpr int MaxPlayers = 16; // TODO: This needs to be put in some kind of unified header later
+// As per http://support.microsoft.com/kb/q192599/ the standard
+// size for network buffers is 8k.
+constexpr size_t MaxTransmitSize = 8000u;
+constexpr size_t MinCompressionSize = 10u;
 constexpr size_t MaxPasswordSize = 256u;
 
-bool netgame, multiplayer;
-int consoleplayer; // i.e. myconnectindex in Build. 
-doomcom_t doomcom;
+enum ENetConnectType : uint8_t
+{
+	PRE_HEARTBEAT,			// Host and guests are keep each other's connections alive
+	PRE_CONNECT,			// Sent from guest to host for initial connection
+	PRE_CONNECT_ACK,		// Sent from host to guest to confirm they've been connected
+	PRE_DISCONNECT,			// Sent from host to guest when another guest leaves
+	PRE_USER_INFO,			// Host and guests are sending each other user infos
+	PRE_USER_INFO_ACK,		// Host and guests are confirming sent user infos
+	PRE_GAME_INFO,			// Sent from host to guest containing general game info
+	PRE_GAME_INFO_ACK,		// Sent from guest to host confirming game info was gotten
+	PRE_GO,					// Sent from host to guest telling them to start the game
+
+	PRE_FULL,				// Sent from host to guest if the lobby is full
+	PRE_IN_PROGRESS,		// Sent from host to guest if the game has already started
+	PRE_WRONG_PASSWORD,		// Sent from host to guest if their provided password was wrong
+	PRE_WRONG_ENGINE,		// Sent from host to guest if their engine version doesn't match the host's
+	PRE_INVALID_FILES,		// Sent from host to guest if their files do not match the host's
+	PRE_KICKED,				// Sent from hsot to guest if the host kicked them from the game
+	PRE_BANNED,				// Sent from host to guest if the host banned them from the game
+};
+
+enum EConnectionStatus
+{
+	CSTAT_NONE,			// Guest isn't connected
+	CSTAT_CONNECTING,	// Guest is trying to connect
+	CSTAT_WAITING,		// Guest is waiting for game info
+	CSTAT_READY,		// Guest is ready to start the game
+};
+
+// These need to be synced with the window backends so information about each
+// client can be properly displayed.
+enum EConnectionFlags : unsigned int
+{
+	CFL_NONE			= 0,
+	CFL_CONSOLEPLAYER	= 1,
+	CFL_HOST			= 1 << 1,
+};
+
+struct FConnection
+{
+	EConnectionStatus Status = CSTAT_NONE;
+	sockaddr_in Address = {};
+	uint64_t InfoAck = 0u;
+	bool bHasGameInfo = false;
+};
+
+bool netgame = false;
+bool multiplayer = false;
+ENetMode NetMode = NET_PeerToPeer;
+int consoleplayer = -1;
+int Net_Arbitrator = 0;
+FClientStack NetworkClients = {};
+
+uint32_t GameID = DEFAULT_GAME_ID;
+uint8_t	TicDup = 1u;
+uint8_t	MaxClients = 1u;
+int RemoteClient = -1;
+size_t NetBufferLength = 0u;
+uint8_t NetBuffer[MAX_MSGLEN] = {};
+
+static u_short		GamePort = (IPPORT_USERRESERVED + 29);
+static SOCKET		MySocket = INVALID_SOCKET;
+static FConnection	Connected[MAXPLAYERS] = {};
+static uint8_t		TransmitBuffer[MaxTransmitSize] = {};
+static TArray<sockaddr_in> BannedConnections = {};
+static bool bGameStarted = false;
 
 CUSTOM_CVAR(String, net_password, "", CVAR_IGNORE)
 {
@@ -121,857 +185,115 @@ CUSTOM_CVAR(String, net_password, "", CVAR_IGNORE)
 	}
 }
 
-FClientStack NetworkClients;
+void Net_SetupUserInfo();
+const char* Net_GetClientName(int client, unsigned int charLimit);
+int Net_SetUserInfo(int client, uint8_t*& stream);
+int Net_ReadUserInfo(int client, uint8_t*& stream);
+int Net_ReadGameInfo(uint8_t*& stream);
+int Net_SetGameInfo(uint8_t*& stream);
 
-//
-// NETWORKING
-//
-
-static u_short DOOMPORT = (IPPORT_USERRESERVED + 29);
-static SOCKET mysocket = INVALID_SOCKET;
-static sockaddr_in sendaddress[MaxPlayers];
-
-#ifdef __WIN32__
-const char *neterror (void);
-#else
-#define neterror() strerror(errno)
-#endif
-
-enum
+static SOCKET CreateUDPSocket()
 {
-	PRE_CONNECT,			// Sent from guest to host for initial connection
-	PRE_KEEPALIVE,
-	PRE_DISCONNECT,			// Sent from guest that aborts the game
-	PRE_ALLHERE,			// Sent from host to guest when everybody has connected
-	PRE_CONACK,				// Sent from host to guest to acknowledge PRE_CONNECT receipt
-	PRE_ALLFULL,			// Sent from host to an unwanted guest
-	PRE_ALLHEREACK,			// Sent from guest to host to acknowledge PRE_ALLHEREACK receipt
-	PRE_GO,					// Sent from host to guest to continue game startup
-	PRE_IN_PROGRESS,		// Sent from host to guest if the game has already started
-	PRE_WRONG_PASSWORD,		// Sent from host to guest if their provided password was wrong
-};
-
-// Set PreGamePacket.fake to this so that the game rejects any pregame packets
-// after it starts. This translates to NCMD_SETUP|NCMD_MULTI.
-#define PRE_FAKE 0x30
-
-struct PreGameConnectPacket
-{
-	uint8_t Fake;
-	uint8_t Message;
-	char Password[MaxPasswordSize];
-};
-
-struct PreGamePacket
-{
-	uint8_t Fake;
-	uint8_t Message;
-	uint8_t NumNodes;
-	union
-	{
-		uint8_t ConsoleNum;
-		uint8_t NumPresent;
-	};
-	struct
-	{
-		uint32_t address;
-		uint16_t port;
-		uint16_t pad;
-	} machines[MaxPlayers];
-};
-
-uint8_t TransmitBuffer[TRANSMIT_SIZE];
-
-FString GetPlayerName(int num)
-{
-	if (sysCallbacks.GetPlayerName) return sysCallbacks.GetPlayerName(num);
-	else return FStringf("Player %d", num + 1);
-}
-
-//
-// UDPsocket
-//
-SOCKET UDPsocket (void)
-{
-	SOCKET s;
-
-	// allocate a socket
-	s = socket (PF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	SOCKET s = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	if (s == INVALID_SOCKET)
-		I_FatalError ("can't create socket: %s", neterror ());
+		I_FatalError("Couldn't create socket: %s", neterror());
 
 	return s;
 }
 
-//
-// BindToLocalPort
-//
-void BindToLocalPort (SOCKET s, u_short port)
+static void BindToLocalPort(SOCKET s, u_short port)
 {
-	int v;
-	sockaddr_in address;
-
-	memset (&address, 0, sizeof(address));
+	sockaddr_in address = {};
 	address.sin_family = AF_INET;
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(port);
 
-	v = bind (s, (sockaddr *)&address, sizeof(address));
+	int v = bind(s, (sockaddr *)&address, sizeof(address));
 	if (v == SOCKET_ERROR)
-		I_FatalError ("BindToPort: %s", neterror ());
+		I_FatalError("Couldn't bind to port: %s", neterror());
 }
 
-void I_ClearNode(int node)
+static void BuildAddress(sockaddr_in& address, const char* addrName)
 {
-	memset(&sendaddress[node], 0, sizeof(sendaddress[node]));
-}
-
-static bool I_ShouldStartNetGame()
-{
-	if (doomcom.consoleplayer != 0)
-		return false;
-
-	return StartWindow->ShouldStartNet();
-}
-
-int FindNode (const sockaddr_in *address)
-{
-	int i = 0;
-
-	// find remote node number
-	for (; i < doomcom.numplayers; ++i)
+	FString target = {};
+	u_short port = GamePort;
+	const char* portName = strchr(addrName, ':');
+	if (portName != nullptr)
 	{
-		if (address->sin_addr.s_addr == sendaddress[i].sin_addr.s_addr
-			&& address->sin_port == sendaddress[i].sin_port)
-		{
-			break;
-		}
-	}
-
-	return (i == doomcom.numplayers) ? -1 : i;
-}
-
-//
-// PacketSend
-//
-void PacketSend (void)
-{
-	int c;
-
-	// FIXME: Catch this before we've overflown the buffer. With long chat
-	// text and lots of backup tics, it could conceivably happen. (Though
-	// apparently it hasn't yet, which is good.)
-	if (doomcom.datalength > MAX_MSGLEN)
-	{
-		I_FatalError("Netbuffer overflow!");
-	}
-	assert(!(doomcom.data[0] & NCMD_COMPRESSED));
-
-	uLong size = TRANSMIT_SIZE - 1;
-	if (doomcom.datalength >= 10)
-	{
-		TransmitBuffer[0] = doomcom.data[0] | NCMD_COMPRESSED;
-		c = compress2(TransmitBuffer + 1, &size, doomcom.data + 1, doomcom.datalength - 1, 9);
-		size += 1;
+		target = FString(addrName, portName - addrName);
+		u_short portConversion = atoi(portName + 1);
+		if (!portConversion)
+			Printf("Malformed port: %s (using %d)\n", portName + 1, GamePort);
+		else
+			port = portConversion;
 	}
 	else
 	{
-		c = -1;	// Just some random error code to avoid sending the compressed buffer.
-	}
-	if (c == Z_OK && size < (uLong)doomcom.datalength)
-	{
-//		Printf("send %lu/%d\n", size, doomcom.datalength);
-		c = sendto(mysocket, (char *)TransmitBuffer, size,
-			0, (sockaddr *)&sendaddress[doomcom.remoteplayer],
-			sizeof(sendaddress[doomcom.remoteplayer]));
-	}
-	else
-	{
-		if (doomcom.datalength > TRANSMIT_SIZE)
-		{
-			I_Error("Net compression failed (zlib error %d)", c);
-		}
-		else
-		{
-//			Printf("send %d\n", doomcom.datalength);
-			c = sendto(mysocket, (char *)doomcom.data, doomcom.datalength,
-				0, (sockaddr *)&sendaddress[doomcom.remoteplayer],
-				sizeof(sendaddress[doomcom.remoteplayer]));
-		}
-	}
-	//	if (c == -1)
-	//			I_Error ("SendPacket error: %s",strerror(errno));
-}
-
-void PreSend(const void* buffer, int bufferlen, const sockaddr_in* to);
-void SendConAck(int num_connected, int num_needed);
-
-//
-// PacketGet
-//
-void PacketGet (void)
-{
-	int c;
-	socklen_t fromlen;
-	sockaddr_in fromaddress;
-	int node;
-
-	fromlen = sizeof(fromaddress);
-	c = recvfrom (mysocket, (char*)TransmitBuffer, TRANSMIT_SIZE, 0,
-				  (sockaddr *)&fromaddress, &fromlen);
-	node = FindNode (&fromaddress);
-
-	if (node >= 0 && c == SOCKET_ERROR)
-	{
-		int err = WSAGetLastError();
-
-		if (err == WSAECONNRESET)
-		{ // The remote node aborted unexpectedly, so pretend it sent an exit packet
-
-			if (StartWindow != NULL)
-			{
-				I_NetMessage ("The connection from %s was dropped.\n",
-					GetPlayerName(node).GetChars());
-			}
-			else
-			{
-				Printf("The connection from %s was dropped.\n",
-					GetPlayerName(node).GetChars());
-			}
-
-			doomcom.data[0] = NCMD_EXIT;
-			c = 1;
-		}
-		else if (err != WSAEWOULDBLOCK)
-		{
-			I_Error ("GetPacket: %s", neterror ());
-		}
-		else
-		{
-			doomcom.remoteplayer = -1;		// no packet
-			return;
-		}
-	}
-	else if (node >= 0 && c > 0)
-	{
-		doomcom.data[0] = TransmitBuffer[0] & ~NCMD_COMPRESSED;
-		if (TransmitBuffer[0] & NCMD_COMPRESSED)
-		{
-			uLongf msgsize = MAX_MSGLEN - 1;
-			int err = uncompress(doomcom.data + 1, &msgsize, TransmitBuffer + 1, c - 1);
-//			Printf("recv %d/%lu\n", c, msgsize + 1);
-			if (err != Z_OK)
-			{
-				Printf("Net decompression failed (zlib error %s)\n", M_ZLibError(err).GetChars());
-				// Pretend no packet
-				doomcom.remoteplayer = -1;
-				return;
-			}
-			c = msgsize + 1;
-		}
-		else
-		{
-//			Printf("recv %d\n", c);
-			memcpy(doomcom.data + 1, TransmitBuffer + 1, c - 1);
-		}
-	}
-	else if (c > 0)
-	{	//The packet is not from any in-game node, so we might as well discard it.
-		if (TransmitBuffer[0] == PRE_FAKE)
-		{
-			// If it's someone waiting in the lobby, let them know the game already started
-			uint8_t msg[] = { PRE_FAKE, PRE_IN_PROGRESS };
-			PreSend(msg, 2, &fromaddress);
-		}
-		doomcom.remoteplayer = -1;
-		return;
+		target = addrName;
 	}
 
-	doomcom.remoteplayer = node;
-	doomcom.datalength = (short)c;
-}
-
-sockaddr_in *PreGet (void *buffer, int bufferlen, bool noabort)
-{
-	static sockaddr_in fromaddress;
-	socklen_t fromlen;
-	int c;
-
-	fromlen = sizeof(fromaddress);
-	c = recvfrom (mysocket, (char *)buffer, bufferlen, 0,
-		(sockaddr *)&fromaddress, &fromlen);
-
-	if (c == SOCKET_ERROR)
-	{
-		int err = WSAGetLastError();
-		if (err == WSAEWOULDBLOCK || (noabort && err == WSAECONNRESET))
-			return NULL;	// no packet
-	}
-	return &fromaddress;
-}
-
-void PreSend (const void *buffer, int bufferlen, const sockaddr_in *to)
-{
-	sendto (mysocket, (const char *)buffer, bufferlen, 0, (const sockaddr *)to, sizeof(*to));
-}
-
-void BuildAddress (sockaddr_in *address, const char *name)
-{
-	hostent *hostentry;		// host information entry
-	u_short port;
-	const char *portpart;
-	bool isnamed = false;
-	int curchar;
-	char c;
-	FString target;
-
-	address->sin_family = AF_INET;
-
-	if ( (portpart = strchr (name, ':')) )
-	{
-		target = FString(name, portpart - name);
-		port = atoi (portpart + 1);
-		if (!port)
-		{
-			Printf ("Weird port: %s (using %d)\n", portpart + 1, DOOMPORT);
-			port = DOOMPORT;
-		}
-	}
-	else
-	{
-		target = name;
-		port = DOOMPORT;
-	}
-	address->sin_port = htons(port);
-
-	for (curchar = 0; (c = target[curchar]) ; curchar++)
+	bool isNamed = false;
+	char c = 0;
+	for (size_t curChar = 0u; (c = target[curChar]); ++curChar)
 	{
 		if ((c < '0' || c > '9') && c != '.')
 		{
-			isnamed = true;
+			isNamed = true;
 			break;
 		}
 	}
 
-	if (!isnamed)
+	address.sin_family = AF_INET;
+	address.sin_port = htons(port);
+	if (!isNamed)
 	{
-		address->sin_addr.s_addr = inet_addr (target.GetChars());
-		Printf ("Node number %d, address %s\n", doomcom.numplayers, target.GetChars());
+		address.sin_addr.s_addr = inet_addr(target.GetChars());
 	}
 	else
 	{
-		hostentry = gethostbyname (target.GetChars());
-		if (!hostentry)
-			I_FatalError ("gethostbyname: couldn't find %s\n%s", target.GetChars(), neterror());
-		address->sin_addr.s_addr = *(int *)hostentry->h_addr_list[0];
-		Printf ("Node number %d, hostname %s\n",
-			doomcom.numplayers, hostentry->h_name);
+		hostent* hostEntry = gethostbyname(target.GetChars());
+		if (hostEntry == nullptr)
+			I_FatalError("gethostbyname: Couldn't find %s\n%s", target.GetChars(), neterror());
+
+		address.sin_addr.s_addr = *(int*)hostEntry->h_addr_list[0];
 	}
 }
 
-void CloseNetwork (void)
+static void StartNetwork(bool autoPort)
 {
-	if (mysocket != INVALID_SOCKET)
-	{
-		closesocket (mysocket);
-		mysocket = INVALID_SOCKET;
-	}
 #ifdef __WIN32__
-	WSACleanup ();
-#endif
-}
-
-void StartNetwork (bool autoPort)
-{
-	u_long trueval = 1;
-#ifdef __WIN32__
-	WSADATA wsad;
-
-	if (WSAStartup (0x0101, &wsad))
-	{
-		I_FatalError ("Could not initialize Windows Sockets");
-	}
+	WSADATA data;
+	if (WSAStartup(0x0101, &data))
+		I_FatalError("Couldn't initialize Windows sockets");
 #endif
 
 	netgame = true;
 	multiplayer = true;
+	MySocket = CreateUDPSocket();
+	BindToLocalPort(MySocket, autoPort ? 0 : GamePort);
 
-	// create communication socket
-	mysocket = UDPsocket ();
-	BindToLocalPort (mysocket, autoPort ? 0 : DOOMPORT);
+	u_long trueVal = 1u;
 #ifndef __sun
-	ioctlsocket (mysocket, FIONBIO, &trueval);
+	ioctlsocket(MySocket, FIONBIO, &trueVal);
 #else
 	fcntl(mysocket, F_SETFL, trueval | O_NONBLOCK);
 #endif
 }
 
-void SendAbort (int connected)
+void CloseNetwork()
 {
-	uint8_t dis[2] = { PRE_FAKE, PRE_DISCONNECT };
-	int i, j;
-
-	if (connected > 1)
+	if (MySocket != INVALID_SOCKET)
 	{
-		if (doomcom.consoleplayer == 0)
-		{
-			// The host needs to let everyone know
-			for (i = 1; i < connected; ++i)
-			{
-				for (j = 4; j > 0; --j)
-				{
-					PreSend (dis, 2, &sendaddress[i]);
-				}
-			}
-		}
-		else
-		{
-			// Guests only need to let the host know.
-			for (i = 4; i > 0; --i)
-			{
-				PreSend (dis, 2, &sendaddress[0]);
-			}
-		}
-	}
-}
-
-void SendConAck (int num_connected, int num_needed)
-{
-	PreGamePacket packet;
-
-	packet.Fake = PRE_FAKE;
-	packet.Message = PRE_CONACK;
-	packet.NumNodes = num_needed;
-	packet.NumPresent = num_connected;
-	for (int node = 1; node < num_connected; ++node)
-	{
-		PreSend (&packet, 4, &sendaddress[node]);
-	}
-	I_NetProgress (num_connected);
-}
-
-bool Host_CheckForConnects (void *userdata)
-{
-	PreGameConnectPacket packet;
-	int* connectedPlayers = (int*)userdata;
-	sockaddr_in *from;
-	int node;
-
-	while ( (from = PreGet (&packet, sizeof(packet), false)) )
-	{
-		if (packet.Fake != PRE_FAKE)
-		{
-			continue;
-		}
-		switch (packet.Message)
-		{
-		case PRE_CONNECT:
-			node = FindNode (from);
-			if (doomcom.numplayers == *connectedPlayers)
-			{
-				if (node == -1)
-				{
-					const uint8_t *s_addr_bytes = (const uint8_t *)&from->sin_addr;
-					I_NetMessage ("Got extra connect from %d.%d.%d.%d:%d",
-						s_addr_bytes[0], s_addr_bytes[1], s_addr_bytes[2], s_addr_bytes[3],
-						from->sin_port);
-					packet.Message = PRE_ALLFULL;
-					PreSend (&packet, 2, from);
-				}
-			}
-			else
-			{
-				if (node == -1)
-				{
-					if (strlen(net_password) > 0 && strcmp(net_password, packet.Password))
-					{
-						packet.Message = PRE_WRONG_PASSWORD;
-						PreSend(&packet, 2, from);
-						break;
-					}
-
-					node = *connectedPlayers;
-					++*connectedPlayers;
-					sendaddress[node] = *from;
-					I_NetMessage ("Got connect from node %d.", node);
-				}
-
-				// Let the new guest (and everyone else) know we got their message.
-				SendConAck (*connectedPlayers, doomcom.numplayers);
-			}
-			break;
-
-		case PRE_DISCONNECT:
-			node = FindNode (from);
-			if (node >= 0)
-			{
-				I_ClearNode(node);
-				I_NetMessage ("Got disconnect from node %d.", node);
-				--*connectedPlayers;
-				while (node < *connectedPlayers)
-				{
-					sendaddress[node] = sendaddress[node+1];
-					++node;
-				}
-
-				// Let remaining guests know that somebody left.
-				SendConAck (*connectedPlayers, doomcom.numplayers);
-			}
-			break;
-		}
-	}
-	if (*connectedPlayers < doomcom.numplayers && !I_ShouldStartNetGame())
-	{
-		// Send message to everyone as a keepalive
-		SendConAck(*connectedPlayers, doomcom.numplayers);
-		return false;
-	}
-
-	// It's possible somebody bailed out after all players were found.
-	// Unfortunately, this isn't guaranteed to catch all of them.
-	// Oh well. Better than nothing.
-	while ( (from = PreGet (&packet, sizeof(packet), false)) )
-	{
-		if (packet.Fake == PRE_FAKE && packet.Message == PRE_DISCONNECT)
-		{
-			node = FindNode (from);
-			if (node >= 0)
-			{
-				I_ClearNode(node);
-				--*connectedPlayers;
-				while (node < *connectedPlayers)
-				{
-					sendaddress[node] = sendaddress[node+1];
-					++node;
-				}
-				// Let remaining guests know that somebody left.
-				SendConAck (*connectedPlayers, doomcom.numplayers);
-			}
-			break;
-		}
-	}
-
-	// TODO: This will need a much better solution later.
-	if (I_ShouldStartNetGame())
-		doomcom.numplayers = *connectedPlayers;
-
-	return *connectedPlayers >= doomcom.numplayers;
-}
-
-bool Host_SendAllHere (void *userdata)
-{
-	int* gotack = (int*)userdata;
-	const int mask = (1 << doomcom.numplayers) - 1;
-	PreGamePacket packet;
-	int node;
-	sockaddr_in *from;
-
-	// Send out address information to all guests. This is will be the final order
-	// of the send addresses so each guest will need to rearrange their own in order
-	// to keep node -> player numbers synchronized.
-	packet.Fake = PRE_FAKE;
-	packet.Message = PRE_ALLHERE;
-	for (node = 1; node < doomcom.numplayers; node++)
-	{
-		int machine, spot = 0;
-
-		packet.ConsoleNum = node;
-		if (!((*gotack) & (1 << node)))
-		{
-			for (spot = 0; spot < doomcom.numplayers; spot++)
-			{
-				packet.machines[spot].address = sendaddress[spot].sin_addr.s_addr;
-				packet.machines[spot].port = sendaddress[spot].sin_port;
-			}
-			packet.NumNodes = doomcom.numplayers;
-		}
-		else
-		{
-			packet.NumNodes = 0;
-		}
-		PreSend (&packet, 4 + spot*8, &sendaddress[node]);
-	}
-
-	// Check for replies.
-	while ( (from = PreGet (&packet, sizeof(packet), false)) )
-	{
-		if (packet.Fake != PRE_FAKE)
-			continue;
-
-		if (packet.Message == PRE_ALLHEREACK)
-		{
-			node = FindNode (from);
-			if (node >= 0)
-				*gotack |= 1 << node;
-		}
-		else if (packet.Message == PRE_CONNECT)
-		{
-			// If someone is still trying to connect, let them know it's either too
-			// late or that they need to move on to the next stage.
-			node = FindNode(from);
-			if (node == -1)
-			{
-				packet.Message = PRE_ALLFULL;
-				PreSend(&packet, 2, from);
-			}
-			else
-			{
-				packet.Message = PRE_CONACK;
-				packet.NumNodes = packet.NumPresent = doomcom.numplayers;
-				PreSend(&packet, 4, from);
-			}
-		}
-	}
-
-	// If everybody has replied, then this loop can end.
-	return ((*gotack) & mask) == mask;
-}
-
-bool HostGame (int i)
-{
-	PreGamePacket packet;
-	int numplayers;
-	int node;
-
-	if ((i == Args->NumArgs() - 1) || !(numplayers = atoi (Args->GetArg(i+1))))
-	{	// No player count specified, assume 2
-		numplayers = 2;
-	}
-
-	if (numplayers > MaxPlayers)
-	{
-		I_FatalError("You cannot host a game with %d players. The limit is currently %d.", numplayers, MaxPlayers);
-	}
-
-	if (numplayers == 1)
-	{ // Special case: Only 1 player, so don't bother starting the network
-		NetworkClients += 0;
+		closesocket(MySocket);
+		MySocket = INVALID_SOCKET;
 		netgame = false;
-		multiplayer = true;
-		doomcom.id = DOOMCOM_ID;
-		doomcom.numplayers = 1;
-		doomcom.consoleplayer = 0;
-		return true;
 	}
-
-	StartNetwork (false);
-
-	// [JC] - this computer is starting the game, therefore it should
-	// be the Net Arbitrator.
-	doomcom.consoleplayer = 0;
-	doomcom.numplayers = numplayers;
-
-	I_NetInit ("Hosting game", numplayers);
-
-	// Wait for the lobby to be full.
-	int connectedPlayers = 1;
-	if (!I_NetLoop (Host_CheckForConnects, (void *)&connectedPlayers))
-	{
-		SendAbort(connectedPlayers);
-		throw CExitEvent(0);
-		return false;
-	}
-
-	// If the player force started with only themselves in the lobby, start the game
-	// immediately.
-	if (doomcom.numplayers <= 1)
-	{
-		NetworkClients += 0;
-		netgame = false;
-		multiplayer = true;
-		doomcom.id = DOOMCOM_ID;
-		doomcom.numplayers = 1;
-		I_NetDone();
-		return true;
-	}
-
-	// Now inform everyone of all machines involved in the game
-	int gotack = 1;
-	I_NetMessage ("Sending all here.");
-	I_NetInit ("Done waiting", 1);
-
-	if (!I_NetLoop (Host_SendAllHere, (void *)&gotack))
-	{
-		SendAbort(doomcom.numplayers);
-		throw CExitEvent(0);
-		return false;
-	}
-
-	// Now go
-	I_NetMessage ("Go");
-	packet.Fake = PRE_FAKE;
-	packet.Message = PRE_GO;
-	for (node = 1; node < doomcom.numplayers; node++)
-	{
-		// If we send the packets eight times to each guest,
-		// hopefully at least one of them will get through.
-		for (int ii = 8; ii != 0; --ii)
-		{
-			PreSend (&packet, 2, &sendaddress[node]);
-		}
-	}
-
-	I_NetMessage ("Total players: %d", doomcom.numplayers);
-
-	doomcom.id = DOOMCOM_ID;
-
-	return true;
+#ifdef __WIN32__
+	WSACleanup();
+#endif
 }
 
-// This routine is used by a guest to notify the host of its presence.
-// Once that host acknowledges receipt of the notification, this routine
-// is never called again.
-
-bool Guest_ContactHost (void *userdata)
-{
-	sockaddr_in *from;
-	PreGamePacket packet;
-	PreGameConnectPacket sendPacket;
-
-	// Let the host know we are here.
-	sendPacket.Fake = PRE_FAKE;
-	sendPacket.Message = PRE_CONNECT;
-	memcpy(sendPacket.Password, net_password, strlen(net_password) + 1);
-	PreSend (&sendPacket, sizeof(sendPacket), &sendaddress[0]);
-
-	// Listen for a reply.
-	while ( (from = PreGet (&packet, sizeof(packet), true)) )
-	{
-		if (packet.Fake == PRE_FAKE && !FindNode(from))
-		{
-			if (packet.Message == PRE_CONACK)
-			{
-				I_NetMessage ("Total players: %d", packet.NumNodes);
-				I_NetInit ("Waiting for other players", packet.NumNodes);
-				I_NetProgress (packet.NumPresent);
-				return true;
-			}
-			else if (packet.Message == PRE_DISCONNECT)
-			{
-				I_NetError("The host cancelled the game.");
-			}
-			else if (packet.Message == PRE_ALLFULL)
-			{
-				I_NetError("The game is full.");
-			}
-			else if (packet.Message == PRE_IN_PROGRESS)
-			{
-				I_NetError("The game was already started.");
-			}
-			else if (packet.Message == PRE_WRONG_PASSWORD)
-			{
-				I_NetError("Invalid password.");
-			}
-		}
-	}
-
-	// In case the progress bar could not be marqueed, bump it.
-	I_NetProgress (0);
-
-	return false;
-}
-
-bool Guest_WaitForOthers (void *userdata)
-{
-	sockaddr_in *from;
-	PreGamePacket packet;
-
-	while ( (from = PreGet (&packet, sizeof(packet), false)) )
-	{
-		if (packet.Fake != PRE_FAKE || FindNode(from))
-		{
-			continue;
-		}
-		switch (packet.Message)
-		{
-		case PRE_CONACK:
-			I_NetProgress (packet.NumPresent);
-			break;
-
-		case PRE_ALLHERE:
-			if (doomcom.consoleplayer == -1)
-			{
-				doomcom.numplayers = packet.NumNodes;
-				doomcom.consoleplayer = packet.ConsoleNum;
-				// Don't use the address sent from the host for our own machine.
-				sendaddress[doomcom.consoleplayer] = sendaddress[1];
-
-				I_NetMessage ("Console player number: %d", doomcom.consoleplayer);
-
-				for (int node = 1; node < doomcom.numplayers; ++node)
-				{
-					if (node == doomcom.consoleplayer)
-						continue;
-
-					sendaddress[node].sin_addr.s_addr = packet.machines[node].address;
-					sendaddress[node].sin_port = packet.machines[node].port;
-
-					// [JC] - fixes problem of games not starting due to
-					// no address family being assigned to nodes stored in
-					// sendaddress[] from the All Here packet.
-					sendaddress[node].sin_family = AF_INET;
-				}
-
-				I_NetMessage("Received All Here, sending ACK.");
-			}
-
-			packet.Fake = PRE_FAKE;
-			packet.Message = PRE_ALLHEREACK;
-			PreSend (&packet, 2, &sendaddress[0]);
-			break;
-
-		case PRE_GO:
-			I_NetMessage ("Received \"Go.\"");
-			return true;
-
-		case PRE_DISCONNECT:
-			I_NetError("The host cancelled the game.");
-			break;
-		}
-	}
-
-	return false;
-}
-
-bool JoinGame (int i)
-{
-	if ((i == Args->NumArgs() - 1) ||
-		(Args->GetArg(i+1)[0] == '-') ||
-		(Args->GetArg(i+1)[0] == '+'))
-		I_FatalError ("You need to specify the host machine's address");
-
-	StartNetwork (true);
-
-	// Host is always node 0
-	BuildAddress (&sendaddress[0], Args->GetArg(i+1));
-	doomcom.numplayers = 2;
-	doomcom.consoleplayer = -1;
-
-	// Let host know we are here
-	I_NetInit ("Contacting host", 0);
-
-	if (!I_NetLoop (Guest_ContactHost, nullptr))
-	{
-		SendAbort(2);
-		throw CExitEvent(0);
-		return false;
-	}
-
-	// Wait for everyone else to connect
-	if (!I_NetLoop (Guest_WaitForOthers, nullptr))
-	{
-		SendAbort(2);
-		throw CExitEvent(0);
-		return false;
-	}
-
-	I_NetMessage ("Total players: %d", doomcom.numplayers);
-
-	doomcom.id = DOOMCOM_ID;
-	return true;
-}
-
-static int PrivateNetOf(in_addr in)
+static int PrivateNetOf(const in_addr& in)
 {
 	int addr = ntohl(in.s_addr);
 	if ((addr & 0xFFFF0000) == 0xC0A80000)		// 192.168.0.0
@@ -994,116 +316,39 @@ static int PrivateNetOf(in_addr in)
 	return 0;
 }
 
-//
-// NodesOnSameNetwork
-//
 // The best I can really do here is check if the others are on the same
 // private network, since that means we (probably) are too.
-//
-
-static bool NodesOnSameNetwork()
+static bool ClientsOnSameNetwork()
 {
-	if (doomcom.consoleplayer != 0)
+	size_t start = 1u;
+	for (; start < MaxClients; ++start)
+	{
+		if (Connected[start].Status != CSTAT_NONE)
+			break;
+	}
+
+	if (start >= MaxClients)
 		return false;
 
-	const int firstClient = PrivateNetOf(sendaddress[1].sin_addr);
-//	Printf("net1 = %08x\n", net1);
-	if (firstClient == 0)
-	{
+	const int firstClient = PrivateNetOf(Connected[start].Address.sin_addr);
+	if (!firstClient)
 		return false;
-	}
-	for (int i = 2; i < doomcom.numplayers; ++i)
+
+	for (size_t i = 1u; i < MaxClients; ++i)
 	{
-		const int net = PrivateNetOf(sendaddress[i].sin_addr);
-//		Printf("Net[%d] = %08x\n", i, net);
-		if (net != firstClient)
-		{
+		if (i == start)
+			continue;
+
+		if (Connected[i].Status == CSTAT_NONE || PrivateNetOf(Connected[i].Address.sin_addr) != firstClient)
 			return false;
-		}
 	}
+
 	return true;
 }
 
-//
-// I_InitNetwork
-//
-// Returns true if packet server mode might be a good idea.
-//
-int I_InitNetwork (void)
-{
-	int i;
-	const char *v;
-
-	memset (&doomcom, 0, sizeof(doomcom));
-
-	// set up for network
-	v = Args->CheckValue ("-dup");
-	if (v)
-	{
-		doomcom.ticdup = clamp<int> (atoi (v), 1, MAXTICDUP);
-	}
-	else
-	{
-		doomcom.ticdup = 1;
-	}
-
-	v = Args->CheckValue ("-port");
-	if (v)
-	{
-		DOOMPORT = atoi (v);
-		Printf ("using alternate port %i\n", DOOMPORT);
-	}
-
-	net_password = Args->CheckValue("-password");
-
-	// parse network game options,
-	//		player 1: -host <numplayers>
-	//		player x: -join <player 1's address>
-	if ( (i = Args->CheckParm ("-host")) )
-	{
-		if (!HostGame (i)) return -1;
-	}
-	else if ( (i = Args->CheckParm ("-join")) )
-	{
-		if (!JoinGame (i)) return -1;
-	}
-	else
-	{
-		// single player game
-		NetworkClients += 0;
-		netgame = false;
-		multiplayer = false;
-		doomcom.id = DOOMCOM_ID;
-		doomcom.ticdup = 1;
-		doomcom.numplayers = 1;
-		doomcom.consoleplayer = 0;
-		return false;
-	}
-
-	if (doomcom.numplayers < 3)
-	{ // Packet server mode with only two players is effectively the same as
-	  // peer-to-peer but with some slightly larger packets.
-		return false;
-	}
-	return !NodesOnSameNetwork();
-}
-
-
-void I_NetCmd (void)
-{
-	if (doomcom.command == CMD_SEND)
-	{
-		PacketSend ();
-	}
-	else if (doomcom.command == CMD_GET)
-	{
-		PacketGet ();
-	}
-	else
-		I_Error ("Bad net cmd: %i\n",doomcom.command);
-}
-
-void I_NetMessage(const char* text, ...)
+// Print a network-related message to the console. This doesn't print to the window so should
+// not be used for that and is mainly for logging.
+static void I_NetLog(const char* text, ...)
 {
 	// todo: use better abstraction once everything is migrated to in-game start screens.
 #if defined _WIN32 || defined __APPLE__
@@ -1123,37 +368,909 @@ void I_NetMessage(const char* text, ...)
 #endif
 }
 
-void I_NetError(const char* error)
+// Gracefully closes the net window so that any error messaging can be properly displayed.
+static void I_NetError(const char* error)
 {
-	doomcom.numplayers = 0;
 	StartWindow->NetClose();
 	I_FatalError("%s", error);
 }
 
+static void I_NetInit(const char* msg, bool host)
+{
+	StartWindow->NetInit(msg, host);
+}
+
 // todo: later these must be dispatched by the main menu, not the start screen.
-void I_NetProgress(int val)
+// Updates the general status of the lobby.
+static void I_NetMessage(const char* msg)
 {
-	StartWindow->NetProgress(val);
+	StartWindow->NetMessage(msg);
 }
-void I_NetInit(const char* msg, int num)
+
+// Listen for incoming connections while the lobby is active. The main thread needs to be locked up
+// here to prevent the engine from continuing to start the game until everyone is ready.
+static bool I_NetLoop(bool (*loopCallback)(void*), void* data)
 {
-	StartWindow->NetInit(msg, num);
+	return StartWindow->NetLoop(loopCallback, data);
 }
-bool I_NetLoop(bool (*timer_callback)(void*), void* userdata)
+
+// A new client has just entered the game, so add them to the player list.
+static void I_NetClientConnected(size_t client, unsigned int charLimit = 0u)
 {
-	return StartWindow->NetLoop(timer_callback, userdata);
+	const char* name = Net_GetClientName(client, charLimit);
+	unsigned int flags = CFL_NONE;
+	if (client == 0)
+		flags |= CFL_HOST;
+	if (client == consoleplayer)
+		flags |= CFL_CONSOLEPLAYER;
+
+	StartWindow->NetConnect(client, name, flags, Connected[client].Status);
 }
+
+// A client changed ready state.
+static void I_NetClientUpdated(size_t client)
+{
+	StartWindow->NetUpdate(client, Connected[client].Status);
+}
+
+static void I_NetClientDisconnected(size_t client)
+{
+	StartWindow->NetDisconnect(client);
+}
+
+static void I_NetUpdatePlayers(size_t current, size_t limit)
+{
+	StartWindow->NetProgress(current, limit);
+}
+
+static bool I_ShouldStartNetGame()
+{
+	return StartWindow->ShouldStartNet();
+}
+
+static void I_GetKickClients(TArray<int>& clients)
+{
+	clients.Clear();
+
+	int c = -1;
+	while ((c = StartWindow->GetNetKickClient()) != -1)
+		clients.Push(c);
+}
+
+static void I_GetBanClients(TArray<int>& clients)
+{
+	clients.Clear();
+
+	int c = -1;
+	while ((c = StartWindow->GetNetBanClient()) != -1)
+		clients.Push(c);
+}
+
 void I_NetDone()
 {
 	StartWindow->NetDone();
 }
+
+void I_ClearClient(size_t client)
+{
+	memset(&Connected[client], 0, sizeof(Connected[client]));
+}
+
+static int FindClient(const sockaddr_in& address)
+{
+	int i = 0;
+	for (; i < MaxClients; ++i)
+	{
+		if (Connected[i].Status == CSTAT_NONE)
+			continue;
+
+		if (address.sin_addr.s_addr == Connected[i].Address.sin_addr.s_addr
+			&& address.sin_port == Connected[i].Address.sin_port)
+		{
+			break;
+		}
+	}
+
+	return i >= MaxClients ? -1 : i;
+}
+
+static void SendPacket(const sockaddr_in& to)
+{
+	// Huge packets should be sent out as sequences, not as one big packet, otherwise it's prone
+	// to high amounts of congestion and reordering needed.
+	if (NetBufferLength > MAX_MSGLEN)
+		I_FatalError("Netbuffer overflow: Tried to send %u bytes of data", NetBufferLength);
+
+	assert(!(NetBuffer[0] & NCMD_COMPRESSED));
+
+	uLong size = MaxTransmitSize - 1u;
+	int res = -1;
+	if (NetBufferLength >= MinCompressionSize)
+	{
+		TransmitBuffer[0] = NetBuffer[0] | NCMD_COMPRESSED;
+		res = compress2(TransmitBuffer + 1, &size, NetBuffer + 1, NetBufferLength - 1u, 9);
+		++size;
+	}
+
+	if (res == Z_OK && size < static_cast<uLong>(NetBufferLength))
+		res = sendto(MySocket, (const char*)TransmitBuffer, size, 0, (const sockaddr*)&to, sizeof(to));
+	else if (NetBufferLength > MaxTransmitSize)
+		I_Error("Net compression failed (zlib error %d)", res);
+	else
+		res = sendto(MySocket, (const char*)NetBuffer, NetBufferLength, 0, (const sockaddr*)&to, sizeof(to));
+}
+
+static void GetPacket(sockaddr_in* const from = nullptr)
+{
+	sockaddr_in fromAddress;
+	socklen_t fromSize = sizeof(fromAddress);
+
+	int msgSize = recvfrom(MySocket, (char *)TransmitBuffer, MaxTransmitSize, 0,
+				  (sockaddr *)&fromAddress, &fromSize);
+
+	int client = FindClient(fromAddress);
+	if (client >= 0 && msgSize == SOCKET_ERROR)
+	{
+		int err = WSAGetLastError();
+		if (err == WSAECONNRESET)
+		{
+			if (consoleplayer == -1)
+			{
+				client = -1;
+				msgSize = 0;
+			}
+			else
+			{
+				// The remote node aborted unexpectedly, so pretend it sent an exit packet. If in packet server
+				// mode and it was the host, just consider the game too bricked to continue since the host has
+				// to determine the new host properly.
+				if (NetMode == NET_PacketServer && client == Net_Arbitrator)
+					I_NetError("Host unexpectedly disconnected");
+
+				NetBuffer[0] = NCMD_EXIT;
+				msgSize = 1;
+			}
+		}
+		else if (err != WSAEWOULDBLOCK)
+		{
+			I_Error("Failed to get packet: %s", neterror());
+		}
+		else
+		{
+			client = -1;
+			msgSize = 0;
+		}
+	}
+	else if (msgSize > 0)
+	{
+		if (client == -1 && !(TransmitBuffer[0] & NCMD_SETUP))
+		{
+			msgSize = 0;
+		}
+		else if (client == -1 && bGameStarted)
+		{
+			NetBuffer[0] = NCMD_SETUP;
+			NetBuffer[1] = PRE_IN_PROGRESS;
+			NetBufferLength = 2u;
+			SendPacket(fromAddress);
+			msgSize = 0;
+		}
+		else
+		{
+			NetBuffer[0] = (TransmitBuffer[0] & ~NCMD_COMPRESSED);
+			if (TransmitBuffer[0] & NCMD_COMPRESSED)
+			{
+				uLongf size = MAX_MSGLEN - 1;
+				int err = uncompress(NetBuffer + 1, &size, TransmitBuffer + 1, msgSize - 1);
+				if (err != Z_OK)
+				{
+					Printf("Net decompression failed (zlib error %s)\n", M_ZLibError(err).GetChars());
+					client = -1;
+					msgSize = 0;
+				}
+				else
+				{
+					msgSize = size + 1;
+				}
+			}
+			else
+			{
+				memcpy(NetBuffer + 1, TransmitBuffer + 1, msgSize - 1);
+			}
+		}
+	}
+	else
+	{
+		client = -1;
+	}
+
+	RemoteClient = client;
+	NetBufferLength = max<int>(msgSize, 0);
+	if (from != nullptr)
+		*from = fromAddress;
+}
+
+void I_NetCmd(ENetCommand cmd)
+{
+	if (cmd == CMD_SEND)
+	{
+		if (RemoteClient >= 0)
+			SendPacket(Connected[RemoteClient].Address);
+	}
+	else if (cmd == CMD_GET)
+	{
+		GetPacket();
+	}
+}
+
+static void SetClientAck(size_t client, size_t from, bool add)
+{
+	const uint64_t bit = (uint64_t)1u << from;
+	if (add)
+		Connected[client].InfoAck |= bit;
+	else
+		Connected[client].InfoAck &= ~bit;
+}
+
+static bool ClientGotAck(size_t client, size_t from)
+{
+	return (Connected[client].InfoAck & ((uint64_t)1u << from));
+}
+
+static bool GetConnection(sockaddr_in& from)
+{
+	GetPacket(&from);
+	return NetBufferLength > 0;
+}
+
+static void RejectConnection(const sockaddr_in& to, ENetConnectType reason)
+{
+	NetBuffer[0] = NCMD_SETUP;
+	NetBuffer[1] = reason;
+	NetBufferLength = 2u;
+
+	SendPacket(to);
+}
+
+static void AddClientConnection(const sockaddr_in& from, size_t client)
+{
+	Connected[client].Status = CSTAT_CONNECTING;
+	Connected[client].Address = from;
+	NetworkClients += client;
+	I_NetLog("Client %u joined the lobby", client);
+	I_NetClientUpdated(client);
+
+	// Make sure any ready clients are marked as needing the new client's info.
+	for (size_t i = 1u; i < MaxClients; ++i)
+	{
+		if (Connected[i].Status == CSTAT_READY)
+		{
+			Connected[i].Status = CSTAT_WAITING;
+			I_NetClientUpdated(i);
+		}
+	}
+}
+
+static void RemoveClientConnection(size_t client)
+{
+	I_NetClientDisconnected(client);
+	I_ClearClient(client);
+	NetworkClients -= client;
+	I_NetLog("Client %u left the lobby", client);
+
+	// Let everyone else know the user left as well.
+	NetBuffer[0] = NCMD_SETUP;
+	NetBuffer[1] = PRE_DISCONNECT;
+	NetBuffer[2] = client;
+	NetBufferLength = 3u;
+
+	for (size_t i = 1u; i < MaxClients; ++i)
+	{
+		if (Connected[i].Status == CSTAT_NONE)
+			continue;
+
+		SetClientAck(i, client, false);
+		for (int i = 0; i < 4; ++i)
+			SendPacket(Connected[i].Address);
+	}
+}
+
+void HandleIncomingConnection()
+{
+	if (consoleplayer != Net_Arbitrator || RemoteClient == -1)
+		return;
+
+	if (Connected[RemoteClient].Status == CSTAT_READY)
+	{
+		NetBuffer[0] = NCMD_SETUP;
+		NetBuffer[1] = PRE_GO;
+		NetBuffer[2] = NetMode;
+		NetBufferLength = 3u;
+		SendPacket(Connected[RemoteClient].Address);
+	}
+}
+
+static bool Host_CheckForConnections(void* connected)
+{
+	const bool forceStarting = I_ShouldStartNetGame();
+	const bool hasPassword = strlen(net_password) > 0;
+	size_t* connectedPlayers = (size_t*)connected;
+
+	TArray<int> toBoot = {};
+	I_GetKickClients(toBoot);
+	for (auto client : toBoot)
+	{
+		if (client <= 0 || Connected[client].Status == CSTAT_NONE)
+			continue;
+
+		sockaddr_in booted = Connected[client].Address;
+
+		RemoveClientConnection(client);
+		--*connectedPlayers;
+		I_NetUpdatePlayers(*connectedPlayers, MaxClients);
+
+		RejectConnection(booted, PRE_KICKED);
+	}
+
+	I_GetBanClients(toBoot);
+	for (auto client : toBoot)
+	{
+		if (client <= 0 || Connected[client].Status == CSTAT_NONE)
+			continue;
+
+		sockaddr_in booted = Connected[client].Address;
+		BannedConnections.Push(booted);
+
+		RemoveClientConnection(client);
+		--*connectedPlayers;
+		I_NetUpdatePlayers(*connectedPlayers, MaxClients);
+
+		RejectConnection(booted, PRE_BANNED);
+	}
+
+	sockaddr_in from;
+	while (GetConnection(from))
+	{
+		if (NetBuffer[0] == NCMD_EXIT)
+		{
+			if (RemoteClient >= 0)
+			{
+				RemoveClientConnection(RemoteClient);
+				--*connectedPlayers;
+				I_NetUpdatePlayers(*connectedPlayers, MaxClients);
+			}
+
+			continue;
+		}
+
+		if (NetBuffer[0] != NCMD_SETUP)
+			continue;
+
+		if (NetBuffer[1] == PRE_CONNECT)
+		{
+			if (RemoteClient >= 0)
+				continue;
+
+			size_t banned = 0u;
+			for (; banned < BannedConnections.Size(); ++banned)
+			{
+				if (BannedConnections[banned].sin_addr.s_addr == from.sin_addr.s_addr)
+					break;
+			}
+
+			if (banned < BannedConnections.Size())
+			{
+				RejectConnection(from, PRE_BANNED);
+			}
+			else if (NetBuffer[2] % 256 != VER_MAJOR || NetBuffer[3] % 256 != VER_MINOR || NetBuffer[4] % 256 != VER_REVISION)
+			{
+				RejectConnection(from, PRE_WRONG_ENGINE);
+			}
+			else if (*connectedPlayers >= MaxClients)
+			{
+				RejectConnection(from, PRE_FULL);
+			}
+			else if (forceStarting)
+			{
+				RejectConnection(from, PRE_IN_PROGRESS);
+			}
+			else if (hasPassword && strcmp(net_password, (const char*)&NetBuffer[5]))
+			{
+				RejectConnection(from, PRE_WRONG_PASSWORD);
+			}
+			else
+			{
+				size_t free = 1u;
+				for (; free < MaxClients; ++free)
+				{
+					if (Connected[free].Status == CSTAT_NONE)
+						break;
+				}
+
+				AddClientConnection(from, free);
+				++*connectedPlayers;
+				I_NetUpdatePlayers(*connectedPlayers, MaxClients);
+			}
+		}
+		else if (NetBuffer[1] == PRE_USER_INFO)
+		{
+			if (Connected[RemoteClient].Status == CSTAT_CONNECTING)
+			{
+				uint8_t* stream = &NetBuffer[2];
+				Net_ReadUserInfo(RemoteClient, stream);
+				Connected[RemoteClient].Status = CSTAT_WAITING;
+				I_NetClientConnected(RemoteClient, 16u);
+			}
+		}
+		else if (NetBuffer[1] == PRE_USER_INFO_ACK)
+		{
+			SetClientAck(RemoteClient, NetBuffer[2], true);
+		}
+		else if (NetBuffer[1] == PRE_GAME_INFO_ACK)
+		{
+			Connected[RemoteClient].bHasGameInfo = true;
+		}
+	}
+
+	const size_t addrSize = sizeof(sockaddr_in);
+	bool ready = true;
+	NetBuffer[0] = NCMD_SETUP;
+	for (size_t client = 1u; client < MaxClients; ++client)
+	{
+		auto& con = Connected[client];
+		// If we're starting before the lobby is full, only check against connected clients.
+		if (con.Status != CSTAT_READY && (!forceStarting || con.Status != CSTAT_NONE))
+			ready = false;
+
+		if (con.Status == CSTAT_CONNECTING)
+		{
+			NetBuffer[1] = PRE_CONNECT_ACK;
+			NetBuffer[2] = client;
+			NetBuffer[3] = *connectedPlayers;
+			NetBuffer[4] = MaxClients;
+			NetBufferLength = 5u;
+			SendPacket(con.Address);
+		}
+		else if (con.Status == CSTAT_WAITING)
+		{
+			bool clientReady = true;
+			if (!ClientGotAck(client, client))
+			{
+				NetBuffer[1] = PRE_USER_INFO_ACK;
+				NetBufferLength = 2u;
+				SendPacket(con.Address);
+				clientReady = false;
+			}
+
+			if (!con.bHasGameInfo)
+			{
+				NetBuffer[1] = PRE_GAME_INFO;
+				NetBuffer[2] = TicDup;
+				NetBufferLength = 3u;
+
+				uint8_t* stream = &NetBuffer[NetBufferLength];
+				NetBufferLength += Net_SetGameInfo(stream);
+				SendPacket(con.Address);
+				clientReady = false;
+			}
+
+			NetBuffer[1] = PRE_USER_INFO;
+			for (size_t i = 0u; i < MaxClients; ++i)
+			{
+				if (i == client || Connected[i].Status == CSTAT_NONE)
+					continue;
+
+				if (!ClientGotAck(client, i))
+				{
+					if (Connected[i].Status >= CSTAT_WAITING)
+					{
+						NetBuffer[2] = i;
+						NetBufferLength = 3u;
+						// Client will already have the host connection information.
+						if (i > 0)
+						{
+							memcpy(&NetBuffer[NetBufferLength], &Connected[i].Address, addrSize);
+							NetBufferLength += addrSize;
+						}
+
+						uint8_t* stream = &NetBuffer[NetBufferLength];
+						NetBufferLength += Net_SetUserInfo(i, stream);
+						SendPacket(con.Address);
+					}
+					clientReady = false;
+				}
+			}
+
+			if (clientReady)
+			{
+				con.Status = CSTAT_READY;
+				I_NetClientUpdated(client);
+			}
+		}
+		else if (con.Status == CSTAT_READY)
+		{
+			NetBuffer[1] = PRE_HEARTBEAT;
+			NetBuffer[2] = *connectedPlayers;
+			NetBuffer[3] = MaxClients;
+			NetBufferLength = 4u;
+			SendPacket(con.Address);
+		}
+	}
+
+	return ready && (*connectedPlayers >= MaxClients || forceStarting);
+}
+
+// Boon TODO: Add cool down between sends
+static void SendAbort()
+{
+	NetBuffer[0] = NCMD_EXIT;
+	NetBufferLength = 1u;
+
+	if (consoleplayer == 0)
+	{
+		for (size_t client = 1u; client < MaxClients; ++client)
+		{
+			if (Connected[client].Status != CSTAT_NONE)
+				SendPacket(Connected[client].Address);
+		}
+	}
+	else
+	{
+		SendPacket(Connected[0].Address);
+	}
+}
+
+static bool HostGame(int arg, bool forcedNetMode)
+{
+	if (arg >= Args->NumArgs() || !(MaxClients = atoi(Args->GetArg(arg))))
+	{	// No player count specified, assume 2
+		MaxClients = 2u;
+	}
+
+	if (MaxClients > MAXPLAYERS)
+		I_FatalError("Cannot host a game with %u players. The limit is currently %u", MaxClients, MAXPLAYERS);
+
+	consoleplayer = 0;
+	NetworkClients += 0;
+	Connected[consoleplayer].Status = CSTAT_READY;
+	Net_SetupUserInfo();
+
+	// If only 1 player, don't bother starting the network
+	if (MaxClients == 1u)
+	{
+		TicDup = 1u;
+		multiplayer = true;
+		return true;
+	}
+
+	StartNetwork(false);
+	I_NetInit("Waiting for other players...", true);
+	I_NetUpdatePlayers(1u, MaxClients);
+	I_NetClientConnected(0u, 16u);
+
+	// Wait for the lobby to be full.
+	size_t connectedPlayers = 1u;
+	if (!I_NetLoop(Host_CheckForConnections, (void*)&connectedPlayers))
+	{
+		SendAbort();
+		throw CExitEvent(0);
+	}
+
+	// Now go
+	I_NetMessage("Starting game");
+	I_NetDone();
+
+	// If the player force started with only themselves in the lobby, start the game
+	// immediately.
+	if (connectedPlayers == 1u)
+	{
+		CloseNetwork();
+		MaxClients = TicDup = 1u;
+		return true;
+	}
+
+	if (!forcedNetMode)
+	{
+		if (MaxClients < 3)
+			NetMode = NET_PeerToPeer;
+		else if (!ClientsOnSameNetwork())
+			NetMode = NET_PacketServer;
+	}
+
+	I_NetLog("Go");
+
+	NetBuffer[0] = NCMD_SETUP;
+	NetBuffer[1] = PRE_GO;
+	NetBuffer[2] = NetMode;
+	NetBufferLength = 3u;
+	for (size_t client = 1u; client < MaxClients; ++client)
+	{
+		if (Connected[client].Status != CSTAT_NONE)
+			SendPacket(Connected[client].Address);
+	}
+
+	I_NetLog("Total players: %u", connectedPlayers);
+
+	return true;
+}
+
+static bool Guest_ContactHost(void* unused)
+{
+	// Listen for a reply.
+	const size_t addrSize = sizeof(sockaddr_in);
+	sockaddr_in from;
+	while (GetConnection(from))
+	{
+		if (RemoteClient != 0)
+			continue;
+
+		if (NetBuffer[0] == NCMD_EXIT)
+			I_NetError("The host cancelled the game");
+
+		if (NetBuffer[0] != NCMD_SETUP)
+			continue;
+
+		if (NetBuffer[1] == PRE_HEARTBEAT)
+		{
+			MaxClients = NetBuffer[3];
+			I_NetUpdatePlayers(NetBuffer[2], MaxClients);
+		}
+		else if (NetBuffer[1] == PRE_DISCONNECT)
+		{
+			I_ClearClient(NetBuffer[2]);
+			NetworkClients -= NetBuffer[2];
+			SetClientAck(consoleplayer, NetBuffer[2], false);
+			I_NetClientDisconnected(NetBuffer[2]);
+		}
+		else if (NetBuffer[1] == PRE_FULL)
+		{
+			I_NetError("The game is full");
+		}
+		else if (NetBuffer[1] == PRE_IN_PROGRESS)
+		{
+			I_NetError("The game has already started");
+		}
+		else if (NetBuffer[1] == PRE_WRONG_PASSWORD)
+		{
+			I_NetError("Invalid password");
+		}
+		else if (NetBuffer[1] == PRE_WRONG_ENGINE)
+		{
+			I_NetError("Engine version does not match the host's engine version");
+		}
+		else if (NetBuffer[1] == PRE_INVALID_FILES)
+		{
+			I_NetError("Files do not match the host's files");
+		}
+		else if (NetBuffer[1] == PRE_KICKED)
+		{
+			I_NetError("You have been kicked from the game");
+		}
+		else if (NetBuffer[1] == PRE_BANNED)
+		{
+			I_NetError("You have been banned from the game");
+		}
+		else if (NetBuffer[1] == PRE_CONNECT_ACK)
+		{
+			if (consoleplayer == -1)
+			{
+				NetworkClients += 0;
+				Connected[0].Status = CSTAT_WAITING;
+				I_NetClientUpdated(0);
+
+				consoleplayer = NetBuffer[2];
+				NetworkClients += consoleplayer;
+				Connected[consoleplayer].Status = CSTAT_CONNECTING;
+				Net_SetupUserInfo();
+
+				MaxClients = NetBuffer[4];
+				I_NetMessage("Sending game information");
+				I_NetUpdatePlayers(NetBuffer[3], MaxClients);
+				I_NetClientConnected(consoleplayer, 16u);
+			}
+		}
+		else if (NetBuffer[1] == PRE_USER_INFO_ACK)
+		{
+			// The host will only ever send us this to confirm they've gotten our data.
+			SetClientAck(consoleplayer, consoleplayer, true);
+			if (Connected[consoleplayer].Status == CSTAT_CONNECTING)
+			{
+				Connected[consoleplayer].Status = CSTAT_WAITING;
+				I_NetClientUpdated(consoleplayer);
+				I_NetMessage("Waiting for game to start");
+			}
+
+			NetBuffer[0] = NCMD_SETUP;
+			NetBuffer[1] = PRE_USER_INFO_ACK;
+			NetBuffer[2] = consoleplayer;
+			NetBufferLength = 3u;
+			SendPacket(from);
+		}
+		else if (NetBuffer[1] == PRE_GAME_INFO)
+		{
+			if (!Connected[consoleplayer].bHasGameInfo)
+			{
+				TicDup = clamp<int>(NetBuffer[2], 1, MAXTICDUP);
+				uint8_t* stream = &NetBuffer[3];
+				Net_ReadGameInfo(stream);
+				Connected[consoleplayer].bHasGameInfo = true;
+			}
+
+			NetBuffer[0] = NCMD_SETUP;
+			NetBuffer[1] = PRE_GAME_INFO_ACK;
+			NetBufferLength = 2u;
+			SendPacket(from);
+		}
+		else if (NetBuffer[1] == PRE_USER_INFO)
+		{
+			const size_t c = NetBuffer[2];
+			if (!ClientGotAck(consoleplayer, c))
+			{
+				NetworkClients += c;
+				size_t byte = 3u;
+				if (c > 0)
+				{
+					Connected[c].Status = CSTAT_WAITING;
+					memcpy(&Connected[c].Address, &NetBuffer[byte], addrSize);
+					byte += addrSize;
+				}
+				else
+				{
+					Connected[c].Status = CSTAT_READY;
+				}
+				uint8_t* stream = &NetBuffer[byte];
+				Net_ReadUserInfo(c, stream);
+				SetClientAck(consoleplayer, c, true);
+
+				I_NetClientConnected(c, 16u);
+			}
+
+			NetBuffer[0] = NCMD_SETUP;
+			NetBuffer[1] = PRE_USER_INFO_ACK;
+			NetBuffer[2] = c;
+			NetBufferLength = 3u;
+			SendPacket(from);
+		}
+		else if (NetBuffer[1] == PRE_GO)
+		{
+			NetMode = static_cast<ENetMode>(NetBuffer[2]);
+			I_NetMessage("Starting game");
+			I_NetLog("Received GO");
+			return true;
+		}
+	}
+
+	NetBuffer[0] = NCMD_SETUP;
+	if (consoleplayer == -1)
+	{
+		NetBuffer[1] = PRE_CONNECT;
+		NetBuffer[2] = VER_MAJOR % 256;
+		NetBuffer[3] = VER_MINOR % 256;
+		NetBuffer[4] = VER_REVISION % 256;
+		const size_t passSize = strlen(net_password) + 1;
+		memcpy(&NetBuffer[5], net_password, passSize);
+		NetBufferLength = 5u + passSize;
+		SendPacket(Connected[0].Address);
+	}
+	else
+	{
+		auto& con = Connected[consoleplayer];
+		if (con.Status == CSTAT_CONNECTING)
+		{
+			NetBuffer[1] = PRE_USER_INFO;
+			NetBufferLength = 2u;
+
+			uint8_t* stream = &NetBuffer[NetBufferLength];
+			NetBufferLength += Net_SetUserInfo(consoleplayer, stream);
+			SendPacket(Connected[0].Address);
+		}
+		else if (con.Status == CSTAT_WAITING)
+		{
+			NetBuffer[1] = PRE_HEARTBEAT;
+			NetBufferLength = 2u;
+			SendPacket(Connected[0].Address);
+		}
+	}
+
+	return false;
+}
+
+static bool JoinGame(int arg)
+{
+	if (arg >= Args->NumArgs()
+		|| Args->GetArg(arg)[0] == '-' || Args->GetArg(arg)[0] == '+')
+	{
+		I_FatalError("You need to specify the host machine's address");
+	}
+
+	StartNetwork(true);
+
+	// Host is always client 0.
+	BuildAddress(Connected[0].Address, Args->GetArg(arg));
+	Connected[0].Status = CSTAT_CONNECTING;
+
+	I_NetInit("Contacting host...", false);
+	I_NetUpdatePlayers(0u, MaxClients);
+	I_NetClientUpdated(0);
+
+	if (!I_NetLoop(Guest_ContactHost, nullptr))
+	{
+		SendAbort();
+		throw CExitEvent(0);
+	}
+
+	for (size_t i = 1u; i < MaxClients; ++i)
+	{
+		if (Connected[i].Status != CSTAT_NONE)
+			Connected[i].Status = CSTAT_READY;
+	}
+
+	I_NetLog("Total players: %u", MaxClients);
+	I_NetDone();
+
+	return true;
+}
+
+//
+// I_InitNetwork
+//
+// Returns true if packet server mode might be a good idea.
+//
+bool I_InitNetwork()
+{
+	// set up for network
+	const char* v = Args->CheckValue("-dup");
+	if (v != nullptr)
+		TicDup = clamp<int>(atoi(v), 1, MAXTICDUP);
+
+	v = Args->CheckValue("-port");
+	if (v != nullptr)
+	{
+		GamePort = atoi(v);
+		Printf("Using alternate port %d\n", GamePort);
+	}
+
+	v = Args->CheckValue("-netmode");
+	if (v != nullptr)
+		NetMode = atoi(v) ? NET_PacketServer : NET_PeerToPeer;
+
+	net_password = Args->CheckValue("-password");
+
+	// parse network game options,
+	//		player 1: -host <numplayers>
+	//		player x: -join <player 1's address>
+	int arg = -1;
+	if ((arg = Args->CheckParm("-host")))
+	{
+		if (!HostGame(arg + 1, v != nullptr))
+			return false;
+	}
+	else if ((arg = Args->CheckParm("-join")))
+	{
+		if (!JoinGame(arg + 1))
+			return false;
+	}
+	else
+	{
+		// single player game
+		TicDup = 1;
+		consoleplayer = 0;
+		NetworkClients += 0;
+		Connected[0].Status = CSTAT_READY;
+		Net_SetupUserInfo();
+	}
+
+	bGameStarted = true;
+	return true;
+}
+
 #ifdef __WIN32__
-const char *neterror (void)
+const char* neterror()
 {
 	static char neterr[16];
 	int			code;
 
-	switch (code = WSAGetLastError ()) {
+	switch (code = WSAGetLastError()) {
 		case WSAEACCES:				return "EACCES";
 		case WSAEADDRINUSE:			return "EADDRINUSE";
 		case WSAEADDRNOTAVAIL:		return "EADDRNOTAVAIL";
@@ -1198,7 +1315,7 @@ const char *neterror (void)
 		case WSAEDISCON:			return "EDISCON";
 
 		default:
-			mysnprintf (neterr, countof(neterr), "%d", code);
+			mysnprintf(neterr, countof(neterr), "%d", code);
 			return neterr;
 	}
 }

--- a/src/common/engine/i_net.h
+++ b/src/common/engine/i_net.h
@@ -2,45 +2,43 @@
 #define __I_NET_H__
 
 #include <stdint.h>
+#include "tarray.h"
 
-// Called by D_DoomMain.
-int I_InitNetwork (void);
-void I_ClearNode(int node);
-void I_NetCmd (void);
-void I_NetMessage(const char*, ...);
-void I_NetError(const char* error);
-void I_NetProgress(int val);
-void I_NetInit(const char* msg, int num);
-bool I_NetLoop(bool (*timer_callback)(void*), void* userdata);
-void I_NetDone();
+inline constexpr size_t MAXPLAYERS = 64u;
 
 enum ENetConstants
 {
-	DOOMCOM_ID = 0x12345678,
+	DEFAULT_GAME_ID = 0x12345678,
 	BACKUPTICS = 35 * 5,	// Remember up to 5 seconds of data.
 	MAXTICDUP = 3,
 	MAXSENDTICS = 35 * 1,	// Only send up to 1 second of data at a time.
-	LOCALCMDTICS = (BACKUPTICS*MAXTICDUP),
+	LOCALCMDTICS = (BACKUPTICS * MAXTICDUP),
 	MAX_MSGLEN = 14000,
-
-	CMD_SEND = 1,
-	CMD_GET = 2,
 };
 
-enum ENCMD
+enum ENetCommand
 {
-	NCMD_EXIT				= 0x80,		// Client has left the game
-	NCMD_RETRANSMIT 		= 0x40,		// 
-	NCMD_SETUP				= 0x20,		// Guest is letting the host know who it is
-	NCMD_LEVELREADY			= 0x10,		// After loading a level, guests send this over to the host who then sends it back after all are received
-	NCMD_QUITTERS			= 0x08,		// Client is getting info about one or more players quitting (packet server only)
-	NCMD_COMPRESSED			= 0x04,		// Remainder of packet is compressed
-	NCMD_LATENCYACK			= 0x02,		// A latency packet was just read, so let the sender know.
-	NCMD_LATENCY			= 0x01,		// Latency packet, used for measuring RTT.
+	CMD_NONE,
+	CMD_SEND,
+	CMD_GET,
+};
 
-	NCMD_USERINFO			= NCMD_SETUP + 1,	// Guest is getting another client's user info
-	NCMD_GAMEINFO			= NCMD_SETUP + 2,	// Guest is getting the state of the game from the host
-	NCMD_GAMEREADY			= NCMD_SETUP + 3,	// Host has verified the game is ready to be started				
+enum ENetFlags
+{
+	NCMD_EXIT = 0x80,		// Client has left the game
+	NCMD_RETRANSMIT = 0x40,		// 
+	NCMD_SETUP = 0x20,		// Guest is letting the host know who it is
+	NCMD_LEVELREADY = 0x10,		// After loading a level, guests send this over to the host who then sends it back after all are received
+	NCMD_QUITTERS = 0x08,		// Client is getting info about one or more players quitting (packet server only)
+	NCMD_COMPRESSED = 0x04,		// Remainder of packet is compressed
+	NCMD_LATENCYACK = 0x02,		// A latency packet was just read, so let the sender know.
+	NCMD_LATENCY = 0x01,		// Latency packet, used for measuring RTT.		
+};
+
+enum ENetMode
+{
+	NET_PeerToPeer,
+	NET_PacketServer
 };
 
 struct FClientStack : public TArray<int>
@@ -59,31 +57,22 @@ struct FClientStack : public TArray<int>
 	}
 };
 
-extern FClientStack NetworkClients;
-
-//
-// Network packet data.
-//
-struct doomcom_t
-{
-	// info common to all nodes
-	uint32_t id;			// should be DOOMCOM_ID
-	int16_t	ticdup;			// 1 = no duplication, 2-3 = dup for slow nets
-	int16_t	numplayers;
-
-	// info specific to this node
-	int16_t	consoleplayer;
-
-	// communication between DOOM and the driver
-	int16_t	command;		// CMD_SEND or CMD_GET
-	int16_t	remoteplayer;		// dest for send, set by get (-1 = no packet).
-	// packet data to be sent
-	int16_t	datalength;		// bytes in data to be sent
-	uint8_t	data[MAX_MSGLEN];
-}; 
-
-extern doomcom_t doomcom;
 extern bool netgame, multiplayer;
 extern int consoleplayer;
+extern int Net_Arbitrator;
+extern FClientStack NetworkClients;
+extern ENetMode NetMode;
+extern uint8_t NetBuffer[MAX_MSGLEN];
+extern size_t NetBufferLength;
+extern uint8_t TicDup;
+extern int RemoteClient;
+extern uint8_t MaxClients;
+extern uint32_t GameID;
+
+bool I_InitNetwork();
+void I_ClearClient(size_t client);
+void I_NetCmd(ENetCommand cmd);
+void I_NetDone();
+void HandleIncomingConnection();
 
 #endif

--- a/src/common/engine/st_start.h
+++ b/src/common/engine/st_start.h
@@ -51,15 +51,21 @@ public:
 	virtual ~FStartupScreen() = default;
 
 	virtual void Progress() {}
+	virtual void AppendStatusLine(const char* status) {}
+	virtual void LoadingStatus(const char* message, int colors) {}
 
-	virtual void NetInit(const char *message, int num_players) {}
-	virtual void NetProgress(int count) {}
+	virtual void NetInit(const char* message, bool host) {}
+	virtual void NetMessage(const char* message) {}
+	virtual void NetConnect(int client, const char* name, unsigned flags, int status) {}
+	virtual void NetUpdate(int client, int status) {}
+	virtual void NetDisconnect(int client) {}
+	virtual void NetProgress(int cur, int limit) {}
 	virtual void NetDone() {}
 	virtual void NetClose() {}
 	virtual bool ShouldStartNet() { return false; }
-	virtual bool NetLoop(bool (*timer_callback)(void *), void *userdata) { return false; }
-	virtual void AppendStatusLine(const char* status) {}
-	virtual void LoadingStatus(const char* message, int colors) {}
+	virtual int GetNetKickClient() { return -1; }
+	virtual int GetNetBanClient() { return -1; }
+	virtual bool NetLoop(bool (*loopCallback)(void *), void *data) { return false; }
 
 protected:
 	int MaxPos, CurPos, NotchPos;
@@ -71,14 +77,21 @@ public:
 	FBasicStartupScreen(int max_progress);
 	~FBasicStartupScreen();
 
-	void Progress();
-	void NetInit(const char* message, int num_players);
-	void NetProgress(int count);
-	void NetMessage(const char* format, ...);	// cover for printf
-	void NetDone();
-	void NetClose();
+	void Progress() override;
+
+	void NetInit(const char* message, bool host) override;
+	void NetMessage(const char* message) override;
+	void NetConnect(int client, const char* name, unsigned flags, int status) override;
+	void NetUpdate(int client, int status) override;
+	void NetDisconnect(int client) override;
+	void NetProgress(int cur, int limit) override;
+	void NetDone() override;
+	void NetClose() override;
 	bool ShouldStartNet() override;
-	bool NetLoop(bool (*timer_callback)(void*), void* userdata);
+	int GetNetKickClient() override;
+	int GetNetBanClient() override;
+	bool NetLoop(bool (*loopCallback)(void*), void* data) override;
+
 protected:
 	int NetMaxPos, NetCurPos;
 };

--- a/src/common/platform/posix/cocoa/st_console.h
+++ b/src/common/platform/posix/cocoa/st_console.h
@@ -63,11 +63,18 @@ public:
 
 	// FStartupScreen functionality
 	void Progress(int current, int maximum);
-	void NetInit(const char* message, int playerCount);
-	void NetProgress(int count);
+
+	void NetInit(const char* const message, const bool host);
+	void NetMessage(const char* const message);
+	void NetConnect(const int client, const char* const name, const unsigned flags, const int status);
+	void NetUpdate(const int client, const int status);
+	void NetDisconnect(const int client);
+	void NetProgress(const int cur, const int limit);
 	void NetDone();
 	void NetClose();
 	bool ShouldStartNet();
+	int GetNetKickClient();
+	int GetNetBanClient();
 
 private:
 	NSWindow*            m_window;

--- a/src/common/platform/posix/cocoa/st_console.mm
+++ b/src/common/platform/posix/cocoa/st_console.mm
@@ -417,7 +417,7 @@ void FConsoleWindow::Progress(const int current, const int maximum)
 }
 
 
-void FConsoleWindow::NetInit(const char* const message, const int playerCount)
+void FConsoleWindow::NetInit(const char* const message, const bool host)
 {
 	if (nil == m_netView)
 	{
@@ -442,19 +442,9 @@ void FConsoleWindow::NetInit(const char* const message, const int playerCount)
 		// Connection progress
 		m_netProgressBar = [[NSProgressIndicator alloc] initWithFrame:NSMakeRect(12.0f, 40.0f, 488.0f, 16.0f)];
 		[m_netProgressBar setAutoresizingMask:NSViewWidthSizable];
-		[m_netProgressBar setMaxValue:playerCount];
-
-		if (0 == playerCount)
-		{
-			// Joining game
-			[m_netProgressBar setIndeterminate:YES];
-			[m_netProgressBar startAnimation:nil];
-		}
-		else
-		{
-			// Hosting game
-			[m_netProgressBar setIndeterminate:NO];
-		}
+		[m_netProgressBar setMaxValue:0];
+		[m_netProgressBar setIndeterminate:YES];
+		[m_netProgressBar startAnimation:nil];
 
 		// Cancel network game button
 		m_netAbortButton = [[NSButton alloc] initWithFrame:NSMakeRect(432.0f, 8.0f, 72.0f, 28.0f)];
@@ -486,22 +476,32 @@ void FConsoleWindow::NetInit(const char* const message, const int playerCount)
 	[m_netMessageText setStringValue:[NSString stringWithUTF8String:message]];
 
 	m_netCurPos = 0;
-	m_netMaxPos = playerCount;
-
-	NetProgress(1); // You always know about yourself
 }
 
-void FConsoleWindow::NetProgress(const int count)
+void FConsoleWindow::NetMessage(const char* const message)
 {
-	if (0 == count)
-	{
-		++m_netCurPos;
-	}
-	else
-	{
-		m_netCurPos = count;
-	}
+	[m_netMessageText setStringValue:[NSString stringWithUTF8String:message]];
+}
 
+void FConsoleWindow::NetConnect(const int client, const char* const name, const unsigned flags, const int status)
+{
+
+}
+
+void FConsoleWindow::NetUpdate(const int client, const int status)
+{
+
+}
+
+void FConsoleWindow::NetDisconnect(const int client)
+{
+
+}
+
+void FConsoleWindow::NetProgress(const int cur, const int limit)
+{
+	m_netCurPos = cur;
+	m_netMaxPos = limit;
 	if (nil == m_netView)
 	{
 		return;
@@ -540,4 +540,14 @@ void FConsoleWindow::NetClose()
 bool FConsoleWindow::ShouldStartNet()
 {
 	return false;
+}
+
+int FConsoleWindow::GetNetKickClient()
+{
+	return -1;
+}
+
+int FConsoleWindow::GetNetBanClient()
+{
+	return -1;
 }

--- a/src/common/platform/posix/cocoa/st_start.mm
+++ b/src/common/platform/posix/cocoa/st_start.mm
@@ -95,14 +95,34 @@ void FBasicStartupScreen::Progress()
 }
 
 
-void FBasicStartupScreen::NetInit(const char* const message, const int playerCount)
+void FBasicStartupScreen::NetInit(const char* const message, const bool host)
 {
-	FConsoleWindow::GetInstance().NetInit(message, playerCount);
+	FConsoleWindow::GetInstance().NetInit(message, host);
 }
 
-void FBasicStartupScreen::NetProgress(const int count)
+void FBasicStartupScreen::NetMessage(const char* const message)
 {
-	FConsoleWindow::GetInstance().NetProgress(count);
+	FConsoleWindow::GetInstance().NetMessage(message);
+}
+
+void FBasicStartupScreen::NetConnect(const int client, const char* const name, const unsigned flags, const int status)
+{
+	FConsoleWindow::GetInstance().NetConnect(client, name, flags, status);
+}
+
+void FBasicStartupScreen::NetUpdate(const int client, const int status)
+{
+	FConsoleWindow::GetInstance().NetUpdate(client, status);
+}
+
+void FBasicStartupScreen::NetDisconnect(const int client)
+{
+	FConsoleWindow::GetInstance().NetDisconnect(client);
+}
+
+void FBasicStartupScreen::NetProgress(const int cur, const int limit)
+{
+	FConsoleWindow::GetInstance().NetProgress(cur, limit);
 }
 
 void FBasicStartupScreen::NetDone()
@@ -120,11 +140,21 @@ bool FBasicStartupScreen::ShouldStartNet()
 	return FConsoleWindow::GetInstance().ShouldStartNet();
 }
 
-bool FBasicStartupScreen::NetLoop(bool (*timerCallback)(void*), void* const userData)
+int FBasicStartupScreen::GetNetKickClient()
+{
+	return FConsoleWindow::GetInstance().GetNetKickClient();
+}
+
+int FBasicStartupScreen::GetNetBanClient()
+{
+	return FConsoleWindow::GetInstance().GetNetBanClient();
+}
+
+bool FBasicStartupScreen::NetLoop(bool (*loopCallback)(void*), void* const data)
 {
 	while (true)
 	{
-		if (timerCallback(userData))
+		if (loopCallback(data))
 		{
 			break;
 		}

--- a/src/common/platform/win32/i_mainwindow.cpp
+++ b/src/common/platform/win32/i_mainwindow.cpp
@@ -118,34 +118,64 @@ void MainWindow::ShowErrorPane(const char* text)
 	restartrequest = ErrorWindow::ExecModal(text, alltext);
 }
 
-void MainWindow::ShowNetStartPane(const char* message, int maxpos)
+void MainWindow::NetInit(const char* message, bool host)
 {
-	NetStartWindow::ShowNetStartPane(message, maxpos);
+	NetStartWindow::NetInit(message, host);
 }
 
-void MainWindow::HideNetStartPane()
+void MainWindow::NetMessage(const char* message)
 {
-	NetStartWindow::HideNetStartPane();
+	NetStartWindow::NetMessage(message);
 }
 
-void MainWindow::CloseNetStartPane()
+void MainWindow::NetConnect(int client, const char* name, unsigned flags, int status)
+{
+	NetStartWindow::NetConnect(client, name, flags, status);
+}
+
+void MainWindow::NetUpdate(int client, int status)
+{
+	NetStartWindow::NetUpdate(client, status);
+}
+
+void MainWindow::NetDisconnect(int client)
+{
+	NetStartWindow::NetDisconnect(client);
+}
+
+void MainWindow::NetProgress(int cur, int limit)
+{
+	NetStartWindow::NetProgress(cur, limit);
+}
+
+void MainWindow::NetDone()
+{
+	NetStartWindow::NetDone();
+}
+
+void MainWindow::NetClose()
 {
 	NetStartWindow::NetClose();
 }
 
-bool MainWindow::ShouldStartNetGame()
+bool MainWindow::ShouldStartNet()
 {
-	return NetStartWindow::ShouldStartNetGame();
+	return NetStartWindow::ShouldStartNet();
 }
 
-void MainWindow::SetNetStartProgress(int pos)
+int MainWindow::GetNetKickClient()
 {
-	NetStartWindow::SetNetStartProgress(pos);
+	return NetStartWindow::GetNetKickClient();
 }
 
-bool MainWindow::RunMessageLoop(bool (*timer_callback)(void*), void* userdata)
+int MainWindow::GetNetBanClient()
 {
-	return NetStartWindow::RunMessageLoop(timer_callback, userdata);
+	return NetStartWindow::GetNetBanClient();
+}
+
+bool MainWindow::NetLoop(bool (*loopCallback)(void*), void* data)
+{
+	return NetStartWindow::NetLoop(loopCallback, data);
 }
 
 bool MainWindow::CheckForRestart()

--- a/src/common/platform/win32/i_mainwindow.h
+++ b/src/common/platform/win32/i_mainwindow.h
@@ -25,12 +25,18 @@ public:
 	void PrintStr(const char* cp);
 	void GetLog(std::function<bool(const void* data, uint32_t size, uint32_t& written)> writeFile);
 
-	void ShowNetStartPane(const char* message, int maxpos);
-	void SetNetStartProgress(int pos);
-	bool RunMessageLoop(bool (*timer_callback)(void*), void* userdata);
-	void HideNetStartPane();
-	void CloseNetStartPane();
-	bool ShouldStartNetGame();
+	void NetInit(const char* message, bool host);
+	void NetMessage(const char* message);
+	void NetConnect(int client, const char* name, unsigned flags, int status);
+	void NetUpdate(int client, int status);
+	void NetDisconnect(int client);
+	void NetProgress(int cur, int limit);
+	void NetDone();
+	void NetClose();
+	bool ShouldStartNet();
+	int GetNetKickClient();
+	int GetNetBanClient();
+	bool NetLoop(bool (*loopCallback)(void*), void* data);
 
 	void SetWindowTitle(const char* caption);
 

--- a/src/common/platform/win32/st_start.cpp
+++ b/src/common/platform/win32/st_start.cpp
@@ -137,14 +137,46 @@ void FBasicStartupScreen::Progress()
 //
 //==========================================================================
 
-void FBasicStartupScreen::NetInit(const char *message, int numplayers)
+void FBasicStartupScreen::NetInit(const char *message, bool host)
 {
-	NetMaxPos = numplayers;
-	mainwindow.ShowNetStartPane(message, numplayers);
-
-	NetMaxPos = numplayers;
+	mainwindow.NetInit(message, host);
 	NetCurPos = 0;
-	NetProgress(1);	// You always know about yourself
+}
+
+void FBasicStartupScreen::NetMessage(const char* message)
+{
+	mainwindow.NetMessage(message);
+}
+
+void FBasicStartupScreen::NetConnect(int client, const char* name, unsigned flags, int status)
+{
+	mainwindow.NetConnect(client, name, flags, status);
+}
+
+void FBasicStartupScreen::NetUpdate(int client, int status)
+{
+	mainwindow.NetUpdate(client, status);
+}
+
+void FBasicStartupScreen::NetDisconnect(int client)
+{
+	mainwindow.NetDisconnect(client);
+}
+
+//==========================================================================
+//
+// FBasicStartupScreen :: NetProgress
+//
+// Sets the network progress meter. If count is 0, it gets bumped by 1.
+// Otherwise, it is set to count.
+//
+//==========================================================================
+
+void FBasicStartupScreen::NetProgress(int cur, int limit)
+{
+	NetMaxPos = limit;
+	NetCurPos = cur;
+	mainwindow.NetProgress(cur, limit);
 }
 
 //==========================================================================
@@ -157,30 +189,27 @@ void FBasicStartupScreen::NetInit(const char *message, int numplayers)
 
 void FBasicStartupScreen::NetDone()
 {
-	mainwindow.HideNetStartPane();
+	mainwindow.NetDone();
 }
 
-//==========================================================================
-//
-// FBasicStartupScreen :: NetProgress
-//
-// Sets the network progress meter. If count is 0, it gets bumped by 1.
-// Otherwise, it is set to count.
-//
-//==========================================================================
-
-void FBasicStartupScreen::NetProgress(int count)
+void FBasicStartupScreen::NetClose()
 {
-	if (count == 0)
-	{
-		NetCurPos++;
-	}
-	else
-	{
-		NetCurPos = count;
-	}
+	mainwindow.NetClose();
+}
 
-	mainwindow.SetNetStartProgress(count);
+bool FBasicStartupScreen::ShouldStartNet()
+{
+	return mainwindow.ShouldStartNet();
+}
+
+int FBasicStartupScreen::GetNetKickClient()
+{
+	return mainwindow.GetNetKickClient();
+}
+
+int FBasicStartupScreen::GetNetBanClient()
+{
+	return mainwindow.GetNetBanClient();
 }
 
 //==========================================================================
@@ -197,17 +226,7 @@ void FBasicStartupScreen::NetProgress(int count)
 //
 //==========================================================================
 
-bool FBasicStartupScreen::NetLoop(bool (*timer_callback)(void *), void *userdata)
+bool FBasicStartupScreen::NetLoop(bool (*loopCallback)(void*), void* data)
 {
-	return mainwindow.RunMessageLoop(timer_callback, userdata);
-}
-
-void FBasicStartupScreen::NetClose()
-{
-	mainwindow.CloseNetStartPane();
-}
-
-bool FBasicStartupScreen::ShouldStartNet()
-{
-	return mainwindow.ShouldStartNetGame();
+	return mainwindow.NetLoop(loopCallback, data);
 }

--- a/src/common/widgets/netstartwindow.cpp
+++ b/src/common/widgets/netstartwindow.cpp
@@ -5,45 +5,141 @@
 #include "gstrings.h"
 #include <zwidget/core/timer.h>
 #include <zwidget/widgets/textlabel/textlabel.h>
+#include <zwidget/widgets/listview/listview.h>
 #include <zwidget/widgets/pushbutton/pushbutton.h>
 
 NetStartWindow* NetStartWindow::Instance = nullptr;
 
-void NetStartWindow::ShowNetStartPane(const char* message, int maxpos)
+void NetStartWindow::NetInit(const char* message, bool host)
 {
 	Size screenSize = GetScreenSize();
-	double windowWidth = 300.0;
-	double windowHeight = 150.0;
+	double windowWidth = 450.0;
+	double windowHeight = 600.0;
 
 	if (!Instance)
 	{
-		Instance = new NetStartWindow();
+		Instance = new NetStartWindow(host);
 		Instance->SetFrameGeometry((screenSize.width - windowWidth) * 0.5, (screenSize.height - windowHeight) * 0.5, windowWidth, windowHeight);
 		Instance->Show();
 	}
 
-	Instance->SetMessage(message, maxpos);
+	Instance->SetMessage(message);
 }
 
-void NetStartWindow::HideNetStartPane()
+void NetStartWindow::NetMessage(const char* message)
+{
+	if (Instance)
+		Instance->SetMessage(message);
+}
+
+void NetStartWindow::NetConnect(int client, const char* name, unsigned flags, int status)
+{
+	if (!Instance)
+		return;
+
+	std::string value = "";
+	if (flags & 1)
+		value.append("*");
+	if (flags & 2)
+		value.append("H");
+
+	Instance->LobbyWindow->UpdateItem(value, client, 1);
+	Instance->LobbyWindow->UpdateItem(name, client, 2);
+	
+	value = "";
+	if (status == 1)
+		value = "CONNECTING";
+	else if (status == 2)
+		value = "WAITING";
+	else if (status == 3)
+		value = "READY";
+
+	Instance->LobbyWindow->UpdateItem(value, client, 3);
+}
+
+void NetStartWindow::NetUpdate(int client, int status)
+{
+	if (!Instance)
+		return;
+
+	std::string value = "";
+	if (status == 1)
+		value = "CONNECTING";
+	else if (status == 2)
+		value = "WAITING";
+	else if (status == 3)
+		value = "READY";
+
+	Instance->LobbyWindow->UpdateItem(value, client, 3);
+}
+
+void NetStartWindow::NetDisconnect(int client)
+{
+	if (Instance)
+	{
+		for (size_t i = 1u; i < Instance->LobbyWindow->GetColumnAmount(); ++i)
+			Instance->LobbyWindow->UpdateItem("", client, i);
+	}
+}
+
+void NetStartWindow::NetProgress(int cur, int limit)
+{
+	if (!Instance)
+		return;
+
+	Instance->maxpos = limit;
+	Instance->SetProgress(cur);
+	for (size_t start = Instance->LobbyWindow->GetItemAmount(); start < Instance->maxpos; ++start)
+		Instance->LobbyWindow->AddItem(std::to_string(start));
+}
+
+void NetStartWindow::NetDone()
 {
 	delete Instance;
 	Instance = nullptr;
 }
 
-void NetStartWindow::SetNetStartProgress(int pos)
+void NetStartWindow::NetClose()
 {
-	if (Instance)
-		Instance->SetProgress(pos);
+	if (Instance != nullptr)
+		Instance->OnClose();
 }
 
-bool NetStartWindow::RunMessageLoop(bool (*newtimer_callback)(void*), void* newuserdata)
+bool NetStartWindow::ShouldStartNet()
+{
+	if (Instance != nullptr)
+		return Instance->shouldstart;
+
+	return false;
+}
+
+int NetStartWindow::GetNetKickClient()
+{
+	if (!Instance || !Instance->kickclients.size())
+		return -1;
+
+	int next = Instance->kickclients.back();
+	Instance->kickclients.pop_back();
+	return next;
+}
+
+int NetStartWindow::GetNetBanClient()
+{
+	if (!Instance || !Instance->banclients.size())
+		return -1;
+
+	int next = Instance->banclients.back();
+	Instance->banclients.pop_back();
+	return next;
+}
+
+bool NetStartWindow::NetLoop(bool (*loopCallback)(void*), void* data)
 {
 	if (!Instance)
 		return false;
 
-	Instance->timer_callback = newtimer_callback;
-	Instance->userdata = newuserdata;
+	Instance->timer_callback = loopCallback;
+	Instance->userdata = data;
 	Instance->CallbackException = {};
 
 	DisplayWindow::RunLoop();
@@ -57,21 +153,7 @@ bool NetStartWindow::RunMessageLoop(bool (*newtimer_callback)(void*), void* newu
 	return Instance->exitreason;
 }
 
-void NetStartWindow::NetClose()
-{
-	if (Instance != nullptr)
-		Instance->OnClose();
-}
-
-bool NetStartWindow::ShouldStartNetGame()
-{
-	if (Instance != nullptr)
-		return Instance->shouldstart;
-
-	return false;
-}
-
-NetStartWindow::NetStartWindow() : Widget(nullptr, WidgetType::Window)
+NetStartWindow::NetStartWindow(bool host) : Widget(nullptr, WidgetType::Window)
 {
 	SetWindowBackground(Colorf::fromRgba8(51, 51, 51));
 	SetWindowBorderColor(Colorf::fromRgba8(51, 51, 51));
@@ -81,27 +163,43 @@ NetStartWindow::NetStartWindow() : Widget(nullptr, WidgetType::Window)
 
 	MessageLabel = new TextLabel(this);
 	ProgressLabel = new TextLabel(this);
+	LobbyWindow = new ListView(this);
 	AbortButton = new PushButton(this);
-	ForceStartButton = new PushButton(this);
 
 	MessageLabel->SetTextAlignment(TextLabelAlignment::Center);
 	ProgressLabel->SetTextAlignment(TextLabelAlignment::Center);
 
 	AbortButton->OnClick = [=]() { OnClose(); };
-	ForceStartButton->OnClick = [=]() { ForceStart(); };
-
 	AbortButton->SetText("Abort");
-	ForceStartButton->SetText("Start Game");
+
+	if (host)
+	{
+		hosting = true;
+
+		ForceStartButton = new PushButton(this);
+		ForceStartButton->OnClick = [=]() { ForceStart(); };
+		ForceStartButton->SetText("Start Game");
+
+		KickButton = new PushButton(this);
+		KickButton->OnClick = [=]() { OnKick(); };
+		KickButton->SetText("Kick");
+
+		BanButton = new PushButton(this);
+		BanButton->OnClick = [=]() { OnBan(); };
+		BanButton->SetText("Ban");
+	}
+
+	// Client number, flags, name, status.
+	LobbyWindow->SetColumnWidths({ 30.0, 30.0, 200.0, 50.0 });
 
 	CallbackTimer = new Timer(this);
 	CallbackTimer->FuncExpired = [=]() { OnCallbackTimerExpired(); };
 	CallbackTimer->Start(500);
 }
 
-void NetStartWindow::SetMessage(const std::string& message, int newmaxpos)
+void NetStartWindow::SetMessage(const std::string& message)
 {
 	MessageLabel->SetText(message);
-	maxpos = newmaxpos;
 }
 
 void NetStartWindow::SetProgress(int newpos)
@@ -126,6 +224,36 @@ void NetStartWindow::ForceStart()
 	shouldstart = true;
 }
 
+void NetStartWindow::OnKick()
+{
+	int item = LobbyWindow->GetSelectedItem();
+
+	size_t i = 0u;
+	for (; i < kickclients.size(); ++i)
+	{
+		if (kickclients[i] == item)
+			break;
+	}
+
+	if (i >= kickclients.size())
+		kickclients.push_back(item);
+}
+
+void NetStartWindow::OnBan()
+{
+	int item = LobbyWindow->GetSelectedItem();
+
+	size_t i = 0u;
+	for (; i < banclients.size(); ++i)
+	{
+		if (banclients[i] == item)
+			break;
+	}
+
+	if (i >= banclients.size())
+		banclients.push_back(item);
+}
+
 void NetStartWindow::OnGeometryChanged()
 {
 	double w = GetWidth();
@@ -138,11 +266,23 @@ void NetStartWindow::OnGeometryChanged()
 
 	labelheight = ProgressLabel->GetPreferredHeight();
 	ProgressLabel->SetFrameGeometry(Rect::xywh(5.0, y, w - 10.0, labelheight));
-	y += labelheight;
+	y += labelheight + 5.0;
+
+	labelheight = (GetHeight() - 30.0 - AbortButton->GetPreferredHeight()) - y;
+	LobbyWindow->SetFrameGeometry(Rect::xywh(5.0, y, w - 10.0, labelheight));
 
 	y = GetHeight() - 15.0 - AbortButton->GetPreferredHeight();
-	AbortButton->SetFrameGeometry((w + 10.0) * 0.5, y, 100.0, AbortButton->GetPreferredHeight());
-	ForceStartButton->SetFrameGeometry((w - 210.0) * 0.5, y, 100.0, ForceStartButton->GetPreferredHeight());
+	if (hosting)
+	{
+		AbortButton->SetFrameGeometry((w + 215.0) * 0.5, y, 100.0, AbortButton->GetPreferredHeight());
+		BanButton->SetFrameGeometry((w + 5.0) * 0.5, y, 100.0, BanButton->GetPreferredHeight());
+		KickButton->SetFrameGeometry((w - 205.0) * 0.5, y, 100.0, KickButton->GetPreferredHeight());
+		ForceStartButton->SetFrameGeometry((w - 415.0) * 0.5, y, 100.0, ForceStartButton->GetPreferredHeight());
+	}
+	else
+	{
+		AbortButton->SetFrameGeometry((w - 100.0) * 0.5, y, 100.0, AbortButton->GetPreferredHeight());
+	}
 }
 
 void NetStartWindow::OnCallbackTimerExpired()

--- a/src/common/widgets/netstartwindow.h
+++ b/src/common/widgets/netstartwindow.h
@@ -4,37 +4,49 @@
 #include <stdexcept>
 
 class TextLabel;
+class ListView;
 class PushButton;
 class Timer;
 
 class NetStartWindow : public Widget
 {
 public:
-	static void ShowNetStartPane(const char* message, int maxpos);
-	static void HideNetStartPane();
-	static void SetNetStartProgress(int pos);
-	static bool RunMessageLoop(bool (*timer_callback)(void*), void* userdata);
+	static void NetInit(const char* message, bool host);
+	static void NetMessage(const char* message);
+	static void NetConnect(int client, const char* name, unsigned flags, int status);
+	static void NetUpdate(int client, int status);
+	static void NetDisconnect(int client);
+	static void NetProgress(int cur, int limit);
+	static void NetDone();
 	static void NetClose();
-	static bool ShouldStartNetGame();
+	static bool ShouldStartNet();
+	static int GetNetKickClient();
+	static int GetNetBanClient();
+	static bool NetLoop(bool (*timer_callback)(void*), void* userdata);
 
 private:
-	NetStartWindow();
+	NetStartWindow(bool host);
 
-	void SetMessage(const std::string& message, int maxpos);
+	void SetMessage(const std::string& message);
 	void SetProgress(int pos);
 
 protected:
 	void OnClose() override;
 	void OnGeometryChanged() override;
 	virtual void ForceStart();
+	virtual void OnKick();
+	virtual void OnBan();
 
 private:
 	void OnCallbackTimerExpired();
 
 	TextLabel* MessageLabel = nullptr;
 	TextLabel* ProgressLabel = nullptr;
+	ListView* LobbyWindow = nullptr;
 	PushButton* AbortButton = nullptr;
 	PushButton* ForceStartButton = nullptr;
+	PushButton* KickButton = nullptr;
+	PushButton* BanButton = nullptr;
 
 	Timer* CallbackTimer = nullptr;
 
@@ -45,6 +57,9 @@ private:
 
 	bool exitreason = false;
 	bool shouldstart = false;
+	bool hosting = false;
+	std::vector<int> kickclients;
+	std::vector<int> banclients;
 
 	std::exception_ptr CallbackException;
 

--- a/src/d_protocol.cpp
+++ b/src/d_protocol.cpp
@@ -446,7 +446,7 @@ int ReadUserCmdMessage(uint8_t*& stream, int player, int tic)
 void RunPlayerCommands(int player, int tic)
 {
 	// We don't have the full command yet, so don't run it.
-	if (gametic % doomcom.ticdup)
+	if (gametic % TicDup)
 		return;
 
 	int len;

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -30,6 +30,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "i_net.h"
 
 //
 // Global parameters/defines.
@@ -63,9 +64,6 @@ constexpr int TICRATE = 35;
 // Global constants that were defines.
 enum
 {
-	// The maximum number of players, multiplayer/networking.
-	MAXPLAYERS = 16,
-
 	// Amount of damage done by a telefrag.
 	TELEFRAG_DAMAGE = 1000000
 };

--- a/src/doomstat.cpp
+++ b/src/doomstat.cpp
@@ -39,9 +39,6 @@ int SaveVersion;
 // Game speed
 EGameSpeed		GameSpeed = SPEED_Normal;
 
-// [RH] Network arbitrator
-int Net_Arbitrator = 0;
-
 int NextSkill = -1;
 
 int SinglePlayerClass[MAXPLAYERS];

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -198,8 +198,6 @@ EXTERN_CVAR (Int, developer)
 
 extern bool ToggleFullscreen;
 
-extern int Net_Arbitrator;
-
 EXTERN_CVAR (Bool, var_friction)
 
 

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -622,7 +622,7 @@ void G_BuildTiccmd (usercmd_t *cmd)
 	//		and not the joystick, since we treat the joystick as
 	//		the analog device it is.
 	if (buttonMap.ButtonDown(Button_Left) || buttonMap.ButtonDown(Button_Right))
-		turnheld += doomcom.ticdup;
+		turnheld += TicDup;
 	else
 		turnheld = 0;
 
@@ -1232,7 +1232,7 @@ void G_Ticker ()
 	}
 
 	// get commands, check consistancy, and build new consistancy check
-	const int curTic = gametic / doomcom.ticdup;
+	const int curTic = gametic / TicDup;
 
 	//Added by MC: For some of that bot stuff. The main bot function.
 	primaryLevel->BotInfo.Main (primaryLevel);
@@ -2545,7 +2545,7 @@ void G_WriteDemoTiccmd (usercmd_t *cmd, int player, int buf)
 	}
 
 	// [RH] Write any special "ticcmds" for this player to the demo
-	if ((specdata = ClientStates[player].Tics[buf % BACKUPTICS].Data.GetData (&speclen)) && !(gametic % doomcom.ticdup))
+	if ((specdata = ClientStates[player].Tics[buf % BACKUPTICS].Data.GetData (&speclen)) && !(gametic % TicDup))
 	{
 		memcpy (demo_p, specdata, speclen);
 		demo_p += speclen;

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -540,6 +540,8 @@
 
 
 
+extern int Net_Arbitrator;
+
 FRandom pr_acs ("ACS");
 
 // I imagine this much stack space is probably overkill, but it could

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1,6 +1,6 @@
 // for flag changer functions.
 const FLAG_NO_CHANGE = -1;
-const MAXPLAYERS = 16;
+const MAXPLAYERS = 64;
 
 enum EStateUseFlags
 {


### PR DESCRIPTION
This is a sister rework to the recent netcode overhaul that focuses on the lobby system instead of just the front end code. In particular, the packet structure has been unified paving the way for actions like in-game joining. Alongside this a new strategy is taken with sharing user info. Rather than being done in distinct stages, info is now gotten and shared organically between them as they connect. As a result only one loop function is now needed for each, allowing for saner incoming connection handling when in-game joining is added in the indeterminate future. A new UI has been added to further allow users to see who's connected and hosts can now better manage these players via kick/ban functionality.

The max player count has been increased to 64 since the rest of the netcode can now properly handle it.

As a note, this adds a few functions to i_net that will need to be stubbed on other engines e.g. Raze. This is for the game-specific data and the functions are defined at the top of i_net.cpp with names like `SetUserData`. Also included are some changes to ZWidget that will need to be backported to the repo properly at some point.