### PR TITLE
Added 32-bit CRC to packets

### DIFF
--- a/src/common/engine/i_net.h
+++ b/src/common/engine/i_net.h
@@ -8,7 +8,6 @@ inline constexpr size_t MAXPLAYERS = 64u;
 
 enum ENetConstants
 {
-	DEFAULT_GAME_ID = 0x12345678,
 	BACKUPTICS = 35 * 5,	// Remember up to 5 seconds of data.
 	MAXTICDUP = 3,
 	MAXSENDTICS = 35 * 1,	// Only send up to 1 second of data at a time.
@@ -67,7 +66,7 @@ extern size_t NetBufferLength;
 extern uint8_t TicDup;
 extern int RemoteClient;
 extern int MaxClients;
-extern uint32_t GameID;
+extern uint64_t GameID;
 
 bool I_InitNetwork();
 void I_ClearClient(size_t client);

--- a/src/common/engine/i_net.h
+++ b/src/common/engine/i_net.h
@@ -66,12 +66,12 @@ extern size_t NetBufferLength;
 extern uint8_t TicDup;
 extern int RemoteClient;
 extern int MaxClients;
-extern uint64_t GameID;
 
 bool I_InitNetwork();
 void I_ClearClient(size_t client);
 void I_NetCmd(ENetCommand cmd);
 void I_NetDone();
 void HandleIncomingConnection();
+void CloseNetwork();
 
 #endif

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -150,7 +150,6 @@ extern void M_SetDefaultMode ();
 extern void G_NewInit ();
 extern void SetupPlayerClasses ();
 void DeinitMenus();
-void CloseNetwork();
 void P_Shutdown();
 void M_SaveDefaultsFinal();
 void R_Shutdown();

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -324,6 +324,8 @@ public:
 
 void Net_ClearBuffers()
 {
+	CloseNetwork();
+
 	for (int i = 0; i < MAXPLAYERS; ++i)
 	{
 		playeringame[i] = false;
@@ -361,6 +363,7 @@ void Net_ClearBuffers()
 	gametic = ClientTic = 0;
 	SkipCommandTimer = SkipCommandAmount = CommandsAhead = 0;
 	NetEvents.ResetStream();
+	bCommandsReset = false;
 
 	LevelStartAck = 0u;
 	LevelStartDelay = LevelStartDebug = 0;

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -1695,9 +1695,6 @@ bool D_CheckNetGame()
 	if (!I_InitNetwork())
 		return false;
 
-	if (GameID != DEFAULT_GAME_ID)
-		I_FatalError("Invalid id set for network buffer");
-
 	if (Args->CheckParm("-extratic"))
 		net_extratic = true;
 


### PR DESCRIPTION
The default 16-bit CRC in the UDP packet header wasn't enough for this to work consistently. Also appends a 64-bit randomly generated number created by the host so that only clients who were given the id can correctly communicate with them (prevents random noise from getting in).