### PR TITLE
Use client-side flag instead of storing ACS controller

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -705,7 +705,6 @@ public:
 
 protected:
 	DLevelScript	*next, *prev;
-	TObjPtr<DACSThinker*> controller;
 	int				script;
 	TArray<int32_t>	Localvars;
 	int				*pc;
@@ -714,6 +713,7 @@ protected:
 	TObjPtr<AActor*>	activator;
 	line_t			*activationline;
 	bool			backSide;
+	bool			bClientSide;
 	FFont			*activefont = nullptr;
 	int				hudwidth, hudheight;
 	int				ClipRectLeft, ClipRectTop, ClipRectWidth, ClipRectHeight;
@@ -741,6 +741,7 @@ protected:
 		}
 	}
 
+	DACSThinker* GetController() const;
 	void Link();
 	void Unlink();
 	void PutLast();
@@ -3520,7 +3521,7 @@ void DLevelScript::Serialize(FSerializer &arc)
 		("wrapwidth", WrapWidth)
 		("inmodulescriptnum", InModuleScriptNumber)
 		("level", Level)
-		("controller", controller);
+		("bclientside", bClientSide);
 
 	if (arc.isReading())
 	{
@@ -3535,8 +3536,14 @@ void DLevelScript::Serialize(FSerializer &arc)
 	}
 }
 
+DACSThinker* DLevelScript::GetController() const
+{
+	return bClientSide ? Level->ClientSideACSThinker : Level->ACSThinker;
+}
+
 void DLevelScript::Unlink ()
 {
+	auto controller = GetController();
 	if (controller->LastScript == this)
 	{
 		controller->LastScript = prev;
@@ -3561,6 +3568,7 @@ void DLevelScript::Unlink ()
 
 void DLevelScript::Link ()
 {
+	auto controller = GetController();
 	next = controller->Scripts;
 	GC::WriteBarrier(this, next);
 	if (controller->Scripts)
@@ -3579,6 +3587,7 @@ void DLevelScript::Link ()
 
 void DLevelScript::PutLast ()
 {
+	auto controller = GetController();
 	if (controller->LastScript == this)
 		return;
 
@@ -3599,6 +3608,7 @@ void DLevelScript::PutLast ()
 
 void DLevelScript::PutFirst ()
 {
+	auto controller = GetController();
 	if (controller->Scripts == this)
 		return;
 
@@ -6941,6 +6951,7 @@ int DLevelScript::RunScript()
 
 	// Hexen truncates all special arguments to bytes (only when using an old MAPINFO and old ACS format
 	const int specialargmask = ((Level->flags2 & LEVEL2_HEXENHACK) && activeBehavior->GetFormat() == ACS_Old) ? 255 : ~0;
+	auto controller = GetController();
 
 	switch (state)
 	{
@@ -10435,14 +10446,14 @@ DLevelScript::DLevelScript (FLevelLocals *l, AActor *who, line_t *where, int num
 		if (Level->ClientSideACSThinker == nullptr)
 			Level->ClientSideACSThinker = Level->CreateClientsideThinker<DACSThinker>();
 
-		controller = Level->ClientSideACSThinker;
+		bClientSide = true;
 	}
 	else
 	{
 		if (Level->ACSThinker == nullptr)
 			Level->ACSThinker = Level->CreateThinker<DACSThinker>();
 
-		controller = Level->ACSThinker;
+		bClientSide = false;
 	}
 
 	script = num;
@@ -10470,7 +10481,7 @@ DLevelScript::DLevelScript (FLevelLocals *l, AActor *who, line_t *where, int num
 	// goes by while they're in their default state.
 
 	if (!(flags & ACS_ALWAYS))
-		controller->RunningScripts[num] = this;
+		GetController()->RunningScripts[num] = this;
 
 	Link();
 


### PR DESCRIPTION
Prevents old save files from breaking if they were running ACS.