### PR TITLE
Add obituaries to ID24 monsters

### DIFF
--- a/wadsrc/static/zscript/actors/doom/id24/id24banshee.zs
+++ b/wadsrc/static/zscript/actors/doom/id24/id24banshee.zs
@@ -35,7 +35,8 @@ class ID24Banshee : Actor
 		SeeSound "monsters/banshee/sight";
 		PainSound "monsters/banshee/pain";
 		DeathSound "monsters/banshee/death";
-		Tag "$FN_ID24BANSHEE";
+	//	SelfObituary "$ID24_OB_BANSHEE";
+		Tag "$ID24_CC_BANSHEE";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/actors/doom/id24/id24ghoul.zs
+++ b/wadsrc/static/zscript/actors/doom/id24/id24ghoul.zs
@@ -36,7 +36,8 @@ class ID24Ghoul : Actor
 		PainSound "monsters/ghoul/pain";
 		DeathSound "monsters/ghoul/death";
 		ActiveSound "monsters/ghoul/active";
-		Tag "$FN_ID24GHOUL";
+		Obituary "$ID24_OB_GHOUL";
+		Tag "$ID24_CC_GHOUL";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/actors/doom/id24/id24mindweaver.zs
+++ b/wadsrc/static/zscript/actors/doom/id24/id24mindweaver.zs
@@ -34,7 +34,8 @@ class ID24Mindweaver : Actor
 		PainSound "monsters/mindweaver/pain";
 		DeathSound "monsters/mindweaver/death";
 		ActiveSound "monsters/mindweaver/active";
-		Tag "$FN_ID24MINDWEAVER";
+		Obituary "$ID24_OB_MINDWEAVER";
+		Tag "$ID24_CC_MINDWEAVER";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/actors/doom/id24/id24plasmaguy.zs
+++ b/wadsrc/static/zscript/actors/doom/id24/id24plasmaguy.zs
@@ -33,7 +33,8 @@ class ID24PlasmaGuy : Actor
 		PainSound "monsters/plasmaguy/pain";
 		DeathSound "monsters/plasmaguy/death";
 		ActiveSound "monsters/plasmaguy/active";
-		Tag "$FN_ID24PLASMAGUY";
+		Obituary "$ID24_OB_SHOCKTROOPER";
+		Tag "$ID24_CC_SHOCKTROOPER";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/actors/doom/id24/id24tyrant.zs
+++ b/wadsrc/static/zscript/actors/doom/id24/id24tyrant.zs
@@ -31,7 +31,8 @@ class ID24Tyrant : Cyberdemon
 		PainSound "monsters/tyrant/pain";
 		DeathSound "monsters/tyrant/death";
 		ActiveSound "monsters/tyrant/active";
-		Tag "$FN_ID24TYRANT";
+		Obituary "$ID24_OB_TYRANT";
+		Tag "$ID24_CC_TYRANT";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/actors/doom/id24/id24vassago.zs
+++ b/wadsrc/static/zscript/actors/doom/id24/id24vassago.zs
@@ -35,7 +35,8 @@ class ID24Vassago : Actor
 		PainSound "monsters/vassago/pain";
 		DeathSound "monsters/vassago/death";
 		ActiveSound "monsters/vassago/active";
-		Tag "$FN_ID24VASSAGO";
+		Obituary "$ID24_OB_VASSAGO";
+		Tag "$ID24_CC_VASSAGO";
 	}
 	States
 	{


### PR DESCRIPTION
I wasn't sure if the `SelfObituary` property should be used, so I commented it out for the Banshee monster (which attacks the player by exploding itself, typically resulting in a "Player killed himself." obituary).

[Here](https://github.com/user-attachments/files/20065402/language.csv) is a language file with obituary strings, including translations into German (by @Meerschweinmann) and Russian. It also includes the official localisations of the monster's names into German, Spanish, Latin American Spanish, French, Italian, Japanese, Korean, Polish, Brazilian Portuguese, and Russian.

I also renamed the language identifiers of the ID24 monsters' tags to match the ones used by Legacy of Rust's cast sequence in DOOM + DOOM II.