### PR TITLE
Fixed potential softlock in packet-server mode

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -873,6 +873,9 @@ static void GetPackets()
 				{
 					pState.CurrentSequence = seq;
 				}
+				// Update this so host switching doesn't have any hiccups in packet-server mode.
+				if (NetMode == NET_PacketServer && consoleplayer != Net_Arbitrator && pNum != Net_Arbitrator)
+					pState.SequenceAck = seq;
 			}
 		}
 	}


### PR DESCRIPTION
Make sure to send over the lowest player's data we got as the ack and not whatever the host specifically had.