### PR TITLE
Fix both floor and ceiling portals in same sector

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -815,9 +815,7 @@ bool HWSectorStackPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 	if (origin->plane != -1) screen->instack[origin->plane]++;
 	if (lines.Size() > 0)
 	{
-		flat.plane.GetFromSector(lines[0].sub->sector,
-								 lines[0].sub->sector->GetPortal(sector_t::ceiling)->mType & (PORTS_STACKEDSECTORTHING | PORTS_PORTAL | PORTS_LINKEDPORTAL) ?
-								 sector_t::ceiling : sector_t::floor);
+		flat.plane.GetFromSector(lines[0].sub->sector, origin->plane);
 		di->SetClipHeight(flat.plane.plane.ZatPoint(vp.Pos),
 						  flat.plane.plane.Normal().Z > 0 ? -1.f : 1.f);
 	}

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -59,8 +59,6 @@ class HWPortal
 	TArray<unsigned int> mPrimIndices;
 	unsigned int mTopCap = ~0u, mBottomCap = ~0u;
 
-	virtual void DrawPortalStencil(FRenderState &state, int pass);
-
 public:
 	FPortalSceneState * mState;
 	TArray<HWWall> lines;
@@ -84,6 +82,7 @@ public:
 	virtual bool NeedDepthBuffer() { return true; }
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state) = 0;
 	virtual void RenderAttached(HWDrawInfo *di) {}
+	virtual void DrawPortalStencil(FRenderState &state, int pass);
 	void SetupStencil(HWDrawInfo *di, FRenderState &state, bool usestencil);
 	void RemoveStencil(HWDrawInfo *di, FRenderState &state, bool usestencil);
 
@@ -106,6 +105,7 @@ struct FPortalSceneState
 
 	int PlaneMirrorMode = 0;
 	bool inskybox = 0;
+	bool vpIsAllowedOoB = 0;
 
 	UniqueList<HWSkyInfo> UniqueSkies;
 	UniqueList<HWHorizonInfo> UniqueHorizons;


### PR DESCRIPTION
Forgot to account for the case where both floor and ceiling of same sector are portals.
One line change.
See: https://github.com/ZDoom/gzdoom/issues/2973

Baka mitai.