### PR TITLE
Fixed Memory leak crash in DepleteBy() virtual relating to TakeInventory

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -932,7 +932,7 @@ class Inventory : Actor
 	//===========================================================================
 	virtual void DepleteBy(int by)
 	{
-		if (amount < 1 || by >= amount)
+		if (by < 1 || amount < 1 || by >= amount)
 		{
 			DepleteOrDestroy();
 		}


### PR DESCRIPTION
Fixed a potential loop crash caused by an undefined amount int in TakeInventory (and derivatives) now it will assume if by is less than 1 that the item is to be destroyed.