### PR TITLE
Added am_showlevelname CVar

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -170,6 +170,7 @@ CVAR(Bool, am_showmonsters, true, CVAR_ARCHIVE);
 CVAR(Bool, am_showitems, false, CVAR_ARCHIVE);
 CVAR(Bool, am_showtime, true, CVAR_ARCHIVE);
 CVAR(Bool, am_showtotaltime, false, CVAR_ARCHIVE);
+CVAR(Bool, am_showlevelname, true, CVAR_ARCHIVE);
 CVAR(Int, am_colorset, 0, CVAR_ARCHIVE);
 CVAR(Bool, am_customcolors, true, CVAR_ARCHIVE);
 CVAR(Int, am_map_secrets, 1, CVAR_ARCHIVE);

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -85,6 +85,7 @@ EXTERN_CVAR (Bool, am_showsecrets)
 EXTERN_CVAR (Bool, am_showitems)
 EXTERN_CVAR (Bool, am_showtime)
 EXTERN_CVAR (Bool, am_showtotaltime)
+EXTERN_CVAR (Bool, am_showlevelname)
 EXTERN_CVAR(Bool, inter_subtitles)
 EXTERN_CVAR(Bool, ui_screenborder_classic_scaling)
 
@@ -598,6 +599,8 @@ void DBaseStatusBar::DoDrawAutomapHUD(int crdefault, int highlight)
 	}
 
 	FormatMapName(primaryLevel, crdefault, &textbuffer);
+	if (textbuffer.IsEmpty())
+		return;
 
 	if (!generic_ui)
 	{

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2282,6 +2282,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, GetSpotState, GetSpotState)
 //---------------------------------------------------------------------------
 
 EXTERN_CVAR(Int, am_showmaplabel)
+EXTERN_CVAR(Bool, am_showlevelname)
 
 void FormatMapName(FLevelLocals *self, int cr, FString *result)
 {
@@ -2295,13 +2296,19 @@ void FormatMapName(FLevelLocals *self, int cr, FString *result)
 	if (self->info->MapLabel.IsNotEmpty())
 	{
 		if (self->info->MapLabel.Compare("*"))
-			*result << self->info->MapLabel << ": ";
+			*result << self->info->MapLabel;
 	}
 	else if (am_showmaplabel == 1 || (am_showmaplabel == 2 && !ishub))
 	{
-		*result << self->MapName << ": ";
+		*result << self->MapName;
 	}
-	*result << mapnamecolor << self->LevelName;
+
+	if (am_showlevelname)
+	{
+		if (!result->IsEmpty())
+			*result << ": ";
+		*result << mapnamecolor << self->LevelName;
+	}
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, FormatMapName, FormatMapName)


### PR DESCRIPTION
Allows controlling the visibility of the level name on the automap.