### PR TITLE
Add commonly GZDoom-specific properties to DEHACKED

### DIFF
--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -1203,6 +1203,8 @@ static int PatchThing (int thingy, int flags)
 	AActor *info;
 	uint8_t dummy[sizeof(AActor)];
 	bool hadHeight = false;
+	bool hadProjHeight = false;
+	bool hadPhysHeight = false;
 	bool hadTranslucency = false;
 	bool hadStyle = false;
 	FStateDefinitions statedef;
@@ -1262,8 +1264,17 @@ static int PatchThing (int thingy, int flags)
 		}
 		else if (linelen == 6 && stricmp (Line1, "Height") == 0)
 		{
-			info->Height = DEHToDouble(val);
-			info->projectilepassheight = 0;	// needs to be disabled
+			// [XA] This is a bit more complex now, since projectilepassheight
+			// and "physical height" now both exist. if either of these are
+			// defined, then override the Height field accordingly.
+			if(!hadPhysHeight)
+			{
+				info->Height = DEHToDouble(val);
+			}
+			if(!hadProjHeight)
+			{
+				info->projectilepassheight = 0;	// needs to be disabled
+			}
 			hadHeight = true;
 		}
 		else if (linelen == 14 && stricmp (Line1, "Missile damage") == 0)
@@ -1457,6 +1468,47 @@ static int PatchThing (int thingy, int flags)
 		{
 			// [crispy] Multiplies the chance of firing a missile (65536 = normal chance)
 			info->missilechancemult = DEHToDouble(val);
+		}
+
+		// [XA] Fields for common GZDoom-specific values that
+		// are desirable to set in a cross-port DEHACKED mod.
+		// adding these prevents users from having to reimplement
+		// actors in zscript just to define these few fields.
+		else if (!stricmp(Line1, "Projectile pass height"))
+		{
+			info->projectilepassheight = DEHToDouble(val);
+			hadProjHeight = true;
+		}
+		else if (!stricmp(Line1, "Physical height"))
+		{
+			// [XA] This is a synonym for Height that is intended
+			// to be ignored in any ports that don't support
+			// projectilepassheight -- this is needed because
+			// other ports' "Height x" is actually equivalent
+			// to Zdoom's "ProjectilePassHeight x; Height y",
+			// i.e. the definition of the Height var is different.
+			info->Height = DEHToDouble(val);
+			hadPhysHeight = true;
+		}
+		else if (!stricmp(Line1, "Tag"))
+		{
+			stripwhite(Line2);
+			info->SetTag(Line2);
+		}
+		else if (!stricmp(Line1, "Obituary"))
+		{
+			stripwhite(Line2);
+			info->StringVar(NAME_Obituary) = Line2;
+		}
+		else if (!stricmp(Line1, "Melee obituary"))
+		{
+			stripwhite(Line2);
+			info->StringVar(NAME_HitObituary) = Line2;
+		}
+		else if (!stricmp(Line1, "Self obituary"))
+		{
+			stripwhite(Line2);
+			info->StringVar(NAME_SelfObituary) = Line2;
 		}
 
 		else if (linelen > 6)
@@ -1727,12 +1779,23 @@ static int PatchThing (int thingy, int flags)
 		else Printf (unknown_str, Line1, "Thing", thingy);
 	}
 
+	// [XA] sanity check: to avoid ambiguity, an actor that defines
+	// ProjectilePassHeight must also define PhysicalHeight, and vice-versa.
+	if(hadPhysHeight && !hadProjHeight)
+	{
+		I_Error("Thing %d: DEHACKED actors that set 'Physical height' must also set 'Projectile pass height'\n", thingy);
+	}
+	else if(!hadPhysHeight && hadProjHeight)
+	{
+		I_Error("Thing %d: DEHACKED actors that set 'Projectile pass height' must also set 'Physical height'\n", thingy);
+	}
+
 	if (info != (AActor *)&dummy)
 	{
 		// Reset heights for things hanging from the ceiling that
 		// don't specify a new height.
 		if (info->flags & MF_SPAWNCEILING &&
-			!hadHeight &&
+			!hadHeight && !hadPhysHeight &&
 			thingy <= (int)OrgHeights.Size() && thingy > 0)
 		{
 			info->Height = OrgHeights[thingy - 1];

--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -482,6 +482,9 @@ xx(PowerupType)
 xx(PlayerPawn)
 xx(RipSound)
 xx(Archvile)
+xx(Obituary)
+xx(HitObituary)
+xx(SelfObituary)
 
 xx(ResolveState)
 


### PR DESCRIPTION
Closes #3060 -- see linked issue for justification, but the gist is that folks making MBF21/DSDHacked mods find themselves needing to set a few GZDoom-specific fields for compatibility, but are forced to reimplement the entire actor in ZScript in order to achieve that. This sucks, naturally. :P

This PR adds the following properties to DEHACKED:
- Tag
- Obituary
- HitObituary ("Melee obituary")
- SelfObituary ("Self obituary")
- ProjectilePassHeight ("Projectile pass height")
- A new alias for Height named "Physical height" -- if this is specified, then the "Height" field in the patch is ignored. More on this in a bit.

The obituary definitions were previously doable via LANGUAGE, but this makes it so modders don't have to dip into GZDoom-specific lumps at all to make things work nicely.

"Physical height" is just an alias for the Height field, but it's necessary in order to work around a fundamental difference in how the Height variable is treated across ports: in GZDoom, if you want to make a 56-unit-tall actor with an effective projectile collision height of 16, you'd set Height to 56 and ProjectilePassHeight to 16, but in other ports (e.g. dsda-doom and others that stick to vanilla), Height is effectively the projectille collision value -- i.e. a Height value of 56 will cause projectiles fired by the player on level ground to collide with it. Oopsie.

To fix this, with this PR you can set the following properties on a thing in DEHACKED:
- `Height 16`
- `ProjectilePassHeight 16`
- `PhysicalHeight 56`

GZDoom will set Height to 56, while other ports will set Height to 16, making everything work consistently.

As an additional sanity check, trying to specify either ProjectilePassHeight or PhysicalHeight without also including the other will throw an error -- the patch must specify both, or neither.