### PR TITLE
Fixed inventory bar ticking when playing online

### DIFF
--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -67,6 +67,12 @@ void P_RunClientsideLogic()
 
 	if (gamestate == GS_LEVEL || gamestate == GS_TITLELEVEL)
 	{
+		for (int i = 0; i < MAXPLAYERS; ++i)
+		{
+			if (playeringame[i] && players[i].inventorytics > 0)
+				--players[i].inventorytics;
+		}
+
 		for (auto level : AllLevels())
 		{
 			auto it = level->GetClientsideThinkerIterator<AActor>();

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -1671,10 +1671,6 @@ class PlayerPawn : Actor
 		++BobTimer;
 		CheckFOV();
 
-		if (player.inventorytics)
-		{
-			player.inventorytics--;
-		}
 		CheckCheats();
 
 		if (bJustAttacked)


### PR DESCRIPTION
No longer tied to the player's latency value as it now runs in the client-side logic.