### PR TITLE
Allow canvas texture creation via ZScript (cleaned up)

### DIFF
--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -587,13 +587,14 @@ DEFINE_ACTION_FUNCTION_NATIVE(_TexMan, UseGamePalette, UseGamePalette)
 	ACTION_RETURN_INT(UseGamePalette(texid));
 }
 
-FCanvas* GetTextureCanvas(const FString& texturename);
+FCanvas* GetTextureCanvas(const FString& texturename, const ETextureType usetype = ETextureType::Wall);
 
 DEFINE_ACTION_FUNCTION(_TexMan, GetCanvas)
 {
 	PARAM_PROLOGUE;
 	PARAM_STRING(texturename);
-	ACTION_RETURN_POINTER(GetTextureCanvas(texturename));
+	PARAM_INT(usetype);
+	ACTION_RETURN_POINTER(GetTextureCanvas(texturename, static_cast<ETextureType>(usetype)));
 }
 
 //=====================================================================================

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -319,7 +319,7 @@ struct TexMan
 	native static int CheckRealHeight(TextureID tex);
 	native static bool OkForLocalization(TextureID patch, String textSubstitute);
 	native static bool UseGamePalette(TextureID tex);
-	native static Canvas GetCanvas(String texture);
+	native static Canvas GetCanvas(String texture, int usetype = Type_Any);
 }
 
 /*
@@ -518,6 +518,8 @@ class Shape2D : Object native
 
 class Canvas : Object native abstract
 {
+	native static Canvas Create(String canvasname, int width, int height, int offsetx = 0, int offsety = 0, int usetype = TexMan.Type_Wall);
+
 	native void Clear(int left, int top, int right, int bottom, Color color, int palcolor = -1);
 	native void Dim(Color col, double amount, int x, int y, int w, int h, ERenderStyle style = STYLE_Translucent);
 


### PR DESCRIPTION
- Adds 'Create' function to Canvas class in ZScript, with underlying CreateTextureCanvas function in native code.  Allows creating an empty canvas by specifying desired name, width, height, x/y offsets, and namespace.

- Updates the ZScript TexMan.GetCanvas call and associated GetTextureCanvas native code to allow specifying a namespace to search instead of only looking for walls.

This is a cleaned up version of pull request #3077.