### PR TITLE
Auto split packets in packet-server mode

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -1410,19 +1410,20 @@ void NetUpdate(int tics)
 			ticLoops = 1;
 
 		const int maxPlayerLoops = isSelf ? 1 : playerLoops;
+		int totalQuits = quitters;
 		for (int tLoops = 0, curTicOfs = 0; tLoops < ticLoops; ++tLoops, curTicOfs += maxCommands)
 		{
 			for (int pLoops = 0, curPlayerOfs = 0; pLoops < maxPlayerLoops; ++pLoops, curPlayerOfs += MaxPlayersPerPacket)
 			{
 				size_t size = 10;
-				if (quitters > 0)
+				if (totalQuits > 0)
 				{
 					NetBuffer[0] |= NCMD_QUITTERS;
-					NetBuffer[size++] = quitters;
-					for (int i = 0; i < quitters; ++i)
+					NetBuffer[size++] = totalQuits;
+					for (int i = 0; i < totalQuits; ++i)
 						NetBuffer[size++] = quitNums[i];
 
-					quitters = 0;
+					totalQuits = 0;
 				}
 				else
 				{

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -942,6 +942,7 @@ static void CheckConsistencies()
 			const int limit = min<int>(CurrentConsistency - 1, clientState.CurrentNetConsistency);
 			while (clientState.LastVerifiedConsistency < limit)
 			{
+				++clientState.LastVerifiedConsistency;
 				const int tic = clientState.LastVerifiedConsistency % BACKUPTICS;
 				if (clientState.LocalConsistency[tic] != clientState.NetConsistency[tic])
 				{
@@ -949,8 +950,6 @@ static void CheckConsistencies()
 					clientState.LastVerifiedConsistency = clientState.CurrentNetConsistency;
 					break;
 				}
-
-				++clientState.LastVerifiedConsistency;
 			}
 		}
 	}


### PR DESCRIPTION
Avoid fragmentation by trying to keep data in each packet to <1500b. Helps avoid possible issues with fragmentation with large player counts and bad network conditions.