### PR TITLE
Scrap dlight lighthead link lists

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -623,6 +623,9 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 		primaryLevel->totaltime = 0;
 		primaryLevel->spawnindex = 0;
 
+		primaryLevel->lightlists.wall_dlist.clear();
+		primaryLevel->lightlists.flat_dlist.clear();
+
 		if (!multiplayer || !deathmatch)
 		{
 			InitPlayerClasses ();

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "doomdata.h"
 #include "g_level.h"
 #include "r_defs.h"
@@ -57,6 +59,12 @@
 #include "doom_aabbtree.h"
 #include "doom_levelmesh.h"
 #include "p_visualthinker.h"
+
+struct FGlobalDLightLists
+{
+	std::unordered_map<FSection*, std::unordered_map<FDynamicLight*, FLightNode*>> flat_dlist;
+	std::unordered_map<side_t*, std::unordered_map<FDynamicLight*, FLightNode*>> wall_dlist;
+};
 
 //============================================================================
 //
@@ -744,6 +752,8 @@ public:
 	bool		lightadditivesurfaces;
 	bool		notexturefill;
 	int			ImpactDecalCount;
+
+	FGlobalDLightLists lightlists;
 
 	FDynamicLight *lights;
 	DVisualThinker* VisualThinkerHead = nullptr;

--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -1268,7 +1268,6 @@ struct side_t
 	int16_t		TierLights[3];	// per-tier light levels
 	uint16_t	Flags;
 	int			UDMFIndex;		// needed to access custom UDMF fields which are stored in loading order.
-	FLightNode * lighthead;		// all dynamic lights that may affect this wall
 	LightmapSurface* lightmap;
 	seg_t **segs;	// all segs belonging to this sidedef in ascending order. Used for precise rendering
 	int numsegs;

--- a/src/playsim/a_dynlight.cpp
+++ b/src/playsim/a_dynlight.cpp
@@ -435,28 +435,27 @@ void FDynamicLight::AddLightNode(FSection *section, side_t *sidedef)
 		touchlists->wall_tlist.try_emplace(sidedef, sidedef);
 	};
 
-	FLightNode * node = new FLightNode;
-	node->lightsource = this;
-
 	if (section)
 	{
-		node->targ = section;
-	
 		auto flatLightList = Level->lightlists.flat_dlist.find(section);
 		if (flatLightList != Level->lightlists.flat_dlist.end())
 		{
-			auto ret = flatLightList->second.try_emplace(this, node);
-			if (ret.second)
+			if (flatLightList->second.find(this) == flatLightList->second.end())
 			{
+				FLightNode * node = new FLightNode;
+				node->lightsource = this;
+				node->targ = section;
+
+				flatLightList->second.try_emplace(this, node);
 				updateFlatTList(section);
-			}
-			else
-			{
-				delete node;
 			}
 		}
 		else
 		{
+			FLightNode * node = new FLightNode;
+			node->lightsource = this;
+			node->targ = section;
+
 			std::unordered_map<FDynamicLight *, FLightNode *> u = { {this, node} };
 			Level->lightlists.flat_dlist.try_emplace(section, u);
 			updateFlatTList(section);
@@ -464,23 +463,25 @@ void FDynamicLight::AddLightNode(FSection *section, side_t *sidedef)
 	}
 	else if (sidedef)
 	{
-		node->targ = sidedef;
-
 		auto wallLightList = Level->lightlists.wall_dlist.find(sidedef);
 		if (wallLightList != Level->lightlists.wall_dlist.end())
 		{
-			auto ret = wallLightList->second.try_emplace(this, node);
-			if (ret.second)
+			if (wallLightList->second.find(this) == wallLightList->second.end())
 			{
+				FLightNode * node = new FLightNode;
+				node->lightsource = this;
+				node->targ = sidedef;
+
+				wallLightList->second.try_emplace(this, node);
 				updateWallTList(sidedef);
-			}
-			else
-			{
-				delete node;
 			}
 		}
 		else
 		{
+			FLightNode * node = new FLightNode;
+			node->lightsource = this;
+			node->targ = sidedef;
+
 			std::unordered_map<FDynamicLight *, FLightNode *> u = { {this, node} };
 			Level->lightlists.wall_dlist.try_emplace(sidedef, u);
 			updateWallTList(sidedef);

--- a/src/playsim/a_dynlight.cpp
+++ b/src/playsim/a_dynlight.cpp
@@ -713,6 +713,7 @@ void FDynamicLight::UnlinkLight ()
 		}
 	}
 	delete touchlists;
+	touchlists = nullptr;
 	shadowmapped = false;
 }
 

--- a/src/playsim/a_dynlight.cpp
+++ b/src/playsim/a_dynlight.cpp
@@ -680,9 +680,9 @@ void FDynamicLight::LinkLight()
 //==========================================================================
 void FDynamicLight::UnlinkLight ()
 {
-	for (auto iter = touchlists->wall_tlist.begin(); iter != touchlists->wall_tlist.end(); iter++)
+	for (const auto& [key, value] : touchlists->wall_tlist)
 	{
-		auto sidedef = iter->second;
+		auto sidedef = value;
 		if (!sidedef) continue;
 		
 		auto wallLightList = Level->lightlists.wall_dlist.find(sidedef);
@@ -696,9 +696,9 @@ void FDynamicLight::UnlinkLight ()
 			}
 		}
 	}
-	for (auto iter = touchlists->flat_tlist.begin(); iter != touchlists->flat_tlist.end(); iter++)
+	for (const auto& [key, value] : touchlists->flat_tlist)
 	{
-		auto sec = iter->second;
+		auto sec = value;
 		if (!sec) continue;
 		
 		auto flatLightList = Level->lightlists.flat_dlist.find(sec);

--- a/src/playsim/a_dynlight.h
+++ b/src/playsim/a_dynlight.h
@@ -195,6 +195,12 @@ struct FLightNode
 	};
 };
 
+struct FDynamicLightTouchLists
+{
+	std::unordered_map<FSection*, FSection*> flat_tlist;
+	std::unordered_map<side_t*, side_t*> wall_tlist;
+};
+
 struct FDynamicLight
 {
 	friend class FLightDefaults;
@@ -286,6 +292,7 @@ public:
 	bool swapped;
 	bool explicitpitch;
 
+	FDynamicLightTouchLists *touchlists;
 };
 
 

--- a/src/playsim/a_dynlight.h
+++ b/src/playsim/a_dynlight.h
@@ -251,6 +251,7 @@ struct FDynamicLight
 
 	void Tick();
 	void UpdateLocation();
+	void AddLightNode(FSection *section, side_t *sidedef);
 	void LinkLight();
 	void UnlinkLight();
 	void ReleaseLight();

--- a/src/r_data/r_sections.cpp
+++ b/src/r_data/r_sections.cpp
@@ -712,7 +712,6 @@ public:
 			dest.sector = &Level->sectors[group.groupedSections[0].section->sectorindex];
 			dest.mapsection = (short)group.groupedSections[0].section->mapsection;
 			dest.hacked = false;
-			dest.lighthead = nullptr;
 			dest.validcount = 0;
 			dest.segments.Set(&output.allLines[numsegments], group.segments.Size());
 			dest.sides.Set(&output.allSides[numsides], group.sideMap.CountUsed());

--- a/src/r_data/r_sections.h
+++ b/src/r_data/r_sections.h
@@ -113,7 +113,6 @@ struct FSection
 	TArrayView<side_t *>	 sides;				// contains all sidedefs, including the internal ones that do not make up the outer shape.
 	TArrayView<subsector_t *>	 subsectors;	// contains all subsectors making up this section
 	sector_t				*sector;
-	FLightNode				*lighthead;			// Light nodes (blended and additive)
 	BoundingRect			 bounds;
 	int						 vertexindex;		// This is relative to the start of the entire sector's vertex plane data because it needs to be used with different sources.
 	int						 vertexcount;

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -290,7 +290,7 @@ public:
 	void AddOtherFloorPlane(int sector, gl_subsectorrendernode * node);
 	void AddOtherCeilingPlane(int sector, gl_subsectorrendernode * node);
 
-	void GetDynSpriteLight(AActor *self, float x, float y, float z, FLightNode *node, int portalgroup, float *out);
+	void GetDynSpriteLight(AActor *self, float x, float y, float z, FSection *sec, int portalgroup, float *out);
 	void GetDynSpriteLight(AActor *thing, particle_t *particle, float *out);
 
 	void PreparePlayerSprites(sector_t * viewsector, area_t in_area);

--- a/src/rendering/hwrenderer/scene/hw_drawstructs.h
+++ b/src/rendering/hwrenderer/scene/hw_drawstructs.h
@@ -333,7 +333,7 @@ public:
 	int dynlightindex;
 
 	void CreateSkyboxVertices(FFlatVertex *buffer);
-	void SetupLights(HWDrawInfo *di, FLightNode *head, FDynLightData &lightdata, int portalgroup);
+	void SetupLights(HWDrawInfo *di, FDynLightData &lightdata, int portalgroup);
 
 	void PutFlat(HWDrawInfo *di, bool fog = false);
 	void Process(HWDrawInfo *di, sector_t * model, int whichplane, bool notexture);

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -163,9 +163,9 @@ void HWFlat::SetupLights(HWDrawInfo *di, FDynLightData &lightdata, int portalgro
 
 	if (flatLightList != di->Level->lightlists.flat_dlist.end())
 	{
-		for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
+		for (const auto& [key, value] : flatLightList->second)
 		{
-			auto node = nodeIterator->second;
+			auto node = value;
 			if (!node) continue;
 			
 			FDynamicLight * light = node->lightsource;

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -148,7 +148,7 @@ void HWFlat::CreateSkyboxVertices(FFlatVertex *vert)
 //
 //==========================================================================
 
-void HWFlat::SetupLights(HWDrawInfo *di, FLightNode * node, FDynLightData &lightdata, int portalgroup)
+void HWFlat::SetupLights(HWDrawInfo *di, FDynLightData &lightdata, int portalgroup)
 {
 	Plane p;
 
@@ -158,29 +158,35 @@ void HWFlat::SetupLights(HWDrawInfo *di, FLightNode * node, FDynLightData &light
 		dynlightindex = -1;
 		return;	// no lights on additively blended surfaces.
 	}
-	while (node)
+
+	auto flatLightList = di->Level->lightlists.flat_dlist.find(section);
+
+	if (flatLightList != di->Level->lightlists.flat_dlist.end())
 	{
-		FDynamicLight * light = node->lightsource;
-
-		if (!light->IsActive() || light->DontLightMap())
+		for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
 		{
-			node = node->nextLight;
-			continue;
-		}
-		iter_dlightf++;
+			auto node = nodeIterator->second;
+			if (!node) continue;
+			
+			FDynamicLight * light = node->lightsource;
 
-		// we must do the side check here because gl_GetLight needs the correct plane orientation
-		// which we don't have for Legacy-style 3D-floors
-		double planeh = plane.plane.ZatPoint(light->Pos);
-		if ((planeh<light->Z() && ceiling) || (planeh>light->Z() && !ceiling))
-		{
-			node = node->nextLight;
-			continue;
-		}
+			if (!light->IsActive() || light->DontLightMap())
+			{
+				continue;
+			}
+			iter_dlightf++;
 
-		p.Set(plane.plane.Normal(), plane.plane.fD());
-		draw_dlightf += GetLight(lightdata, portalgroup, p, light, false);
-		node = node->nextLight;
+			// we must do the side check here because gl_GetLight needs the correct plane orientation
+			// which we don't have for Legacy-style 3D-floors
+			double planeh = plane.plane.ZatPoint(light->Pos);
+			if ((planeh<light->Z() && ceiling) || (planeh>light->Z() && !ceiling))
+			{
+				continue;
+			}
+
+			p.Set(plane.plane.Normal(), plane.plane.fD());
+			draw_dlightf += GetLight(lightdata, portalgroup, p, light, false);
+		}
 	}
 
 	dynlightindex = screen->mLights->UploadLights(lightdata);
@@ -196,7 +202,7 @@ void HWFlat::DrawSubsectors(HWDrawInfo *di, FRenderState &state)
 {
 	if (di->Level->HasDynamicLights && screen->BuffersArePersistent() && !di->isFullbrightScene())
 	{
-		SetupLights(di, section->lighthead, lightdata, sector->PortalGroup);
+		SetupLights(di, lightdata, sector->PortalGroup);
 	}
 	state.SetLightIndex(dynlightindex);
 
@@ -399,7 +405,7 @@ inline void HWFlat::PutFlat(HWDrawInfo *di, bool fog)
 	{
 		if (di->Level->HasDynamicLights && texture != nullptr && !di->isFullbrightScene() && !(hacktype & (SSRF_PLANEHACK|SSRF_FLOODHACK)) )
 		{
-			SetupLights(di, section->lighthead, lightdata, sector->PortalGroup);
+			SetupLights(di, lightdata, sector->PortalGroup);
 		}
 	}
 	di->AddFlat(this, fog);

--- a/src/rendering/hwrenderer/scene/hw_renderhacks.cpp
+++ b/src/rendering/hwrenderer/scene/hw_renderhacks.cpp
@@ -115,23 +115,28 @@ int HWDrawInfo::SetupLightsForOtherPlane(subsector_t * sub, FDynLightData &light
 	{
 		Plane p;
 
-		FLightNode * node = sub->section->lighthead;
-
 		lightdata.Clear();
-		while (node)
+
+		auto flatLightList = Level->lightlists.flat_dlist.find(sub->section);
+
+		if (flatLightList != Level->lightlists.flat_dlist.end())
 		{
-			FDynamicLight * light = node->lightsource;
-
-			if (!light->IsActive())
+			for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
 			{
-				node = node->nextLight;
-				continue;
-			}
-			iter_dlightf++;
+				auto node = nodeIterator->second;
+				if (!node) continue;
 
-			p.Set(plane->Normal(), plane->fD());
-			draw_dlightf += GetLight(lightdata, sub->sector->PortalGroup, p, light, true);
-			node = node->nextLight;
+				FDynamicLight * light = node->lightsource;
+
+				if (!light->IsActive())
+				{
+					continue;
+				}
+				iter_dlightf++;
+
+				p.Set(plane->Normal(), plane->fD());
+				draw_dlightf += GetLight(lightdata, sub->sector->PortalGroup, p, light, true);
+			}
 		}
 
 		return screen->mLights->UploadLights(lightdata);

--- a/src/rendering/hwrenderer/scene/hw_renderhacks.cpp
+++ b/src/rendering/hwrenderer/scene/hw_renderhacks.cpp
@@ -121,9 +121,9 @@ int HWDrawInfo::SetupLightsForOtherPlane(subsector_t * sub, FDynLightData &light
 
 		if (flatLightList != Level->lightlists.flat_dlist.end())
 		{
-			for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
+			for (const auto& [key, value] : flatLightList->second)
 			{
-				auto node = nodeIterator->second;
+				auto node = value;
 				if (!node) continue;
 
 				FDynamicLight * light = node->lightsource;

--- a/src/rendering/hwrenderer/scene/hw_spritelight.cpp
+++ b/src/rendering/hwrenderer/scene/hw_spritelight.cpp
@@ -128,9 +128,9 @@ void HWDrawInfo::GetDynSpriteLight(AActor *self, float x, float y, float z, FSec
 
 	if (flatLightList != Level->lightlists.flat_dlist.end())
 	{
-		for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
+		for (const auto& [key, value] : flatLightList->second)
 		{
-			auto node = nodeIterator->second;
+			auto node = value;
 			if (!node) continue;
 
 			light=node->lightsource;
@@ -251,9 +251,9 @@ void hw_GetDynModelLight(AActor *self, FDynLightData &modellightdata)
 			auto flatLightList = self->Level->lightlists.flat_dlist.find(subsector->section);
 			if (flatLightList != self->Level->lightlists.flat_dlist.end())
 			{
-				for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
+				for (const auto& [key, value] : flatLightList->second)
 				{ // check all lights touching a subsector
-					auto node = nodeIterator->second;
+					auto node = value;
 					if (!node) continue;
 					FDynamicLight *light = node->lightsource;
 					if (light->ShouldLightActor(self))

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -424,76 +424,134 @@ void HWWall::SetupLights(HWDrawInfo*di, FDynLightData &lightdata)
 	auto normal = glseg.Normal();
 	p.Set(normal, -normal.X * glseg.x1 - normal.Z * glseg.y1);
 
-	FLightNode *node;
-	if (seg->sidedef == NULL)
-	{
-		node = NULL;
-	}
-	else if (!(seg->sidedef->Flags & WALLF_POLYOBJ))
-	{
-		node = seg->sidedef->lighthead;
-	}
-	else if (sub)
+	if ((seg->sidedef->Flags & WALLF_POLYOBJ) && sub)
 	{
 		// Polobject segs cannot be checked per sidedef so use the subsector instead.
-		node = sub->section->lighthead;
-	}
-	else node = NULL;
+		auto flatLightList = di->Level->lightlists.flat_dlist.find(sub->section);
 
-	// Iterate through all dynamic lights which touch this wall and render them
-	while (node)
-	{
-		if (node->lightsource->IsActive() && !node->lightsource->DontLightMap())
+		if (flatLightList != di->Level->lightlists.flat_dlist.end())
 		{
-			iter_dlight++;
-
-			DVector3 posrel = node->lightsource->PosRelative(seg->frontsector->PortalGroup);
-			float x = posrel.X;
-			float y = posrel.Y;
-			float z = posrel.Z;
-			float dist = fabsf(p.DistToPoint(x, z, y));
-			float radius = node->lightsource->GetRadius();
-			float scale = 1.0f / ((2.f * radius) - dist);
-			FVector3 fn, pos;
-
-			if (radius > 0.f && dist < radius)
+			for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
 			{
-				FVector3 nearPt, up, right;
+				auto node = nodeIterator->second;
+				if (!node) continue;
 
-				pos = { x, z, y };
-				fn = p.Normal();
-
-				fn.GetRightUp(right, up);
-
-				FVector3 tmpVec = fn * dist;
-				nearPt = pos + tmpVec;
-
-				FVector3 t1;
-				int outcnt[4]={0,0,0,0};
-				texcoord tcs[4];
-
-				// do a quick check whether the light touches this polygon
-				for(int i=0;i<4;i++)
+				if (node->lightsource->IsActive() && !node->lightsource->DontLightMap())
 				{
-					t1 = FVector3(&vtx[i*3]);
-					FVector3 nearToVert = t1 - nearPt;
-					tcs[i].u = ((nearToVert | right) * scale) + 0.5f;
-					tcs[i].v = ((nearToVert | up) * scale) + 0.5f;
+					iter_dlight++;
 
-					if (tcs[i].u<0) outcnt[0]++;
-					if (tcs[i].u>1) outcnt[1]++;
-					if (tcs[i].v<0) outcnt[2]++;
-					if (tcs[i].v>1) outcnt[3]++;
+					DVector3 posrel = node->lightsource->PosRelative(seg->frontsector->PortalGroup);
+					float x = posrel.X;
+					float y = posrel.Y;
+					float z = posrel.Z;
+					float dist = fabsf(p.DistToPoint(x, z, y));
+					float radius = node->lightsource->GetRadius();
+					float scale = 1.0f / ((2.f * radius) - dist);
+					FVector3 fn, pos;
 
-				}
-				if (outcnt[0]!=4 && outcnt[1]!=4 && outcnt[2]!=4 && outcnt[3]!=4) 
-				{
-					draw_dlight += GetLight(lightdata, seg->frontsector->PortalGroup, p, node->lightsource, true);
+					if (radius > 0.f && dist < radius)
+					{
+						FVector3 nearPt, up, right;
+
+						pos = { x, z, y };
+						fn = p.Normal();
+
+						fn.GetRightUp(right, up);
+
+						FVector3 tmpVec = fn * dist;
+						nearPt = pos + tmpVec;
+
+						FVector3 t1;
+						int outcnt[4]={0,0,0,0};
+						texcoord tcs[4];
+
+						// do a quick check whether the light touches this polygon
+						for(int i=0;i<4;i++)
+						{
+							t1 = FVector3(&vtx[i*3]);
+							FVector3 nearToVert = t1 - nearPt;
+							tcs[i].u = ((nearToVert | right) * scale) + 0.5f;
+							tcs[i].v = ((nearToVert | up) * scale) + 0.5f;
+
+							if (tcs[i].u<0) outcnt[0]++;
+							if (tcs[i].u>1) outcnt[1]++;
+							if (tcs[i].v<0) outcnt[2]++;
+							if (tcs[i].v>1) outcnt[3]++;
+
+						}
+						if (outcnt[0]!=4 && outcnt[1]!=4 && outcnt[2]!=4 && outcnt[3]!=4) 
+						{
+							draw_dlight += GetLight(lightdata, seg->frontsector->PortalGroup, p, node->lightsource, true);
+						}
+					}
 				}
 			}
 		}
-		node = node->nextLight;
 	}
+	else
+	{
+		auto wallLightList = di->Level->lightlists.wall_dlist.find(seg->sidedef);
+
+		if (wallLightList != di->Level->lightlists.wall_dlist.end())
+		{
+			for (auto nodeIterator = wallLightList->second.begin(); nodeIterator != wallLightList->second.end(); nodeIterator++)
+			{
+				auto node = nodeIterator->second;
+				if (!node) continue;
+
+				if (node->lightsource->IsActive() && !node->lightsource->DontLightMap())
+				{
+					iter_dlight++;
+
+					DVector3 posrel = node->lightsource->PosRelative(seg->frontsector->PortalGroup);
+					float x = posrel.X;
+					float y = posrel.Y;
+					float z = posrel.Z;
+					float dist = fabsf(p.DistToPoint(x, z, y));
+					float radius = node->lightsource->GetRadius();
+					float scale = 1.0f / ((2.f * radius) - dist);
+					FVector3 fn, pos;
+
+					if (radius > 0.f && dist < radius)
+					{
+						FVector3 nearPt, up, right;
+
+						pos = { x, z, y };
+						fn = p.Normal();
+
+						fn.GetRightUp(right, up);
+
+						FVector3 tmpVec = fn * dist;
+						nearPt = pos + tmpVec;
+
+						FVector3 t1;
+						int outcnt[4]={0,0,0,0};
+						texcoord tcs[4];
+
+						// do a quick check whether the light touches this polygon
+						for(int i=0;i<4;i++)
+						{
+							t1 = FVector3(&vtx[i*3]);
+							FVector3 nearToVert = t1 - nearPt;
+							tcs[i].u = ((nearToVert | right) * scale) + 0.5f;
+							tcs[i].v = ((nearToVert | up) * scale) + 0.5f;
+
+							if (tcs[i].u<0) outcnt[0]++;
+							if (tcs[i].u>1) outcnt[1]++;
+							if (tcs[i].v<0) outcnt[2]++;
+							if (tcs[i].v>1) outcnt[3]++;
+
+						}
+						if (outcnt[0]!=4 && outcnt[1]!=4 && outcnt[2]!=4 && outcnt[3]!=4) 
+						{
+							draw_dlight += GetLight(lightdata, seg->frontsector->PortalGroup, p, node->lightsource, true);
+						}
+					}
+				}
+			}
+		}
+	}
+
 	dynlightindex = screen->mLights->UploadLights(lightdata);
 }
 

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -431,9 +431,9 @@ void HWWall::SetupLights(HWDrawInfo*di, FDynLightData &lightdata)
 
 		if (flatLightList != di->Level->lightlists.flat_dlist.end())
 		{
-			for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
+			for (const auto& [key, value] : flatLightList->second)
 			{
-				auto node = nodeIterator->second;
+				auto node = value;
 				if (!node) continue;
 
 				if (node->lightsource->IsActive() && !node->lightsource->DontLightMap())
@@ -494,9 +494,9 @@ void HWWall::SetupLights(HWDrawInfo*di, FDynLightData &lightdata)
 
 		if (wallLightList != di->Level->lightlists.wall_dlist.end())
 		{
-			for (auto nodeIterator = wallLightList->second.begin(); nodeIterator != wallLightList->second.end(); nodeIterator++)
+			for (const auto& [key, value] : wallLightList->second)
 			{
-				auto node = nodeIterator->second;
+				auto node = value;
 				if (!node) continue;
 
 				if (node->lightsource->IsActive() && !node->lightsource->DontLightMap())

--- a/src/rendering/swrenderer/line/r_walldraw.cpp
+++ b/src/rendering/swrenderer/line/r_walldraw.cpp
@@ -227,9 +227,9 @@ namespace swrenderer
 			auto wallLightList = Level->lightlists.wall_dlist.find(curline->sidedef);
 			if (wallLightList != Level->lightlists.wall_dlist.end())
 			{
-				for (auto nodeIterator = wallLightList->second.begin(); nodeIterator != wallLightList->second.end(); nodeIterator++)
+				for (const auto& [key, value] : wallLightList->second)
 				{
-					auto node = nodeIterator->second;
+					auto node = value;
 					if (!node) continue;
 
 					if (node->lightsource->IsActive())

--- a/src/rendering/swrenderer/plane/r_visibleplane.cpp
+++ b/src/rendering/swrenderer/plane/r_visibleplane.cpp
@@ -66,7 +66,7 @@ namespace swrenderer
 		fillshort(top, viewwidth, 0x7fff);
 	}
 
-	void VisiblePlane::AddLights(RenderThread *thread, FLightNode *node)
+	void VisiblePlane::AddLights(RenderThread *thread, FSection *sec)
 	{
 		if (!r_dynlights)
 			return;
@@ -75,30 +75,37 @@ namespace swrenderer
 		if (cameraLight->FixedColormap() != NULL || cameraLight->FixedLightLevel() >= 0)
 			return; // [SP] no dynlights if invul or lightamp
 
-		while (node)
+		auto Level = sec->sector->Level;
+		auto flatLightList = Level->lightlists.flat_dlist.find(sec);
+		if (flatLightList != Level->lightlists.flat_dlist.end())
 		{
-			if (node->lightsource->IsActive() && (height.PointOnSide(node->lightsource->Pos) > 0))
+			for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
 			{
-				bool found = false;
-				VisiblePlaneLight *light_node = lights;
-				while (light_node)
+				auto node = nodeIterator->second;
+				if (!node) continue;
+
+				if (node->lightsource->IsActive() && (height.PointOnSide(node->lightsource->Pos) > 0))
 				{
-					if (light_node->lightsource == node->lightsource)
+					bool found = false;
+					VisiblePlaneLight *light_node = lights;
+					while (light_node)
 					{
-						found = true;
-						break;
+						if (light_node->lightsource == node->lightsource)
+						{
+							found = true;
+							break;
+						}
+						light_node = light_node->next;
 					}
-					light_node = light_node->next;
-				}
-				if (!found)
-				{
-					VisiblePlaneLight *newlight = thread->FrameMemory->NewObject<VisiblePlaneLight>();
-					newlight->next = lights;
-					newlight->lightsource = node->lightsource;
-					lights = newlight;
+					if (!found)
+					{
+						VisiblePlaneLight *newlight = thread->FrameMemory->NewObject<VisiblePlaneLight>();
+						newlight->next = lights;
+						newlight->lightsource = node->lightsource;
+						lights = newlight;
+					}
 				}
 			}
-			node = node->nextLight;
 		}
 	}
 

--- a/src/rendering/swrenderer/plane/r_visibleplane.cpp
+++ b/src/rendering/swrenderer/plane/r_visibleplane.cpp
@@ -79,9 +79,9 @@ namespace swrenderer
 		auto flatLightList = Level->lightlists.flat_dlist.find(sec);
 		if (flatLightList != Level->lightlists.flat_dlist.end())
 		{
-			for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
+			for (const auto& [key, value] : flatLightList->second)
 			{
-				auto node = nodeIterator->second;
+				auto node = value;
 				if (!node) continue;
 
 				if (node->lightsource->IsActive() && (height.PointOnSide(node->lightsource->Pos) > 0))

--- a/src/rendering/swrenderer/plane/r_visibleplane.h
+++ b/src/rendering/swrenderer/plane/r_visibleplane.h
@@ -46,7 +46,7 @@ namespace swrenderer
 	{
 		VisiblePlane(RenderThread *thread);
 
-		void AddLights(RenderThread *thread, FLightNode *node);
+		void AddLights(RenderThread *thread, FSection *sec);
 		void Render(RenderThread *thread, fixed_t alpha, bool additive, bool masked);
 
 		VisiblePlane *next = nullptr;		// Next visplane in hash chain -- killough

--- a/src/rendering/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.cpp
@@ -561,7 +561,7 @@ namespace swrenderer
 				Fake3DOpaque::Normal,
 				0);
 
-			ceilingplane->AddLights(Thread, sub->section->lighthead);
+			ceilingplane->AddLights(Thread, sub->section);
 		}
 
 		int adjusted_floorlightlevel = floorlightlevel;
@@ -601,7 +601,7 @@ namespace swrenderer
 				Fake3DOpaque::Normal,
 				0);
 
-			floorplane->AddLights(Thread, sub->section->lighthead);
+			floorplane->AddLights(Thread, sub->section);
 		}
 
 		Add3DFloorPlanes(sub, frontsector, basecolormap, foggy, adjusted_ceilinglightlevel, adjusted_floorlightlevel);
@@ -738,7 +738,7 @@ namespace swrenderer
 						Fake3DOpaque::FakeFloor,
 						fakeAlpha);
 
-					floorplane3d->AddLights(Thread, sub->section->lighthead);
+					floorplane3d->AddLights(Thread, sub->section);
 
 					FakeDrawLoop(sub, &tempsec, floorplane3d, nullptr, Fake3DOpaque::FakeFloor);
 				}
@@ -806,7 +806,7 @@ namespace swrenderer
 						Fake3DOpaque::FakeCeiling,
 						fakeAlpha);
 
-					ceilingplane3d->AddLights(Thread, sub->section->lighthead);
+					ceilingplane3d->AddLights(Thread, sub->section);
 
 					FakeDrawLoop(sub, &tempsec, nullptr, ceilingplane3d, Fake3DOpaque::FakeCeiling);
 				}

--- a/src/rendering/swrenderer/things/r_sprite.cpp
+++ b/src/rendering/swrenderer/things/r_sprite.cpp
@@ -208,42 +208,48 @@ namespace swrenderer
 			float lit_red = 0;
 			float lit_green = 0;
 			float lit_blue = 0;
-			auto node = vis->section->lighthead;
-			while (node != nullptr)
+			auto Level = vis->sector->Level;
+			auto flatLightList = Level->lightlists.flat_dlist.find(vis->section);
+			if (flatLightList != Level->lightlists.flat_dlist.end())
 			{
-				FDynamicLight *light = node->lightsource;
-				if (light->ShouldLightActor(thing))
+				for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
 				{
-					float lx = (float)(light->X() - thing->X());
-					float ly = (float)(light->Y() - thing->Y());
-					float lz = (float)(light->Z() - thing->Center());
-					float LdotL = lx * lx + ly * ly + lz * lz;
-					float radius = node->lightsource->GetRadius();
-					if (radius * radius >= LdotL)
+					auto node = nodeIterator->second;
+					if (!node) continue;
+
+					FDynamicLight *light = node->lightsource;
+					if (light->ShouldLightActor(thing))
 					{
-						float distance = sqrt(LdotL);
-						float attenuation = 1.0f - distance / radius;
-						if (attenuation > 0.0f)
-						{						
-							float red = light->GetRed() * (1.0f / 255.0f);
-							float green = light->GetGreen() * (1.0f / 255.0f);
-							float blue = light->GetBlue() * (1.0f / 255.0f);
-							/*if (light->IsSubtractive())
-							{
-								float bright = FVector3(lr, lg, lb).Length();
-								FVector3 lightColor(lr, lg, lb);
-								red = (bright - lr) * -1;
-								green = (bright - lg) * -1;
-								blue = (bright - lb) * -1;
-							}*/
-						
-							lit_red += red * attenuation;
-							lit_green += green * attenuation;
-							lit_blue += blue * attenuation;
+						float lx = (float)(light->X() - thing->X());
+						float ly = (float)(light->Y() - thing->Y());
+						float lz = (float)(light->Z() - thing->Center());
+						float LdotL = lx * lx + ly * ly + lz * lz;
+						float radius = node->lightsource->GetRadius();
+						if (radius * radius >= LdotL)
+						{
+							float distance = sqrt(LdotL);
+							float attenuation = 1.0f - distance / radius;
+							if (attenuation > 0.0f)
+							{						
+								float red = light->GetRed() * (1.0f / 255.0f);
+								float green = light->GetGreen() * (1.0f / 255.0f);
+								float blue = light->GetBlue() * (1.0f / 255.0f);
+								/*if (light->IsSubtractive())
+								{
+									float bright = FVector3(lr, lg, lb).Length();
+									FVector3 lightColor(lr, lg, lb);
+									red = (bright - lr) * -1;
+									green = (bright - lg) * -1;
+									blue = (bright - lb) * -1;
+								}*/
+							
+								lit_red += red * attenuation;
+								lit_green += green * attenuation;
+								lit_blue += blue * attenuation;
+							}
 						}
 					}
 				}
-				node = node->nextLight;
 			}
 			lit_red = clamp(lit_red * 255.0f, 0.0f, 255.0f);
 			lit_green = clamp(lit_green * 255.0f, 0.0f, 255.0f);

--- a/src/rendering/swrenderer/things/r_sprite.cpp
+++ b/src/rendering/swrenderer/things/r_sprite.cpp
@@ -212,9 +212,9 @@ namespace swrenderer
 			auto flatLightList = Level->lightlists.flat_dlist.find(vis->section);
 			if (flatLightList != Level->lightlists.flat_dlist.end())
 			{
-				for (auto nodeIterator = flatLightList->second.begin(); nodeIterator != flatLightList->second.end(); nodeIterator++)
+				for (const auto& [key, value] : flatLightList->second)
 				{
-					auto node = nodeIterator->second;
+					auto node = value;
 					if (!node) continue;
 
 					FDynamicLight *light = node->lightsource;


### PR DESCRIPTION
Replaces the lighthead double linked lists with unordered_maps. Vastly improves performance of large moving dlights over complex map geometry.

Test recordings on [Bastion of Chaos](https://drive.google.com/file/d/1ZWK54XzL34ciZpANb9VM1kM2PgZ2Fbmu/view?usp=sharing) (a very performance demanding map for GZDoom).

| Renderer | Before | After |
| - | - | - |
| SW Pal | [before_pal.webm](https://github.com/user-attachments/assets/3dcad66d-dcf7-4fc5-b29d-5d4ac869339a) | [after_pal.webm](https://github.com/user-attachments/assets/6e8cb0c9-842c-4ab9-aa39-8cbc0d906500) |
| SW RGBA | [before_rgba.webm](https://github.com/user-attachments/assets/8bdc06ac-20f1-4afc-bbdd-2ea0757fe065) | [after_rgba.webm](https://github.com/user-attachments/assets/c29929e0-5514-40a4-91db-9913df036ad9) |
| HW | [before_hw.webm](https://github.com/user-attachments/assets/6e53028b-1c9b-43a6-bea0-5e9bbc1df01c) | [after_hw.webm](https://github.com/user-attachments/assets/68b13295-fff9-41fe-ad21-215b3fed19d7) |

Before:
One large moving light utterly annihilates performance.

After:
Many large moving lights with acceptable performance.