### PR TITLE
cl_debugprediction console variable

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -162,6 +162,14 @@ CUSTOM_CVAR(Int, cl_showchat, CHAT_GLOBAL, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 		self = CHAT_GLOBAL;
 }
 
+CUSTOM_CVAR(Int, cl_debugprediction, 0, CVAR_CHEAT)
+{
+	if (self < 0)
+		self = 0;
+	else if (self > BACKUPTICS - 1)
+		self = BACKUPTICS - 1;
+}
+
 // Used to write out all network events that occured leading up to the next tick.
 static struct NetEventData
 {
@@ -1969,7 +1977,19 @@ void TryRunTics()
 	int runTics = min<int>(totalTics, availableTics);
 	if (totalTics > 0 && totalTics < availableTics - 1 && !singletics)
 		++runTics;
-	
+
+	// Test player prediction code in singleplayer
+	// by running the gametic behind the ClientTic
+	if (!netgame && !demoplayback && cl_debugprediction > 0)
+	{
+		int debugTarget = ClientTic - cl_debugprediction;
+		int debugOffset = gametic - debugTarget;
+		if (debugOffset > 0)
+		{
+			runTics = max<int>(runTics - debugOffset, 0);
+		}
+	}
+
 	// If there are no tics to run, check for possible stall conditions and new
 	// commands to predict.
 	if (runTics <= 0)

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -133,6 +133,8 @@ CUSTOM_CVAR(Float, cl_rubberband_limit, 756.0f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG
 		self = 0.0f;
 }
 
+EXTERN_CVAR (Int, cl_debugprediction)
+
 ColorSetList ColorSets;
 PainFlashList PainFlashes;
 
@@ -1440,7 +1442,7 @@ void P_PredictPlayer (player_t *player)
 		player->mo == NULL ||
 		player != player->mo->Level->GetConsolePlayer() ||
 		player->playerstate != PST_LIVE ||
-		!netgame ||
+		(!netgame && cl_debugprediction == 0) ||
 		/*player->morphTics ||*/
 		(player->cheats & CF_PREDICTING))
 	{


### PR DESCRIPTION
Makes `gametic` run behind `ClientTic` by n ticks, and forces player prediction code to run. Only works if you are in a singleplayer game.

This is intended to be useful for mod development, as it allows for quickly testing prediction / latency issues, without needing to create a multiplayer server. It may also come in handy if any improvements are made to the prediction code in the future.
