### PR TITLE
Fixed pitch culling in reflective flats for OoB Viewpoints

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -486,7 +486,9 @@ void HWDrawInfo::CreateScene(bool drawpsprites)
 	{
 		double a2 = 20.0 + 0.5*Viewpoint.FieldOfView.Degrees(); // FrustumPitch for vertical clipping
 		if (a2 > 179.0) a2 = 179.0;
-		vClipper->SafeAddClipRangeDegPitches(vp.HWAngles.Pitch.Degrees() - a2, vp.HWAngles.Pitch.Degrees() + a2); // clip the suplex range
+		double pitchmult = (portalState.PlaneMirrorFlag % 2 != 0) ? -1.0 : 1.0;
+		vClipper->SafeAddClipRangeDegPitches(pitchmult * vp.HWAngles.Pitch.Degrees() - a2, pitchmult * vp.HWAngles.Pitch.Degrees() + a2); // clip the suplex range
+		Viewpoint.PitchSin *= pitchmult;
 	}
 
 	// reset the portal manager

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -486,7 +486,7 @@ void HWDrawInfo::CreateScene(bool drawpsprites)
 	{
 		double a2 = 20.0 + 0.5*Viewpoint.FieldOfView.Degrees(); // FrustumPitch for vertical clipping
 		if (a2 > 179.0) a2 = 179.0;
-		double pitchmult = (portalState.PlaneMirrorFlag & 1) ? -1.0 : 1.0;
+		double pitchmult = !!(portalState.PlaneMirrorFlag & 1) ? -1.0 : 1.0;
 		vClipper->SafeAddClipRangeDegPitches(pitchmult * vp.HWAngles.Pitch.Degrees() - a2, pitchmult * vp.HWAngles.Pitch.Degrees() + a2); // clip the suplex range
 		Viewpoint.PitchSin *= pitchmult;
 	}

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -486,7 +486,7 @@ void HWDrawInfo::CreateScene(bool drawpsprites)
 	{
 		double a2 = 20.0 + 0.5*Viewpoint.FieldOfView.Degrees(); // FrustumPitch for vertical clipping
 		if (a2 > 179.0) a2 = 179.0;
-		double pitchmult = (portalState.PlaneMirrorFlag % 2 != 0) ? -1.0 : 1.0;
+		double pitchmult = (portalState.PlaneMirrorFlag & 1) ? -1.0 : 1.0;
 		vClipper->SafeAddClipRangeDegPitches(pitchmult * vp.HWAngles.Pitch.Degrees() - a2, pitchmult * vp.HWAngles.Pitch.Degrees() + a2); // clip the suplex range
 		Viewpoint.PitchSin *= pitchmult;
 	}


### PR DESCRIPTION
The vertical clipper needed viewpoint pitch sign to be flipped to work correctly. Only relevant for OoB viewpoints.