### PR TITLE
Fix DSDHacked actors not spawning when placed in a map

### DIFF
--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -139,6 +139,7 @@ static PClassActor* FindInfoName(int index, bool mustexist = false)
 			cls = static_cast<PClassActor*>(RUNTIME_CLASS(AActor)->CreateDerivedClass(name.GetChars(), (unsigned)sizeof(AActor)));
 			NewClassType(cls, -1);	// This needs a VM type to work as intended.
 			cls->InitializeDefaults();
+			PClassActor::AllActorClasses.Push(cls);
 		}
 		if (cls)
 		{
@@ -3714,7 +3715,11 @@ void FinishDehPatch ()
 			mysnprintf(typeNameBuilder, countof(typeNameBuilder), "DehackedPickup%d", nameindex++);
 			bool newlycreated;
 			subclass = static_cast<PClassActor *>(dehtype->CreateDerivedClass(typeNameBuilder, dehtype->Size, &newlycreated, 0));
-			if (newlycreated) subclass->InitializeDefaults();
+			if (newlycreated)
+			{
+				subclass->InitializeDefaults();
+				PClassActor::AllActorClasses.Push(subclass);
+			}
 		} 
 		while (subclass == nullptr);
 		NewClassType(subclass, 0);	// This needs a VM type to work as intended.


### PR DESCRIPTION
Fixes #2619 -- makes extra actors defined by DSDHacked work correctly.

The bug was exactly as described [here](https://github.com/ZDoom/gzdoom/issues/2619#issuecomment-2329152344) (thanks @tomas7770 for the investigation here) -- DSDHacked-defined actors weren't getting added to the DoomEdNum map, so map-placed spawns weren't working. Just needed to add the newly-created actors to `PClassActor::AllActorClasses` and everything just works fine.

Test case is a bit DIY, but I basically just took [Eviternity II](https://eviternity.dfdoom.com) and renamed the DECORATE lump to repro the bug. Actors like the invulnerable cyberdemons in MAP24 would appear as <!> objects before the fix; with this PR they show up successfully.