### PR TITLE
Use old SNDINFO syntax for ID24 sounds

### DIFF
--- a/wadsrc/static/filter/game-doomchex/sndinfo.txt
+++ b/wadsrc/static/filter/game-doomchex/sndinfo.txt
@@ -460,60 +460,60 @@ $alias				intermission/pastdmstats	*gibbed
 
 // id24 sounds
 
-world/officelamp = DSBREAK
+world/officelamp		dsbreak
 
-ambient/klaxon = DSKLAXON
-ambient/portalopen = DSGATOPN
-ambient/portalloop = DSGATLOP
-ambient/portalclose = DSGATCLS
+ambient/klaxon			dsklaxon
+ambient/portalopen		dsgatopn
+ambient/portalloop		dsgatlop
+ambient/portalclose		dsgatcls
 
-monsters/ghoul/sight = DSGHLSIT
-monsters/ghoul/pain = DSGHLPAI
-monsters/ghoul/death = DSGHLDTH
-monsters/ghoul/active = DSGHLACT
-monsters/ghoul/attack = DSFIRSHT
-monsters/ghoul/shotx = DSFIRXPL
+monsters/ghoul/sight		dsghlsit
+monsters/ghoul/pain		dsghlpai
+monsters/ghoul/death		dsghldth
+monsters/ghoul/active		dsghlact
+monsters/ghoul/attack		dsfirsht
+monsters/ghoul/shotx		dsfirxpl
 
-monsters/banshee/sight = DSBANACT
-monsters/banshee/pain = DSBANPAI
-monsters/banshee/death = DSBANDTH
-monsters/banshee/active = DSBANACT
+monsters/banshee/sight		dsbanact
+monsters/banshee/pain		dsbanpai
+monsters/banshee/death		dsbandth
+monsters/banshee/active		dsbanact
 
-monsters/mindweaver/sight = DSCSPSIT
-monsters/mindweaver/pain = DSDMPAIN
-monsters/mindweaver/death = DSCSPDTH
-monsters/mindweaver/active = DSCSPACT
-monsters/mindweaver/walk = DSCSPWLK
+monsters/mindweaver/sight	dscspsit
+monsters/mindweaver/pain	dsdmpain
+monsters/mindweaver/death	dscspdth
+monsters/mindweaver/active	dscspact
+monsters/mindweaver/walk	dscspwlk
 
-monsters/plasmaguy/pain = DSPPOPAI
-monsters/plasmaguy/death = DSPPODTH
-monsters/plasmaguy/active = DSPPOACT
-monsters/plasmaguy/head = DSPPOHED
+monsters/plasmaguy/pain		dsppopai
+monsters/plasmaguy/death	dsppodth
+monsters/plasmaguy/active	dsppoact
+monsters/plasmaguy/head		dsppohed
 
-monsters/vassago/sight = DSVASSIT
-monsters/vassago/pain = DSVASPAI
-monsters/vassago/death = DSVASDTH
-monsters/vassago/active = DSVASACT
-monsters/vassago/attack = DSVASATK
-monsters/vassago/burn = DSINCBRN
-monsters/vassago/shotx = DSFLAME
-monsters/vassago/hot1 = DSINCHT1
-monsters/vassago/hot2 = DSINCHT2
-monsters/vassago/hot3 = DSINCHT3
+monsters/vassago/sight		dsvassit
+monsters/vassago/pain		dsvaspai
+monsters/vassago/death		dsvasdth
+monsters/vassago/active		dsvasact
+monsters/vassago/attack		dsvasatk
+monsters/vassago/burn		dsincbrn
+monsters/vassago/shotx		dsflame
+monsters/vassago/hot1		dsincht1
+monsters/vassago/hot2		dsincht2
+monsters/vassago/hot3		dsincht3
 
-monsters/tyrant/sight = DSTYRSIT
-monsters/tyrant/pain = DSTYRPAI
-monsters/tyrant/death = DSTYRDTH
-monsters/tyrant/active = DSTYRACT
-monsters/tyrant/walk = DSTYRWLK
+monsters/tyrant/sight		dstyrsit
+monsters/tyrant/pain		dstyrpai
+monsters/tyrant/death		dstyrdth
+monsters/tyrant/active		dstyract
+monsters/tyrant/walk		dstyrwlk
 
-weapons/incinerator/fire1 DSINCFI1
-weapons/incinerator/fire2 DSINCFI2
-weapons/incinerator/burn DSINCBRN
-weapons/incinerator/hot1 DSINCHT1
-weapons/incinerator/hot2 DSINCHT2
-weapons/incinerator/hot3 DSINCHT3
+weapons/incinerator/fire1	dsincfi1
+weapons/incinerator/fire2	dsincfi2
+weapons/incinerator/burn	dsincbrn
+weapons/incinerator/hot1	dsincht1
+weapons/incinerator/hot2	dsincht2
+weapons/incinerator/hot3	dsincht3
 
-weapons/calamityblade/charge DSHETCHG
-weapons/calamityblade/shoot DSHETSHT
-weapons/calamityblade/explode DSHETXPL
+weapons/calamityblade/charge	dshetchg
+weapons/calamityblade/shoot	dshetsht
+weapons/calamityblade/explode	dshetxpl


### PR DESCRIPTION
I made the mistake of mixing the two different syntax in my last PR. Here's a fix.