### PR TITLE
Particle rendering for VisualThinkers

### DIFF
--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -53,6 +53,14 @@ struct FLevelLocals;
 
 // [RH] Particle details
 
+enum EParticleStyle
+{
+	PT_DEFAULT	= -1, // Use gl_particles_style
+	PT_SQUARE	= 0,
+	PT_ROUND	= 1,
+	PT_SMOOTH	= 2,
+};
+
 enum EParticleFlags
 {
 	SPF_FULLBRIGHT				= 1 << 0,

--- a/src/playsim/p_visualthinker.h
+++ b/src/playsim/p_visualthinker.h
@@ -20,6 +20,12 @@ enum EVisualThinkerFlags
 	VTF_FlipY			= 1 << 3, // flip the sprite on the x/y axis.
 	VTF_DontInterpolate	= 1 << 4, // disable all interpolation
 	VTF_AddLightLevel	= 1 << 5, // adds sector light level to 'LightLevel'
+
+	VTF_ParticleDefault = 0x40, 
+	VTF_ParticleSquare = 0x80, 
+	VTF_ParticleRound = 0xC0, 
+	VTF_ParticleSmooth = 0x100,
+	VTF_IsParticle = 0x1C0,			// Renders as a particle instead
 };
 
 class DVisualThinker : public DThinker
@@ -53,6 +59,8 @@ public:
 	void SetTranslation(FName trname);
 	int GetRenderStyle() const;
 	bool isFrozen();
+	bool ValidTexture();
+	int GetParticleType() const;
 	int GetLightLevel(sector_t *rendersector) const;
 	FVector3 InterpolatedPosition(double ticFrac) const;
 	float InterpolatedRoll(double ticFrac) const;

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1532,4 +1532,18 @@ enum EVisualThinkerFlags
 	VTF_FlipY			= 1 << 3, // flip the sprite on the x/y axis.
 	VTF_DontInterpolate	= 1 << 4, // disable all interpolation
 	VTF_AddLightLevel	= 1 << 5, // adds sector light level to 'LightLevel'
+
+	VTF_ParticleDefault = 0x40, 
+	VTF_ParticleSquare	= 0x80, 
+	VTF_ParticleRound	= 0xC0, 
+	VTF_ParticleSmooth	= 0x100,
+	VTF_IsParticle		= 0x1C0
+};
+
+enum EParticleStyle
+{
+	PT_DEFAULT	= -1, // Use gl_particles_style
+	PT_SQUARE	= 0,
+	PT_ROUND	= 1,
+	PT_SMOOTH	= 2,
 };

--- a/wadsrc/static/zscript/visualthinker.zs
+++ b/wadsrc/static/zscript/visualthinker.zs
@@ -60,4 +60,30 @@ Class VisualThinker : Thinker native
 		}
 		return p;
 	}
+
+	native int GetParticleType() const;
+
+	void SetParticleType(EParticleStyle type = PT_DEFAULT)
+	{
+		switch(type)
+		{
+		Default:
+			VisualThinkerFlags = (VisualThinkerFlags & ~VTF_IsParticle) | VTF_ParticleDefault;
+			break;
+		case PT_SQUARE:
+			VisualThinkerFlags = (VisualThinkerFlags & ~VTF_IsParticle) | VTF_ParticleSquare;
+			break;
+		case PT_ROUND:
+			VisualThinkerFlags = (VisualThinkerFlags & ~VTF_IsParticle) | VTF_ParticleRound;
+			break;
+		case PT_SMOOTH:
+			VisualThinkerFlags = (VisualThinkerFlags & ~VTF_IsParticle) | VTF_ParticleSmooth;
+			break;
+		}
+	}
+
+	void DisableParticle()
+	{
+		VisualThinkerFlags &= ~VTF_IsParticle;
+	}
 }


### PR DESCRIPTION
To activate, use `SetParticleType(int type)`. To deactivate, use `DisableParticle()`.

Types are:
- PT_DEFAULT (default value; uses `gl_particles_style`)
- PT_SQUARE
- PT_ROUND
- PT_SMOOTH

While in this mode:
- `Texture` & `Translation` are ignored
- `Scale.X` sets the size
- `SColor` sets the color

Misc changes:
- Removed warning on textureless destruction