### PR TITLE
Fixed issue where seams can be seen when using animated fire textures

### DIFF
--- a/src/common/textures/firetexture.cpp
+++ b/src/common/textures/firetexture.cpp
@@ -69,9 +69,9 @@ void FireTexture::SetPalette(TArray<PalEntry>& colors)
 
 void FireTexture::Update()
 {
-	for (unsigned int y = 1; y < Height; y++)
+	for (unsigned int x = 0; x < Width; x++)
 	{
-		for (unsigned int x = 0; x < Width; x++)
+		for (unsigned int y = 1; y < Height; y++)
 		{
 			uint8_t srcPixel = Image[y * Width + x];
 


### PR DESCRIPTION
With the `firetexture` feature from `ANIMDEFS` you can currently sometimes clearly see "seams" where the texture ends:

![fire](https://github.com/user-attachments/assets/c88af301-bd06-447c-8d65-ce920fd79939)

This is due to the way the code loops over the pixels. This PR fixes the order, which also makes it in line with the [Kaiser/Sanglard code](https://fabiensanglard.net/doom_fire_psx/).

Example PK3: [animated-fire.zip](https://github.com/user-attachments/files/20139180/animated-fire.zip) (you might have to wait some time, since it's not always as obvious as in the GIF above).
