### PR TITLE
Run net events on load barriers

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -394,7 +394,6 @@ void Net_ResetCommands(bool midTic)
 		// Make sure not to run its current command either.
 		auto& curTic = state.Tics[tic % BACKUPTICS];
 		memset(&curTic.Command, 0, sizeof(curTic.Command));
-		curTic.Data.SetData(nullptr, 0);
 	}
 
 	NetEvents.ResetStream();


### PR DESCRIPTION
Needed for initial cheats in start up params to apply correctly.