### PR TITLE
Added client-side Thinkers

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -261,7 +261,7 @@ CCMD(togglemap)
 {
 	if (gameaction == ga_nothing)
 	{
-		gameaction = ga_togglemap;
+		AM_ToggleMap();
 	}
 }
 

--- a/src/common/objects/dobject.cpp
+++ b/src/common/objects/dobject.cpp
@@ -573,6 +573,7 @@ void DObject::Serialize(FSerializer &arc)
 	SerializeFlag("justspawned", OF_JustSpawned);
 	SerializeFlag("spawned", OF_Spawned);
 	SerializeFlag("networked", OF_Networked);
+	SerializeFlag("clientside", OF_ClientSide);
 		
 	ObjectFlags |= OF_SerialSuccess;
 
@@ -668,7 +669,7 @@ void NetworkEntityManager::SetClientNetworkEntity(DObject* mo, const unsigned in
 
 void NetworkEntityManager::AddNetworkEntity(DObject* const ent)
 {
-	if (ent->IsNetworked())
+	if (ent->IsNetworked() || ent->IsClientside())
 		return;
 
 	// Slot 0 is reserved for the world.
@@ -756,6 +757,18 @@ DEFINE_ACTION_FUNCTION_NATIVE(DObject, GetNetworkID, GetNetworkID)
 	PARAM_SELF_PROLOGUE(DObject);
 
 	ACTION_RETURN_INT(self->GetNetworkID());
+}
+
+static int IsClientside(DObject* self)
+{
+	return self->IsClientside();
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(DObject, IsClientside, IsClientside)
+{
+	PARAM_SELF_PROLOGUE(DObject);
+
+	ACTION_RETURN_BOOL(self->IsClientside());
 }
 
 static void EnableNetworking(DObject* const self, const bool enable)

--- a/src/common/objects/dobject.h
+++ b/src/common/objects/dobject.h
@@ -359,6 +359,7 @@ private:
 public:
 	inline bool IsNetworked() const { return (ObjectFlags & OF_Networked); }
 	inline uint32_t GetNetworkID() const { return _networkID; }
+	inline bool IsClientside() const { return (ObjectFlags & OF_ClientSide); }
 	void SetNetworkID(const uint32_t id);
 	void ClearNetworkID();
 	void RemoveFromNetwork();

--- a/src/common/objects/dobjgc.h
+++ b/src/common/objects/dobjgc.h
@@ -27,6 +27,7 @@ enum EObjectFlags
 	OF_Spawned			= 1 << 12,      // Thinker was spawned at all (some thinkers get deleted before spawning)
 	OF_Released			= 1 << 13,		// Object was released from the GC system and should not be processed by GC function
 	OF_Networked		= 1 << 14,		// Object has a unique network identifier that makes it synchronizable between all clients.
+	OF_ClientSide		= 1 << 15,		// Object is owned by a specific client rather than the server
 };
 
 template<class T> class TObjPtr;

--- a/src/common/objects/dobjtype.cpp
+++ b/src/common/objects/dobjtype.cpp
@@ -440,7 +440,7 @@ DObject *PClass::CreateNew()
 	ConstructNative (mem);
 
 	if (Defaults != nullptr)
-		((DObject *)mem)->ObjectFlags |= ((DObject *)Defaults)->ObjectFlags & OF_Transient;
+		((DObject *)mem)->ObjectFlags |= ((DObject *)Defaults)->ObjectFlags & (OF_Transient | OF_ClientSide);
 
 	((DObject *)mem)->SetClass (const_cast<PClass *>(this));
 	InitializeSpecials(mem, Defaults, &PClass::SpecialInits);

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1136,12 +1136,6 @@ void G_Ticker ()
 			primaryLevel->DoReborn(i, false);
 	}
 
-	if (ToggleFullscreen)
-	{
-		ToggleFullscreen = false;
-		AddCommandString ("toggle vid_fullscreen");
-	}
-
 	// do things to change the game state
 	oldgamestate = gamestate;
 	while (gameaction != ga_nothing)
@@ -1192,17 +1186,8 @@ void G_Ticker ()
 		case ga_worlddone:
 			G_DoWorldDone ();
 			break;
-		case ga_screenshot:
-			M_ScreenShot (shotfile.GetChars());
-			shotfile = "";
-			gameaction = ga_nothing;
-			break;
 		case ga_fullconsole:
 			G_FullConsole ();
-			gameaction = ga_nothing;
-			break;
-		case ga_togglemap:
-			AM_ToggleMap ();
 			gameaction = ga_nothing;
 			break;
 		case ga_resumeconversation:
@@ -1263,18 +1248,12 @@ void G_Ticker ()
 		}
 	}
 
-	// [ZZ] also tick the UI part of the events
-	primaryLevel->localEventManager->UiTick();
 	C_RunDelayedCommands();
 
 	// do main actions
 	switch (gamestate)
 	{
 	case GS_LEVEL:
-		P_Ticker ();
-		primaryLevel->automap->Ticker ();
-		break;
-
 	case GS_TITLELEVEL:
 		P_Ticker ();
 		break;
@@ -1303,9 +1282,6 @@ void G_Ticker ()
 	default:
 		break;
 	}
-
-	// [MK] Additional ticker for UI events right after all others
-	primaryLevel->localEventManager->PostUiTick();
 }
 
 
@@ -1844,7 +1820,8 @@ void G_ScreenShot (const char *filename)
 	if (gameaction == ga_nothing)
 	{
 		shotfile = filename;
-		gameaction = ga_screenshot;
+		M_ScreenShot(shotfile.GetChars());
+		shotfile = "";
 	}
 }
 

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -457,7 +457,7 @@ void G_NewInit ()
 	int i;
 
 	// Destory all old player refrences that may still exist
-	TThinkerIterator<AActor> it(primaryLevel, NAME_PlayerPawn, STAT_TRAVELLING);
+	TThinkerIterator<AActor> it(primaryLevel, NAME_PlayerPawn, STAT_TRAVELLING, false);
 	AActor *pawn, *next;
 
 	next = it.Next();
@@ -473,6 +473,7 @@ void G_NewInit ()
 	// Destroy thinkers that may remain after change level failure
 	// Usually, the list contains just a sentinel when such error occurred
 	primaryLevel->Thinkers.DestroyThinkersInList(STAT_TRAVELLING);
+	primaryLevel->ClientsideThinkers.DestroyThinkersInList(STAT_TRAVELLING); // This isn't currently supported, but maybe in the future
 
 	G_ClearSnapshots ();
 	netgame = false;
@@ -586,6 +587,7 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 	for (auto Level : AllLevels())
 	{
 		Level->Thinkers.DestroyThinkersInList(STAT_STATIC);
+		Level->ClientsideThinkers.DestroyThinkersInList(STAT_STATIC);
 	}
 
 	if (paused)
@@ -1780,6 +1782,7 @@ int FLevelLocals::FinishTravel ()
 	// Since this list is excluded from regular thinker cleaning, anything that may survive through here
 	// will endlessly multiply and severely break the following savegames or just simply crash on broken pointers.
 	Thinkers.DestroyThinkersInList(STAT_TRAVELLING);
+	ClientsideThinkers.DestroyThinkersInList(STAT_TRAVELLING);
 	return failnum;
 }
  
@@ -2284,6 +2287,7 @@ void FLevelLocals::Mark()
 	GC::Mark(SpotState);
 	GC::Mark(FraggleScriptThinker);
 	GC::Mark(ACSThinker);
+	GC::Mark(ClientSideACSThinker);
 	GC::Mark(automap);
 	GC::Mark(interpolator.Head);
 	GC::Mark(SequenceListHead);
@@ -2296,6 +2300,7 @@ void FLevelLocals::Mark()
 		GC::Mark(localEventManager->LastEventHandler);
 	}
 	Thinkers.MarkRoots();
+	ClientsideThinkers.MarkRoots();
 	canvasTextureInfo.Mark();
 	for (auto &c : CorpseQueue)
 	{

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -138,8 +138,8 @@ struct FLevelLocals
 	void ClearAllSubsectorLinks();
 	void TranslateLineDef (line_t *ld, maplinedef_t *mld, int lineindexforid = -1);
 	int TranslateSectorSpecial(int special);
-	bool IsTIDUsed(int tid);
-	int FindUniqueTID(int start_tid, int limit);
+	bool IsTIDUsed(int tid, bool clientside);
+	int FindUniqueTID(int start_tid, int limit, bool clientside);
 	int GetConversation(int conv_id);
 	int GetConversation(FName classname);
 	void SetConversation(int convid, PClassActor *Class, int dlgindex);
@@ -249,6 +249,7 @@ public:
 	void SpawnExtraPlayers();
 	void Serialize(FSerializer &arc, bool hubload);
 	DThinker *FirstThinker (int statnum);
+	DThinker* FirstClientsideThinker(int statnum);
 
 	// g_Game
 	void PlayerReborn (int player);
@@ -295,12 +296,21 @@ public:
 	}
 	template<class T> TThinkerIterator<T> GetThinkerIterator(FName subtype = NAME_None, int statnum = MAX_STATNUM+1)
 	{
-		if (subtype == NAME_None) return TThinkerIterator<T>(this, statnum);
-		else return TThinkerIterator<T>(this, subtype, statnum);
+		if (subtype == NAME_None) return TThinkerIterator<T>(this, statnum, false);
+		else return TThinkerIterator<T>(this, subtype, statnum, false);
 	}
 	template<class T> TThinkerIterator<T> GetThinkerIterator(FName subtype, int statnum, AActor *prev)
 	{
-		return TThinkerIterator<T>(this, subtype, statnum, prev);
+		return TThinkerIterator<T>(this, subtype, statnum, prev, false);
+	}
+	template<class T> TThinkerIterator<T> GetClientsideThinkerIterator(FName subtype = NAME_None, int statnum = MAX_STATNUM + 1)
+	{
+		if (subtype == NAME_None) return TThinkerIterator<T>(this, statnum, true);
+		else return TThinkerIterator<T>(this, subtype, statnum, true);
+	}
+	template<class T> TThinkerIterator<T> GetClientsideThinkerIterator(FName subtype, int statnum, AActor* prev)
+	{
+		return TThinkerIterator<T>(this, subtype, statnum, prev, true);
 	}
 	FActorIterator GetActorIterator(int tid)
 	{
@@ -313,6 +323,18 @@ public:
 	NActorIterator GetActorIterator(FName type, int tid)
 	{
 		return NActorIterator(TIDHash, type, tid);
+	}
+	FActorIterator GetClientSideActorIterator(int tid)
+	{
+		return FActorIterator(ClientSideTIDHash, tid);
+	}
+	FActorIterator GetClientSideActorIterator(int tid, AActor* start)
+	{
+		return FActorIterator(ClientSideTIDHash, tid, start);
+	}
+	NActorIterator GetClientSideActorIterator(FName type, int tid)
+	{
+		return NActorIterator(ClientSideTIDHash, type, tid);
 	}
 	AActor *SingleActorFromTID(int tid, AActor *defactor)
 	{
@@ -411,6 +433,7 @@ public:
 	void ClearTIDHashes ()
 	{
 		memset(TIDHash, 0, sizeof(TIDHash));
+		memset(ClientSideTIDHash, 0, sizeof(ClientSideTIDHash));
 	}
 
 
@@ -438,6 +461,24 @@ public:
 	T* CreateThinker(Args&&... args)
 	{
 		auto thinker = static_cast<T*>(CreateThinker(RUNTIME_CLASS(T), T::DEFAULT_STAT));
+		thinker->Construct(std::forward<Args>(args)...);
+		return thinker;
+	}
+
+	DThinker* CreateClientsideThinker(PClass* cls, int statnum = STAT_DEFAULT)
+	{
+		DThinker* thinker = static_cast<DThinker*>(cls->CreateNew());
+		assert(thinker->IsKindOf(RUNTIME_CLASS(DThinker)));
+		thinker->ObjectFlags |= OF_JustSpawned | OF_ClientSide | OF_Transient;
+		ClientsideThinkers.Link(thinker, statnum);
+		thinker->Level = this;
+		return thinker;
+	}
+
+	template<typename T, typename... Args>
+	T* CreateClientsideThinker(Args&&... args)
+	{
+		auto thinker = static_cast<T*>(CreateClientsideThinker(RUNTIME_CLASS(T), T::DEFAULT_STAT));
 		thinker->Construct(std::forward<Args>(args)...);
 		return thinker;
 	}
@@ -511,6 +552,7 @@ public:
 
 	FBehaviorContainer Behaviors;
 	AActor *TIDHash[128];
+	AActor* ClientSideTIDHash[128];
 
 	TArray<FStrifeDialogueNode *> StrifeDialogues;
 	FDialogueIDMap DialogueRoots;
@@ -674,6 +716,7 @@ public:
 	TArray<particle_t>	Particles;
 	TArray<uint16_t>	ParticlesInSubsec;
 	FThinkerCollection Thinkers;
+	FThinkerCollection ClientsideThinkers;
 
 	TArray<DVector2>	Scrolls;		// NULL if no DScrollers in this level
 
@@ -710,6 +753,7 @@ public:
 	TArray<TObjPtr<AActor *>> CorpseQueue;
 	TObjPtr<DFraggleThinker *> FraggleScriptThinker = MakeObjPtr<DFraggleThinker*>(nullptr);
 	TObjPtr<DACSThinker*> ACSThinker = MakeObjPtr<DACSThinker*>(nullptr);
+	TObjPtr<DACSThinker*> ClientSideACSThinker = MakeObjPtr<DACSThinker*>(nullptr);
 
 	TObjPtr<DSpotState *> SpotState = MakeObjPtr<DSpotState*>(nullptr);
 

--- a/src/gamedata/info.cpp
+++ b/src/gamedata/info.cpp
@@ -63,6 +63,7 @@ extern void ClearStrifeTypes();
 
 TArray<PClassActor *> PClassActor::AllActorClasses;
 FRandom FState::pr_statetics("StateTics");
+FCRandom FState::pr_csstatetics("ClientsideStateTics");
 
 cycle_t ActionCycles;
 
@@ -489,7 +490,7 @@ void PClassActor::InitializeDefaults()
 				memset(Defaults + ParentClass->Size, 0, Size - ParentClass->Size);
 			}
 
-			optr->ObjectFlags = ((DObject*)ParentClass->Defaults)->ObjectFlags & OF_Transient;
+			optr->ObjectFlags = ((DObject*)ParentClass->Defaults)->ObjectFlags & (OF_Transient | OF_ClientSide);
 		}
 		else
 		{

--- a/src/gamedata/info.h
+++ b/src/gamedata/info.h
@@ -150,6 +150,14 @@ public:
 		}
 		return Tics + pr_statetics.GenRand32() % (TicRange + 1);
 	}
+	inline int GetClientsideTics() const
+	{
+		if (TicRange == 0)
+		{
+			return Tics;
+		}
+		return Tics + pr_csstatetics.GenRand32() % (TicRange + 1);
+	}
 	inline int GetMisc1() const
 	{
 		return Misc1;
@@ -176,6 +184,7 @@ public:
 	static PClassActor *StaticFindStateOwner (const FState *state, PClassActor *info);
 	static FString StaticGetStateName(const FState *state, PClassActor *info = nullptr);
 	static FRandom pr_statetics;
+	static FCRandom pr_csstatetics;
 
 };
 

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -949,6 +949,7 @@ void FLevelLocals::Serialize(FSerializer &arc, bool hubload)
 	if (arc.isReading())
 	{
 		Thinkers.DestroyAllThinkers();
+		ClientsideThinkers.DestroyAllThinkers();
 		interpolator.ClearInterpolations();
 		arc.ReadObjects(hubload);
 		// If there have been object deserialization errors we must absolutely not continue here because scripted objects can do unpredictable things.

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -296,6 +296,7 @@ void FLevelLocals::ClearLevelData(bool fullgc)
 	
 	interpolator.ClearInterpolations();	// [RH] Nothing to interpolate on a fresh level.
 	Thinkers.DestroyAllThinkers(fullgc);
+	ClientsideThinkers.DestroyAllThinkers(fullgc);
 	ClearAllSubsectorLinks(); // can't be done as part of the polyobj deletion process.
 
 	total_monsters = total_items = total_secrets =
@@ -331,6 +332,7 @@ void FLevelLocals::ClearLevelData(bool fullgc)
 	if (SpotState) SpotState->Destroy();
 	SpotState = nullptr;
 	ACSThinker = nullptr;
+	ClientSideACSThinker = nullptr;
 	FraggleScriptThinker = nullptr;
 	CorpseQueue.Clear();
 	canvasTextureInfo.EmptyList();
@@ -644,6 +646,7 @@ void P_Shutdown ()
 	for (auto Level : AllLevels())
 	{
 		Level->Thinkers.DestroyThinkersInList(STAT_STATIC);
+		Level->ClientsideThinkers.DestroyThinkersInList(STAT_STATIC);
 	}
 	P_FreeLevelData ();
 	// [ZZ] delete global event handlers

--- a/src/playsim/dthinker.cpp
+++ b/src/playsim/dthinker.cpp
@@ -269,6 +269,66 @@ void FThinkerCollection::RunThinkers(FLevelLocals *Level)
 
 //==========================================================================
 //
+// This version doesn't modify the level since that's already been done by
+// the networked ticking. This also runs while the player is predicting
+// to make sure it keeps ticking regardless of network game status.
+//
+//==========================================================================
+
+void FThinkerCollection::RunClientsideThinkers(FLevelLocals* Level)
+{
+	int i, count;
+
+	bool dolights;
+	if ((gl_lights && vid_rendermode == 4) || (r_dynlights && vid_rendermode != 4))
+	{
+		dolights = true;// Level->lights || (Level->flags3 & LEVEL3_LIGHTCREATED);
+	}
+	else
+	{
+		dolights = false;
+	}
+
+	auto recreateLights = [=]() {
+		auto it = Level->GetClientsideThinkerIterator<AActor>();
+
+		// Set dynamic lights at the end of the tick, so that this catches all changes being made through the last frame.
+		while (auto ac = it.Next())
+		{
+			if (ac->flags8 & MF8_RECREATELIGHTS)
+			{
+				ac->flags8 &= ~MF8_RECREATELIGHTS;
+				if (dolights) ac->SetDynamicLights();
+			}
+			// This was merged from P_RunEffects to eliminate the costly duplicate ThinkerIterator loop.
+			if ((ac->effects || ac->fountaincolor) && ac->ShouldRenderLocally() && !Level->isFrozen())
+			{
+				P_RunEffect(ac, ac->effects);
+			}
+		}
+	};
+
+	// Tick every thinker left from last time
+	for (i = STAT_FIRST_THINKING; i <= MAX_STATNUM; ++i)
+	{
+		Thinkers[i].TickThinkers(nullptr);
+	}
+
+	// Keep ticking the fresh thinkers until there are no new ones.
+	do
+	{
+		count = 0;
+		for (i = STAT_FIRST_THINKING; i <= MAX_STATNUM; ++i)
+		{
+			count += FreshThinkers[i].TickThinkers(&Thinkers[i]);
+		}
+	} while (count != 0);
+
+	recreateLights();
+}
+
+//==========================================================================
+//
 // Destroy every thinker
 //
 //==========================================================================
@@ -784,6 +844,11 @@ DThinker *FLevelLocals::FirstThinker (int statnum)
 	return Thinkers.FirstThinker(statnum);
 }
 
+DThinker* FLevelLocals::FirstClientsideThinker(int statnum)
+{
+	return ClientsideThinkers.FirstThinker(statnum);
+}
+
 //==========================================================================
 //
 //
@@ -797,7 +862,10 @@ void DThinker::ChangeStatNum (int statnum)
 		statnum = MAX_STATNUM;
 	}
 	Remove();
-	Level->Thinkers.Link(this, statnum);
+	if (IsClientside())
+		Level->ClientsideThinkers.Link(this, statnum);
+	else
+		Level->Thinkers.Link(this, statnum);
 }
 
 static void ChangeStatNum(DThinker *thinker, int statnum)
@@ -923,8 +991,9 @@ size_t DThinker::PropagateMark()
 //
 //==========================================================================
 
-FThinkerIterator::FThinkerIterator (FLevelLocals *l, const PClass *type, int statnum) : Level(l)
+FThinkerIterator::FThinkerIterator (FLevelLocals *l, const PClass *type, int statnum, bool clientside) : Level(l)
 {
+	m_ThinkerPool = clientside ? &Level->ClientsideThinkers : &Level->Thinkers;
 	if ((unsigned)statnum > MAX_STATNUM)
 	{
 		m_Stat = STAT_FIRST_THINKING;
@@ -945,8 +1014,9 @@ FThinkerIterator::FThinkerIterator (FLevelLocals *l, const PClass *type, int sta
 //
 //==========================================================================
 
-FThinkerIterator::FThinkerIterator (FLevelLocals *l, const PClass *type, int statnum, DThinker *prev) : Level(l)
+FThinkerIterator::FThinkerIterator (FLevelLocals *l, const PClass *type, int statnum, DThinker *prev, bool clientside) : Level(l)
 {
+	m_ThinkerPool = clientside ? &Level->ClientsideThinkers : &Level->Thinkers;
 	if ((unsigned)statnum > MAX_STATNUM)
 	{
 		m_Stat = STAT_FIRST_THINKING;
@@ -977,7 +1047,7 @@ FThinkerIterator::FThinkerIterator (FLevelLocals *l, const PClass *type, int sta
 
 void FThinkerIterator::Reinit ()
 {
-	m_CurrThinker = Level->Thinkers.Thinkers[m_Stat].GetHead();
+	m_CurrThinker = m_ThinkerPool->Thinkers[m_Stat].GetHead();
 	m_SearchingFresh = false;
 }
 
@@ -1018,7 +1088,7 @@ DThinker *FThinkerIterator::Next (bool exact)
 			}
 			if ((m_SearchingFresh = !m_SearchingFresh))
 			{
-				m_CurrThinker = Level->Thinkers.FreshThinkers[m_Stat].GetHead();
+				m_CurrThinker = m_ThinkerPool->FreshThinkers[m_Stat].GetHead();
 			}
 		} while (m_SearchingFresh);
 		if (m_SearchStats)
@@ -1029,7 +1099,7 @@ DThinker *FThinkerIterator::Next (bool exact)
 				m_Stat = STAT_FIRST_THINKING;
 			}
 		}
-		m_CurrThinker = Level->Thinkers.Thinkers[m_Stat].GetHead();
+		m_CurrThinker = m_ThinkerPool->Thinkers[m_Stat].GetHead();
 		m_SearchingFresh = false;
 	} while (m_SearchStats && m_Stat != STAT_FIRST_THINKING);
 	return nullptr;

--- a/src/playsim/dthinker.h
+++ b/src/playsim/dthinker.h
@@ -79,6 +79,7 @@ struct FThinkerCollection
 	}
 
 	void RunThinkers(FLevelLocals *Level);	// The level is needed to tick the lights
+	void RunClientsideThinkers(FLevelLocals* Level);
 	void DestroyAllThinkers(bool fullgc = true);
 	void SerializeThinkers(FSerializer &arc, bool keepPlayers);
 	void MarkRoots();
@@ -132,14 +133,15 @@ protected:
 	const PClass *m_ParentType;
 private:
 	FLevelLocals *Level;
+	FThinkerCollection* m_ThinkerPool;
 	DThinker *m_CurrThinker;
 	uint8_t m_Stat;
 	bool m_SearchStats;
 	bool m_SearchingFresh;
 
 public:
-	FThinkerIterator (FLevelLocals *Level, const PClass *type, int statnum=MAX_STATNUM+1);
-	FThinkerIterator (FLevelLocals *Level, const PClass *type, int statnum, DThinker *prev);
+	FThinkerIterator (FLevelLocals *Level, const PClass *type, int statnum=MAX_STATNUM+1, bool clientside = false);
+	FThinkerIterator (FLevelLocals *Level, const PClass *type, int statnum, DThinker *prev, bool clientside = false);
 	DThinker *Next (bool exact = false);
 	void Reinit ();
 };
@@ -147,19 +149,19 @@ public:
 template <class T> class TThinkerIterator : public FThinkerIterator
 {
 public:
-	TThinkerIterator (FLevelLocals *Level, int statnum=MAX_STATNUM+1) : FThinkerIterator (Level, RUNTIME_CLASS(T), statnum)
+	TThinkerIterator (FLevelLocals *Level, int statnum=MAX_STATNUM+1, bool clientside = false) : FThinkerIterator (Level, RUNTIME_CLASS(T), statnum, clientside)
 	{
 	}
-	TThinkerIterator (FLevelLocals *Level, int statnum, DThinker *prev) : FThinkerIterator (Level, RUNTIME_CLASS(T), statnum, prev)
+	TThinkerIterator (FLevelLocals *Level, int statnum, DThinker *prev, bool clientside = false) : FThinkerIterator (Level, RUNTIME_CLASS(T), statnum, prev, clientside)
 	{
 	}
-	TThinkerIterator (FLevelLocals *Level, const PClass *subclass, int statnum=MAX_STATNUM+1) : FThinkerIterator(Level, subclass, statnum)
+	TThinkerIterator (FLevelLocals *Level, const PClass *subclass, int statnum=MAX_STATNUM+1, bool clientside = false) : FThinkerIterator(Level, subclass, statnum, clientside)
 	{
 	}
-	TThinkerIterator (FLevelLocals *Level, FName subclass, int statnum=MAX_STATNUM+1) : FThinkerIterator(Level, PClass::FindClass(subclass), statnum)
+	TThinkerIterator (FLevelLocals *Level, FName subclass, int statnum=MAX_STATNUM+1, bool clientside = false) : FThinkerIterator(Level, PClass::FindClass(subclass), statnum, clientside)
 	{
 	}
-	TThinkerIterator (FLevelLocals *Level, FName subclass, int statnum, DThinker *prev) : FThinkerIterator(Level, PClass::FindClass(subclass), statnum, prev)
+	TThinkerIterator (FLevelLocals *Level, FName subclass, int statnum, DThinker *prev, bool clientside = false) : FThinkerIterator(Level, PClass::FindClass(subclass), statnum, prev, clientside)
 	{
 	}
 	T *Next (bool exact = false)

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -653,6 +653,11 @@ struct CallReturn
 };
 
 
+static bool IsClientSideScript(const ScriptPtr& script)
+{
+	return (script.Flags & SCRIPTF_ClientSide);
+}
+
 class DLevelScript : public DObject
 {
 	DECLARE_CLASS(DLevelScript, DObject)
@@ -675,7 +680,7 @@ public:
 	};
 
 	DLevelScript(FLevelLocals *l, AActor *who, line_t *where, int num, const ScriptPtr *code, FBehavior *module,
-		const int *args, int argcount, int flags);
+		const int *args, int argcount, int flags, bool clientside);
 
 	void Serialize(FSerializer &arc);
 	int RunScript();
@@ -700,6 +705,7 @@ public:
 
 protected:
 	DLevelScript	*next, *prev;
+	TObjPtr<DACSThinker*> controller;
 	int				script;
 	TArray<int32_t>	Localvars;
 	int				*pc;
@@ -783,7 +789,7 @@ private:
 };
 
 static DLevelScript *P_GetScriptGoing (FLevelLocals *Level, AActor *who, line_t *where, int num, const ScriptPtr *code, FBehavior *module,
-	const int *args, int argcount, int flags);
+	const int *args, int argcount, int flags, bool clientside);
 
 
 struct FBehavior::ArrayInfo
@@ -2015,6 +2021,13 @@ void FBehaviorContainer::MarkLevelVarStrings()
 			script->MarkLocalVarStrings();
 		}
 	}
+	if (Level->ClientSideACSThinker != nullptr)
+	{
+		for (DLevelScript* script = Level->ClientSideACSThinker->Scripts; script != NULL; script = script->GetNext())
+		{
+			script->MarkLocalVarStrings();
+		}
+	}
 }
 
 void FBehaviorContainer::LockLevelVarStrings(int levelnum)
@@ -2028,6 +2041,13 @@ void FBehaviorContainer::LockLevelVarStrings(int levelnum)
 	if (Level->ACSThinker != nullptr)
 	{
 		for (DLevelScript *script = Level->ACSThinker->Scripts; script != NULL; script = script->GetNext())
+		{
+			script->LockLocalVarStrings(levelnum);
+		}
+	}
+	if (Level->ClientSideACSThinker != nullptr)
+	{
+		for (DLevelScript* script = Level->ClientSideACSThinker->Scripts; script != NULL; script = script->GetNext())
 		{
 			script->LockLocalVarStrings(levelnum);
 		}
@@ -3307,7 +3327,7 @@ void FBehavior::StartTypedScripts (uint16_t type, AActor *activator, bool always
 		if (ptr->Type == type)
 		{
 			DLevelScript *runningScript = P_GetScriptGoing (Level, activator, NULL, ptr->Number,
-				ptr, this, &arg1, 1, always ? ACS_ALWAYS : 0);
+				ptr, this, &arg1, 1, always ? ACS_ALWAYS : 0, IsClientSideScript(*ptr));
 			if (nullptr != runningScript && runNow)
 			{
 				runningScript->RunScript();
@@ -3329,6 +3349,12 @@ void FBehaviorContainer::StopMyScripts (AActor *actor)
 	if (controller != NULL)
 	{
 		controller->StopScriptsFor (actor);
+	}
+
+	controller = actor->Level->ClientSideACSThinker;
+	if (controller != NULL)
+	{
+		controller->StopScriptsFor(actor);
 	}
 }
 
@@ -3510,8 +3536,6 @@ void DLevelScript::Serialize(FSerializer &arc)
 
 void DLevelScript::Unlink ()
 {
-	DACSThinker *controller = Level->ACSThinker;
-
 	if (controller->LastScript == this)
 	{
 		controller->LastScript = prev;
@@ -3536,8 +3560,6 @@ void DLevelScript::Unlink ()
 
 void DLevelScript::Link ()
 {
-	DACSThinker *controller = Level->ACSThinker;
-
 	next = controller->Scripts;
 	GC::WriteBarrier(this, next);
 	if (controller->Scripts)
@@ -3556,8 +3578,6 @@ void DLevelScript::Link ()
 
 void DLevelScript::PutLast ()
 {
-	DACSThinker *controller = Level->ACSThinker;
-
 	if (controller->LastScript == this)
 		return;
 
@@ -3578,8 +3598,6 @@ void DLevelScript::PutLast ()
 
 void DLevelScript::PutFirst ()
 {
-	DACSThinker *controller = Level->ACSThinker;
-
 	if (controller->Scripts == this)
 		return;
 
@@ -5856,11 +5874,11 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, int32_t *args, int &
 			break;
 
 		case ACSF_UniqueTID:
-			return Level->FindUniqueTID(argCount > 0 ? args[0] : 0, (argCount > 1 && args[1] >= 0) ? args[1] : 0);
+			return Level->FindUniqueTID(argCount > 0 ? args[0] : 0, (argCount > 1 && args[1] >= 0) ? args[1] : 0, false);
 
 		case ACSF_IsTIDUsed:
 			MIN_ARG_COUNT(1);
-			return Level->IsTIDUsed(args[0]);
+			return Level->IsTIDUsed(args[0], false);
 
 		case ACSF_Sqrt:
 			MIN_ARG_COUNT(1);
@@ -6902,7 +6920,6 @@ PClass *DLevelScript::GetClassForIndex(int index) const
 
 int DLevelScript::RunScript()
 {
-	DACSThinker *controller = Level->ACSThinker;
 	ACSLocalVariables locals(Localvars);
 	ACSLocalArrays noarrays;
 	ACSLocalArrays *localarrays = &noarrays;
@@ -10389,9 +10406,9 @@ scriptwait:
 #undef PushtoStack
 
 static DLevelScript *P_GetScriptGoing (FLevelLocals *l, AActor *who, line_t *where, int num, const ScriptPtr *code, FBehavior *module,
-	const int *args, int argcount, int flags)
+	const int *args, int argcount, int flags, bool clientside)
 {
-	DACSThinker *controller = l->ACSThinker;
+	DACSThinker *controller = clientside ? l->ClientSideACSThinker : l->ACSThinker;
 	DLevelScript **running;
 
 	if (controller && !(flags & ACS_ALWAYS) && (running = controller->RunningScripts.CheckKey(num)) != NULL)
@@ -10404,16 +10421,28 @@ static DLevelScript *P_GetScriptGoing (FLevelLocals *l, AActor *who, line_t *whe
 		return NULL;
 	}
 
-	return Create<DLevelScript> (l, who, where, num, code, module, args, argcount, flags);
+	return Create<DLevelScript> (l, who, where, num, code, module, args, argcount, flags, clientside);
 }
 
 DLevelScript::DLevelScript (FLevelLocals *l, AActor *who, line_t *where, int num, const ScriptPtr *code, FBehavior *module,
-	const int *args, int argcount, int flags)
+	const int *args, int argcount, int flags, bool clientside)
 	: activeBehavior (module)
 {
 	Level = l;
-	if (Level->ACSThinker == nullptr)
-		Level->ACSThinker = Level->CreateThinker<DACSThinker>();
+	if (clientside)
+	{
+		if (Level->ClientSideACSThinker == nullptr)
+			Level->ClientSideACSThinker = Level->CreateClientsideThinker<DACSThinker>();
+
+		controller = Level->ClientSideACSThinker;
+	}
+	else
+	{
+		if (Level->ACSThinker == nullptr)
+			Level->ACSThinker = Level->CreateThinker<DACSThinker>();
+
+		controller = Level->ACSThinker;
+	}
 
 	script = num;
 	assert(code->VarCount >= code->ArgCount);
@@ -10440,11 +10469,11 @@ DLevelScript::DLevelScript (FLevelLocals *l, AActor *who, line_t *where, int num
 	// goes by while they're in their default state.
 
 	if (!(flags & ACS_ALWAYS))
-		Level->ACSThinker->RunningScripts[num] = this;
+		controller->RunningScripts[num] = this;
 
 	Link();
 
-	if (Level->flags2 & LEVEL2_HEXENHACK)
+	if (!clientside && (Level->flags2 & LEVEL2_HEXENHACK))
 	{
 		PutLast();
 	}
@@ -10452,14 +10481,20 @@ DLevelScript::DLevelScript (FLevelLocals *l, AActor *who, line_t *where, int num
 	DPrintf(DMSG_SPAMMY, "%s started.\n", ScriptPresentation(num).GetChars());
 }
 
-void SetScriptState (DACSThinker *controller, int script, DLevelScript::EScriptState state)
+void SetScriptState (FLevelLocals& level, int script, DLevelScript::EScriptState state)
 {
 	DLevelScript **running;
 
+	auto controller = level.ACSThinker;
 	if (controller != NULL && (running = controller->RunningScripts.CheckKey(script)) != NULL)
 	{
 		(*running)->SetState (state);
+		return;
 	}
+
+	controller = level.ClientSideACSThinker;
+	if (controller != NULL && (running = controller->RunningScripts.CheckKey(script)) != NULL)
+		(*running)->SetState(state);
 }
 
 void FLevelLocals::DoDeferedScripts ()
@@ -10471,33 +10506,32 @@ void FLevelLocals::DoDeferedScripts ()
 	for(int i = info->deferred.Size()-1; i>=0; i--)
 	{
 		acsdefered_t *def = &info->deferred[i];
+		scriptdata = Behaviors.FindScript(def->script, module);
+		if (scriptdata == nullptr)
+		{
+			Printf("P_DoDeferredScripts: Unknown %s\n", ScriptPresentation(def->script).GetChars());
+			continue;
+		}
+
 		switch (def->type)
 		{
 		case acsdefered_t::defexecute:
 		case acsdefered_t::defexealways:
-			scriptdata = Behaviors.FindScript (def->script, module);
-			if (scriptdata)
-			{
-				P_GetScriptGoing (this, (unsigned)def->playernum < MAXPLAYERS &&
-					PlayerInGame(def->playernum) ? Players[def->playernum]->mo : nullptr,
-					nullptr, def->script,
-					scriptdata, module,
-					def->args, 3,
-					def->type == acsdefered_t::defexealways ? ACS_ALWAYS : 0);
-			}
-			else
-			{
-				Printf ("P_DoDeferredScripts: Unknown %s\n", ScriptPresentation(def->script).GetChars());
-			}
+			P_GetScriptGoing (this, (unsigned)def->playernum < MAXPLAYERS &&
+				PlayerInGame(def->playernum) ? Players[def->playernum]->mo : nullptr,
+				nullptr, def->script,
+				scriptdata, module,
+				def->args, 3,
+				def->type == acsdefered_t::defexealways ? ACS_ALWAYS : 0, IsClientSideScript(*scriptdata));
 			break;
 
 		case acsdefered_t::defsuspend:
-			SetScriptState (ACSThinker, def->script, DLevelScript::SCRIPT_Suspended);
+			SetScriptState (*this, def->script, DLevelScript::SCRIPT_Suspended);
 			DPrintf (DMSG_SPAMMY, "Deferred suspend of %s\n", ScriptPresentation(def->script).GetChars());
 			break;
 
 		case acsdefered_t::defterminate:
-			SetScriptState (ACSThinker, def->script, DLevelScript::SCRIPT_PleaseRemove);
+			SetScriptState (*this, def->script, DLevelScript::SCRIPT_PleaseRemove);
 			DPrintf (DMSG_SPAMMY, "Deferred terminate of %s\n", ScriptPresentation(def->script).GetChars());
 			break;
 		}
@@ -10561,8 +10595,15 @@ int P_StartScript (FLevelLocals *Level, AActor *who, line_t *where, int script, 
 					return false;
 				}
 			}
-			DLevelScript *runningScript = P_GetScriptGoing (Level, who, where, script,
-				scriptdata, module, args, argcount, flags);
+
+			DLevelScript* runningScript = nullptr;
+			const bool clientside = IsClientSideScript(*scriptdata);
+			if (!(flags & ACS_NET) || !clientside || (who && Level->isConsolePlayer(who->player->mo)))
+			{
+				runningScript = P_GetScriptGoing(Level, who, where, script,
+					scriptdata, module, args, argcount, flags, clientside);
+			}
+
 			if (runningScript != NULL)
 			{
 				if (flags & ACS_WANTRESULT)
@@ -10596,7 +10637,7 @@ void P_SuspendScript (FLevelLocals *Level, int script, const char *map)
 	if (strnicmp (Level->MapName.GetChars(), map, 8))
 		addDefered (FindLevelInfo (map), acsdefered_t::defsuspend, script, NULL, 0, NULL);
 	else
-		SetScriptState (Level->ACSThinker, script, DLevelScript::SCRIPT_Suspended);
+		SetScriptState (*Level, script, DLevelScript::SCRIPT_Suspended);
 }
 
 void P_TerminateScript (FLevelLocals *Level, int script, const char *map)
@@ -10604,7 +10645,7 @@ void P_TerminateScript (FLevelLocals *Level, int script, const char *map)
 	if (strnicmp (Level->MapName.GetChars(), map, 8))
 		addDefered (FindLevelInfo (map), acsdefered_t::defterminate, script, NULL, 0, NULL);
 	else
-		SetScriptState (Level->ACSThinker, script, DLevelScript::SCRIPT_PleaseRemove);
+		SetScriptState (*Level, script, DLevelScript::SCRIPT_PleaseRemove);
 }
 
 FSerializer &Serialize(FSerializer &arc, const char *key, acsdefered_t &defer, acsdefered_t *def)

--- a/src/playsim/p_acs.h
+++ b/src/playsim/p_acs.h
@@ -339,7 +339,8 @@ enum
 // Script flags
 enum
 {
-	SCRIPTF_Net = 0x0001	// Safe to "puke" in multiplayer
+	SCRIPTF_Net = 0x0001,		 // Safe to "puke" in multiplayer
+	SCRIPTF_ClientSide = 0x0002, // Executed locally for clients but not across them
 };
 
 enum ACSFormat { ACS_Old, ACS_Enhanced, ACS_LittleEnhanced, ACS_Unknown };

--- a/src/playsim/p_maputl.cpp
+++ b/src/playsim/p_maputl.cpp
@@ -294,38 +294,36 @@ void AActor::UnlinkFromWorld (FLinkContext *ctx)
 		// killough 8/11/98: simpler scheme using pointers-to-pointers for prev
 		// pointers, allows head node pointers to be treated like everything else
 		AActor **prev = sprev;
-		AActor  *next = snext;
-
-		if (prev != NULL)	// prev will be NULL if this actor gets deleted due to cleaning up from a broken savegame
+		if (prev != NULL)
 		{
+			AActor* next = snext;
 			if ((*prev = next))  // unlink from sector list
 				next->sprev = prev;
 			snext = NULL;
 			sprev = (AActor **)(size_t)0xBeefCafe;	// Woo! Bug-catching value!
-
-			// phares 3/14/98
-			//
-			// Save the sector list pointed to by touching_sectorlist.
-			// In P_SetThingPosition, we'll keep any nodes that represent
-			// sectors the Thing still touches. We'll add new ones then, and
-			// delete any nodes for sectors the Thing has vacated. Then we'll
-			// put it back into touching_sectorlist. It's done this way to
-			// avoid a lot of deleting/creating for nodes, when most of the
-			// time you just get back what you deleted anyway.
-
-			if (ctx != nullptr)
-			{
-				ctx->sector_list = touching_sectorlist;
-				ctx->render_list = touching_rendersectors;
-			}
-			else
-			{
-				P_DelSeclist(touching_sectorlist, &sector_t::touching_thinglist);
-				P_DelSeclist(touching_rendersectors, &sector_t::touching_renderthings);
-			}
-			touching_sectorlist = nullptr; //to be restored by P_SetThingPosition
-			touching_rendersectors = nullptr;
 		}
+
+		// phares 3/14/98
+		//
+		// Save the sector list pointed to by touching_sectorlist.
+		// In P_SetThingPosition, we'll keep any nodes that represent
+		// sectors the Thing still touches. We'll add new ones then, and
+		// delete any nodes for sectors the Thing has vacated. Then we'll
+		// put it back into touching_sectorlist. It's done this way to
+		// avoid a lot of deleting/creating for nodes, when most of the
+		// time you just get back what you deleted anyway.
+		if (ctx != nullptr)
+		{
+			ctx->sector_list = touching_sectorlist;
+			ctx->render_list = touching_rendersectors;
+		}
+		else
+		{
+			P_DelSeclist(touching_sectorlist, &sector_t::touching_thinglist);
+			P_DelSeclist(touching_rendersectors, &sector_t::touching_renderthings);
+		}
+		touching_sectorlist = nullptr; //to be restored by P_SetThingPosition
+		touching_rendersectors = nullptr;
 	}
 		
 	if (!(flags & MF_NOBLOCKMAP))
@@ -469,32 +467,37 @@ void AActor::LinkToWorld(FLinkContext *ctx, bool spawningmapthing, sector_t *sec
 	subsector = Level->PointInRenderSubsector(Pos());	// this is from the rendering nodes, not the gameplay nodes!
 	section = subsector->section;
 
+	const bool clientside = IsClientside();
 	if (!(flags & MF_NOSECTOR))
 	{
-		// invisible things don't go into the sector links
-		// killough 8/11/98: simpler scheme using pointer-to-pointer prev
-		// pointers, allows head nodes to be treated like everything else
+		if (!clientside)
+		{
+			// invisible things don't go into the sector links
+			// killough 8/11/98: simpler scheme using pointer-to-pointer prev
+			// pointers, allows head nodes to be treated like everything else
 
-		AActor **link = &sector->thinglist;
-		AActor *next = *link;
-		if ((snext = next))
-			next->sprev = &snext;
-		sprev = link;
-		*link = this;
+			AActor** link = &sector->thinglist;
+			AActor* next = *link;
+			if ((snext = next))
+				next->sprev = &snext;
+			sprev = link;
+			*link = this;
 
-		// phares 3/16/98
-		//
-		// If sector_list isn't NULL, it has a collection of sector
-		// nodes that were just removed from this Thing.
+			// phares 3/16/98
+			//
+			// If sector_list isn't NULL, it has a collection of sector
+			// nodes that were just removed from this Thing.
 
-		// Collect the sectors the object will live in by looking at
-		// the existing sector_list and adding new nodes and deleting
-		// obsolete ones.
+			// Collect the sectors the object will live in by looking at
+			// the existing sector_list and adding new nodes and deleting
+			// obsolete ones.
 
-		// When a node is deleted, its sector links (the links starting
-		// at sector_t->touching_thinglist) are broken. When a node is
-		// added, new sector links are created.
-		touching_sectorlist = P_CreateSecNodeList(this, radius, ctx != nullptr? ctx->sector_list : nullptr, &sector_t::touching_thinglist);	// Attach to thing
+			// When a node is deleted, its sector links (the links starting
+			// at sector_t->touching_thinglist) are broken. When a node is
+			// added, new sector links are created.
+			touching_sectorlist = P_CreateSecNodeList(this, radius, ctx != nullptr ? ctx->sector_list : nullptr, &sector_t::touching_thinglist);	// Attach to thing
+		}
+
 		if (renderradius >= 0) touching_rendersectors = P_CreateSecNodeList(this, RenderRadius(), ctx != nullptr ? ctx->render_list : nullptr, &sector_t::touching_renderthings);
 		else
 		{
@@ -505,7 +508,7 @@ void AActor::LinkToWorld(FLinkContext *ctx, bool spawningmapthing, sector_t *sec
 
 
 	// link into blockmap (inert things don't need to be in the blockmap)
-	if (!(flags & MF_NOBLOCKMAP))
+	if (!(flags & MF_NOBLOCKMAP) && !clientside)
 	{
 		FPortalGroupArray check;
 

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -75,6 +75,7 @@ extern float			BackbuttonAlpha;
 #define DEFINE_FLAG(prefix, name, type, variable) { (unsigned int)prefix##_##name, #name, (int)(size_t)&((type*)1)->variable - 1, sizeof(((type *)0)->variable), VARF_Native }
 #define DEFINE_PROTECTED_FLAG(prefix, name, type, variable) { (unsigned int)prefix##_##name, #name, (int)(size_t)&((type*)1)->variable - 1, sizeof(((type *)0)->variable), VARF_Native|VARF_ReadOnly|VARF_InternalAccess }
 #define DEFINE_FLAG2(symbol, name, type, variable) { (unsigned int)symbol, #name, (int)(size_t)&((type*)1)->variable - 1, sizeof(((type *)0)->variable), VARF_Native }
+#define DEFINE_PROTECTED_FLAG2(symbol, name, type, variable) { (unsigned int)symbol, #name, (int)(size_t)&((type*)1)->variable - 1, sizeof(((type *)0)->variable), VARF_Native|VARF_ReadOnly|VARF_InternalAccess }
 #define DEFINE_FLAG2_DEPRECATED(symbol, name, type, variable, version) { (unsigned int)symbol, #name, (int)(size_t)&((type*)1)->variable - 1, sizeof(((type *)0)->variable), VARF_Native|VARF_Deprecated }
 #define DEFINE_DEPRECATED_FLAG(name, version) { DEPF_##name, #name, -1, 0, VARF_Deprecated, version }
 #define DEFINE_DUMMY_FLAG(name, deprec) { DEPF_UNUSED, #name, -1, 0, deprec? VARF_Deprecated:0 }
@@ -412,6 +413,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG2(BOUNCE_ModifyPitch, BOUNCEMODIFIESPITCH, AActor, BounceFlags),
 	
 	DEFINE_FLAG2(OF_Transient, NOSAVEGAME, AActor, ObjectFlags),
+	DEFINE_PROTECTED_FLAG2(OF_ClientSide, CLIENTSIDE, AActor, ObjectFlags),
 
 	// Deprecated flags which need a ZScript workaround.
 	DEFINE_DEPRECATED_FLAG(MISSILEMORE, MakeVersion(4, 13, 0)),
@@ -463,7 +465,6 @@ static FFlagDef MoreFlagDefs[] =
 	// [BB] New DECORATE network related flag defines here.
 	DEFINE_DUMMY_FLAG(NONETID, false),
 	DEFINE_DUMMY_FLAG(ALLOWCLIENTSPAWN, false),
-	DEFINE_DUMMY_FLAG(CLIENTSIDEONLY, false),
 	DEFINE_DUMMY_FLAG(SERVERSIDEONLY, false),
 };
 

--- a/src/scripting/vmiterators.cpp
+++ b/src/scripting/vmiterators.cpp
@@ -41,8 +41,8 @@ class DThinkerIterator : public DObject, public FThinkerIterator
 	DECLARE_ABSTRACT_CLASS(DThinkerIterator, DObject)
 
 public:
-	DThinkerIterator(FLevelLocals *Level, PClass *cls, int statnum = MAX_STATNUM + 1)
-		: FThinkerIterator(Level, cls, statnum)
+	DThinkerIterator(FLevelLocals *Level, PClass *cls, int statnum = MAX_STATNUM + 1, bool clientside = false)
+		: FThinkerIterator(Level, cls, statnum, clientside)
 	{
 	}
 };
@@ -60,6 +60,19 @@ DEFINE_ACTION_FUNCTION_NATIVE(DThinkerIterator, Create, CreateThinkerIterator)
 	PARAM_CLASS(type, DThinker);
 	PARAM_INT(statnum);
 	ACTION_RETURN_OBJECT(CreateThinkerIterator(type, statnum));
+}
+
+static DThinkerIterator* CreateClientsideThinkerIterator(PClass* type, int statnum)
+{
+	return Create<DThinkerIterator>(currentVMLevel, type, statnum, true);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(DThinkerIterator, CreateClientside, CreateClientsideThinkerIterator)
+{
+	PARAM_PROLOGUE;
+	PARAM_CLASS(type, DThinker);
+	PARAM_INT(statnum);
+	ACTION_RETURN_OBJECT(CreateClientsideThinkerIterator(type, statnum));
 }
 
 static DThinker *NextThinker(DThinkerIterator *self, bool exact)
@@ -363,6 +376,19 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, CreateActorIterator, CreateActI)
 	PARAM_INT(tid);
 	PARAM_CLASS(type, AActor);
 	ACTION_RETURN_OBJECT(CreateActI(self, tid, type));
+}
+
+static DActorIterator* CreateClientSideActI(FLevelLocals* Level, int tid, PClassActor* type)
+{
+	return Create<DActorIterator>(Level->ClientSideTIDHash, type, tid);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, CreateClientSideActorIterator, CreateClientSideActI)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_INT(tid);
+	PARAM_CLASS(type, AActor);
+	ACTION_RETURN_OBJECT(CreateClientSideActI(self, tid, type));
 }
 
 static AActor *NextActI(DActorIterator *self)

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2615,6 +2615,26 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, setFrozen, setFrozen)
 	return 0;
 }
 
+static DThinker* CreateClientsideThinker(FLevelLocals* self, PClass* type, int statnum)
+{
+	if (type->IsDescendantOf(NAME_Actor))
+	{
+		ThrowAbortException(X_OTHER, "Clientside Actors cannot be created from this function");
+		return nullptr;
+	}
+
+	return self->CreateClientsideThinker(type, statnum);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, CreateClientsideThinker, CreateClientsideThinker)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_POINTER_NOT_NULL(type, PClass);
+	PARAM_INT(statnum);
+
+	ACTION_RETURN_OBJECT(CreateClientsideThinker(self, type, statnum));
+}
+
 //=====================================================================================
 //
 //

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -999,9 +999,9 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, GetFloorTerrain, GetFloorTerrain)
 	ACTION_RETURN_POINTER(GetFloorTerrain(self));
 }
 
-static int P_FindUniqueTID(FLevelLocals *Level, int start, int limit)
+static int P_FindUniqueTID(FLevelLocals *Level, int start, int limit, bool clientside)
 {
-	return Level->FindUniqueTID(start, limit);
+	return Level->FindUniqueTID(start, limit, clientside);
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, FindUniqueTid, P_FindUniqueTID)
@@ -1009,7 +1009,8 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, FindUniqueTid, P_FindUniqueTID)
 	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
 	PARAM_INT(start);
 	PARAM_INT(limit);
-	ACTION_RETURN_INT(P_FindUniqueTID(self, start, limit));
+	PARAM_BOOL(clientside);
+	ACTION_RETURN_INT(P_FindUniqueTID(self, start, limit, clientside));
 }
 
 static void RemoveFromHash(AActor *self)

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -786,6 +786,7 @@ class Actor : Thinker native
 	native bool CheckPosition(Vector2 pos, bool actorsonly = false, FCheckPosition tm = null);
 	native bool TestMobjLocation();
 	native static Actor Spawn(class<Actor> type, vector3 pos = (0,0,0), int replace = NO_REPLACE);
+	native static clearscope Actor SpawnClientside(class<Actor> type, vector3 pos = (0,0,0), int replace = NO_REPLACE);
 	native Actor SpawnMissile(Actor dest, class<Actor> type, Actor owner = null);
 	native Actor SpawnMissileXYZ(Vector3 pos, Actor dest, Class<Actor> type, bool checkspawn = true, Actor owner = null);
 	native Actor SpawnMissileZ (double z, Actor dest, class<Actor> type);

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -140,9 +140,6 @@ extend class Object
 	native static void MarkSound(Sound snd);
 	native static uint BAM(double angle);
 	native static void SetMusicVolume(float vol);
-	native clearscope static Object GetNetworkEntity(uint id);
-	native play void EnableNetworking(bool enable);
-	native clearscope uint GetNetworkID() const;
 }
 
 class Thinker : Object native play
@@ -199,6 +196,7 @@ class Thinker : Object native play
 class ThinkerIterator : Object native
 {
 	native static ThinkerIterator Create(class<Object> type = "Actor", int statnum=Thinker.MAX_STATNUM+1);
+	native static ThinkerIterator CreateClientside(class<Thinker> type = "Actor", int statnum=Thinker.MAX_STATNUM+1);
 	native Thinker Next(bool exact = false);
 	native void Reinit();
 }
@@ -499,7 +497,7 @@ struct LevelLocals native
 	native bool IsFreelookAllowed() const;
 	native void StartIntermission(Name type, int state) const;
 	native play SpotState GetSpotState(bool create = true);
-	native int FindUniqueTid(int start = 0, int limit = 0);
+	native int FindUniqueTid(int start = 0, int limit = 0, bool clientside = false);
 	native uint GetSkyboxPortal(Actor actor);
 	native void ReplaceTextures(String from, String to, int flags);
     clearscope native HealthGroup FindHealthGroup(int id);
@@ -535,9 +533,11 @@ struct LevelLocals native
 	native void ChangeSky(TextureID sky1, TextureID sky2 );
 	native void ForceLightning(int mode = 0, sound tempSound = "");
 
+	native clearscope Thinker CreateClientsideThinker(class<Thinker> type, int statnum = Thinker.STAT_DEFAULT);
 	native SectorTagIterator CreateSectorTagIterator(int tag, line defline = null);
 	native LineIdIterator CreateLineIdIterator(int tag);
 	native ActorIterator CreateActorIterator(int tid, class<Actor> type = "Actor");
+	native ActorIterator CreateClientSideActorIterator(int tid, class<Actor> type = "Actor");
 
 	String TimeFormatted(bool totals = false)
 	{

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -779,6 +779,11 @@ class Object native
 
 	native static Function<void> FindFunction(Class<Object> cls, Name fn);
 
+	native clearscope static Object GetNetworkEntity(uint id);
+	native play void EnableNetworking(bool enable);
+	native clearscope uint GetNetworkID() const;
+	native clearscope bool IsClientside() const;
+
 	native virtualscope void Destroy();
 
 	// This does not call into the native method of the same name to avoid problems with objects that get garbage collected late on shutdown.


### PR DESCRIPTION
Adds support for client-side Thinkers, Actors, and ACS scripts (ACS uses the existing CLIENTSIDE keyword). These will tick regardless of the network state allowing for localized client handling and are put in their own separate lists so they can't be accidentally accessed by server code. They currently aren't serialized since this would have no meaning for other clients in the game that would get saved. Other logic like the menu, console, HUD, and particles have also been moved to client-side ticking to prevent them from becoming locked up by poor network conditions. Additionally, screenshotting and the automap are now handled immediately instead of having to wait for any game tick to run first, making them free of net lag.

(This will be drafted for the time being until the prediction backup changes can be further tested to make sure it's not causing any crashes)