### PR TITLE
VisualThinker Particle Rendering

### DIFF
--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -1005,6 +1005,7 @@ void DVisualThinker::Construct()
 	cursector = nullptr;
 	PT.color = 0xffffff;
 	AnimatedTexture.SetNull();
+	ParticleStyle = PT_DEFAULT;
 
 	_prev = _next = nullptr;
 	if (Level->VisualThinkerHead != nullptr)
@@ -1108,7 +1109,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, SpawnVisualThinker, SpawnVisualThink
 void DVisualThinker::UpdateSpriteInfo()
 {
 	PT.style = ERenderStyle(GetRenderStyle());
-	if((PT.flags & SPF_LOCAL_ANIM) && PT.texture != AnimatedTexture)
+	if ((PT.flags & SPF_LOCAL_ANIM) && PT.texture != AnimatedTexture)
 	{
 		AnimatedTexture = PT.texture;
 		TexAnim.InitStandaloneAnimation(PT.animData, PT.texture, Level->maptime);
@@ -1134,10 +1135,8 @@ void DVisualThinker::Tick()
 	if (ObjectFlags & OF_EuthanizeMe)
 		return;
 
-	// There won't be a standard particle for this, it's only for graphics.
-	if (!PT.texture.isValid())
+	if (!ValidTexture())
 	{
-		Printf("No valid texture, destroyed");
 		Destroy();
 		return;
 	}
@@ -1256,6 +1255,11 @@ bool DVisualThinker::isFrozen()
 	return IsFrozen(this);
 }
 
+bool DVisualThinker::ValidTexture()
+{
+	return ((flags & VTF_Particle) || PT.texture.isValid());
+}
+
 DEFINE_ACTION_FUNCTION_NATIVE(DVisualThinker, IsFrozen, IsFrozen)
 {
 	PARAM_SELF_PROLOGUE(DVisualThinker);
@@ -1355,6 +1359,8 @@ DEFINE_FIELD_NAMED(DVisualThinker, PT.alpha, Alpha);
 DEFINE_FIELD_NAMED(DVisualThinker, PT.texture, Texture);
 DEFINE_FIELD_NAMED(DVisualThinker, PT.flags, Flags);
 DEFINE_FIELD_NAMED(DVisualThinker, flags, VisualThinkerFlags);
+DEFINE_FIELD_NAMED(DVisualThinker, PT.size, PSize);
+DEFINE_FIELD_NAMED(DVisualThinker, ParticleStyle, PStyle);
 
 DEFINE_FIELD(DVisualThinker, Prev);
 DEFINE_FIELD(DVisualThinker, Scale);

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -53,6 +53,14 @@ struct FLevelLocals;
 
 // [RH] Particle details
 
+enum EParticleStyle
+{
+	PT_DEFAULT	= -1, // Use gl_particles_style
+	PT_SQUARE	= 0,
+	PT_ROUND	= 1,
+	PT_SMOOTH	= 2,
+};
+
 enum EParticleFlags
 {
 	SPF_FULLBRIGHT				= 1 << 0,

--- a/src/playsim/p_visualthinker.h
+++ b/src/playsim/p_visualthinker.h
@@ -20,6 +20,7 @@ enum EVisualThinkerFlags
 	VTF_FlipY			= 1 << 3, // flip the sprite on the x/y axis.
 	VTF_DontInterpolate	= 1 << 4, // disable all interpolation
 	VTF_AddLightLevel	= 1 << 5, // adds sector light level to 'LightLevel'
+	VTF_Particle		= 1 << 6, // Renders as a particle instead. 
 };
 
 class DVisualThinker : public DThinker
@@ -39,6 +40,7 @@ public:
 	FTranslationID	Translation;
 	FTextureID		AnimatedTexture;
 	sector_t		*cursector;
+	int8_t			ParticleStyle;
 
 	int flags;
 
@@ -53,6 +55,7 @@ public:
 	void SetTranslation(FName trname);
 	int GetRenderStyle() const;
 	bool isFrozen();
+	bool ValidTexture();
 	int GetLightLevel(sector_t *rendersector) const;
 	FVector3 InterpolatedPosition(double ticFrac) const;
 	float InterpolatedRoll(double ticFrac) const;

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1532,4 +1532,13 @@ enum EVisualThinkerFlags
 	VTF_FlipY			= 1 << 3, // flip the sprite on the x/y axis.
 	VTF_DontInterpolate	= 1 << 4, // disable all interpolation
 	VTF_AddLightLevel	= 1 << 5, // adds sector light level to 'LightLevel'
+	VTF_Particle		= 1 << 6, // Renders as a particle instead. 
+};
+
+enum EParticleStyle
+{
+	PT_DEFAULT	= -1, // Use gl_particles_style
+	PT_SQUARE	= 0,
+	PT_ROUND	= 1,
+	PT_SMOOTH	= 2,
 };

--- a/wadsrc/static/zscript/visualthinker.zs
+++ b/wadsrc/static/zscript/visualthinker.zs
@@ -14,6 +14,8 @@ Class VisualThinker : Thinker native
 	
 	native uint16			Flags;
 	native int				VisualThinkerFlags;
+	native int8				PStyle;
+	native float			PSize;
     
     FlagDef                 FlipOffsetX :       VisualThinkerFlags, 0;
     FlagDef                 FlipOffsetY :       VisualThinkerFlags, 1;


### PR DESCRIPTION
> Added particle rendering to VisualThinkers.
> 
> To activate, add `VTF_Particle` to `VisualThinkerFlags`.
> 
> While in this mode:
> - Texture, Scale & Translation have no effect
> - PSize sets the size of the particle
> - SColor is the only way to set colors
> - PStyle sets the particle shape
> 
> PStyle shapes are:
> - PT_DEFAULT (default value; use `gl_particles_style`)
> - PT_SQUARE
> - PT_ROUND
> - PT_SMOOTH
> 
> Misc changes:
> - Removed warning on textureless destruction

Also worth noting: 
I was going to attempt adding the ability to specify what type of shape regular (non-vthinker) particles could be, but that's currently impossible due to `particle_t` being locked to 128 in size, so I'll leave that to someone else to attempt.

Currently this is hardware only. Once this is merged, I'll look into the possibility of adding it for software. But that's neither a promise it'll happen, nor a guarantee it'll work.