### PR TITLE
Intensity property for GLDEFS and A_AttachLights

### DIFF
--- a/src/playsim/a_dynlight.cpp
+++ b/src/playsim/a_dynlight.cpp
@@ -113,6 +113,7 @@ void AttachLight(AActor *self)
 
 	light->pSpotInnerAngle = &self->AngleVar(NAME_SpotInnerAngle);
 	light->pSpotOuterAngle = &self->AngleVar(NAME_SpotOuterAngle);
+	light->lightDefIntensity = 1.0;
 	light->pPitch = &self->Angles.Pitch;
 	light->pLightFlags = (LightFlags*)&self->IntVar(NAME_lightflags);
 	light->pArgs = self->args;
@@ -863,7 +864,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, A_AttachLightDef, AttachLightDef)
 //
 //==========================================================================
 
-int AttachLightDirect(AActor *self, int _lightid, int type, int color, int radius1, int radius2, int flags, double ofs_x, double ofs_y, double ofs_z, double param, double spoti, double spoto, double spotp)
+int AttachLightDirect(AActor *self, int _lightid, int type, int color, int radius1, int radius2, int flags, double ofs_x, double ofs_y, double ofs_z, double param, double spoti, double spoto, double spotp, double intensity)
 {
 	FName lightid = FName(ENamedName(_lightid));
 	auto userlight = self->UserLights[FindUserLight(self, lightid, true)];
@@ -879,6 +880,7 @@ int AttachLightDirect(AActor *self, int _lightid, int type, int color, int radiu
 	userlight->SetParameter(type == PulseLight? param*TICRATE : param*360.);
 	userlight->SetSpotInnerAngle(spoti);
 	userlight->SetSpotOuterAngle(spoto);
+	userlight->SetLightDefIntensity(intensity);
 	if (spotp >= -90. && spotp <= 90.)
 	{
 		userlight->SetSpotPitch(spotp);
@@ -908,7 +910,8 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, A_AttachLight, AttachLightDirect)
 	PARAM_FLOAT(spoti);
 	PARAM_FLOAT(spoto);
 	PARAM_FLOAT(spotp);
-	ACTION_RETURN_BOOL(AttachLightDirect(self, lightid.GetIndex(), type, color, radius1, radius2, flags, ofs_x, ofs_y, ofs_z, parami, spoti, spoto, spotp));
+	PARAM_FLOAT(intensity);
+	ACTION_RETURN_BOOL(AttachLightDirect(self, lightid.GetIndex(), type, color, radius1, radius2, flags, ofs_x, ofs_y, ofs_z, parami, spoti, spoto, spotp, intensity));
 }
 
 //==========================================================================

--- a/src/playsim/a_dynlight.h
+++ b/src/playsim/a_dynlight.h
@@ -77,6 +77,7 @@ public:
 	void SetDontLightOthers(bool on) { if (on) m_lightFlags |= LF_DONTLIGHTOTHERS; else m_lightFlags &= ~LF_DONTLIGHTOTHERS; }
 	void SetDontLightMap(bool on) { if (on) m_lightFlags |= LF_DONTLIGHTMAP; else m_lightFlags &= ~LF_DONTLIGHTMAP; }
 	void SetNoShadowmap(bool on) { if (on) m_lightFlags |= LF_NOSHADOWMAP; else m_lightFlags &= ~LF_NOSHADOWMAP; }
+	void SetLightDefIntensity(double i) { m_LightDefIntensity = i; }
 	void SetSpot(bool spot) { if (spot) m_lightFlags |= LF_SPOT; else m_lightFlags &= ~LF_SPOT; }
 	void SetSpotInnerAngle(double angle) { m_spotInnerAngle = DAngle::fromDeg(angle); }
 	void SetSpotOuterAngle(double angle) { m_spotOuterAngle = DAngle::fromDeg(angle); }
@@ -128,6 +129,7 @@ protected:
 	DAngle m_spotInnerAngle = DAngle::fromDeg(10.0);
 	DAngle m_spotOuterAngle = DAngle::fromDeg(25.0);
 	DAngle m_pitch = nullAngle;
+	double m_LightDefIntensity = 1.0; // Light over/underbright multiplication for GLDEFS-defined lights
 	
 	friend FSerializer &Serialize(FSerializer &arc, const char *key, FLightDefaults &value, FLightDefaults *def);
 };
@@ -231,6 +233,7 @@ struct FDynamicLight
 	int GetBlue() const { return pArgs[LIGHT_BLUE]; }
 	int GetIntensity() const { return pArgs[LIGHT_INTENSITY]; }
 	int GetSecondaryIntensity() const { return pArgs[LIGHT_SECONDARY_INTENSITY]; }
+	double GetLightDefIntensity() const { return lightDefIntensity; }
 
 	bool IsSubtractive() const { return !!((*pLightFlags) & LF_SUBTRACTIVE); }
 	bool IsAdditive() const { return !!((*pLightFlags) & LF_ADDITIVE); }
@@ -292,6 +295,8 @@ public:
 	bool owned;
 	bool swapped;
 	bool explicitpitch;
+
+	double lightDefIntensity;
 
 	FDynamicLightTouchLists touchlists;
 };

--- a/src/r_data/a_dynlightdata.cpp
+++ b/src/r_data/a_dynlightdata.cpp
@@ -81,6 +81,7 @@ FSerializer &Serialize(FSerializer &arc, const char *key, FLightDefaults &value,
 			("spotinner", value.m_spotInnerAngle)
 			("spotouter", value.m_spotOuterAngle)
 			("pitch", value.m_pitch)
+			("lightdefintensity", value.m_LightDefIntensity)
 		.EndObject();
 	}
 	return arc;
@@ -125,6 +126,7 @@ void FLightDefaults::ApplyProperties(FDynamicLight * light) const
 	light->m_active = true;
 	light->lighttype = m_type;
 	light->specialf1 = m_Param;
+	light->lightDefIntensity = m_LightDefIntensity;
 	light->pArgs = m_Args;
 	light->pLightFlags = &m_lightFlags;
 	if (m_lightFlags & LF_SPOT)

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -200,6 +200,7 @@ static const char *LightTags[]=
    "noshadowmap",
    "dontlightothers",
    "dontlightmap",
+   "intensity",
    nullptr
 };
 
@@ -226,6 +227,7 @@ enum {
    LIGHTTAG_NOSHADOWMAP,
    LIGHTTAG_DONTLIGHTOTHERS,
    LIGHTTAG_DONTLIGHTMAP,
+   LIGHTTAG_INTENSITY,
 };
 
 //==========================================================================
@@ -541,6 +543,9 @@ class GLDefsParser
 						defaults->SetSpotOuterAngle(outerAngle);
 					}
 					break;
+				case LIGHTTAG_INTENSITY:
+					defaults->SetLightDefIntensity(ParseFloat(sc));
+					break;
 				default:
 					sc.ScriptError("Unknown tag: %s\n", sc.String);
 				}
@@ -642,6 +647,9 @@ class GLDefsParser
 						defaults->SetSpotInnerAngle(innerAngle);
 						defaults->SetSpotOuterAngle(outerAngle);
 					}
+					break;
+				case LIGHTTAG_INTENSITY:
+					defaults->SetLightDefIntensity(ParseFloat(sc));
 					break;
 				default:
 					sc.ScriptError("Unknown tag: %s\n", sc.String);
@@ -748,6 +756,9 @@ class GLDefsParser
 						defaults->SetSpotOuterAngle(outerAngle);
 					}
 					break;
+				case LIGHTTAG_INTENSITY:
+					defaults->SetLightDefIntensity(ParseFloat(sc));
+					break;
 				default:
 					sc.ScriptError("Unknown tag: %s\n", sc.String);
 				}
@@ -852,6 +863,9 @@ class GLDefsParser
 						defaults->SetSpotOuterAngle(outerAngle);
 					}
 					break;
+				case LIGHTTAG_INTENSITY:
+					defaults->SetLightDefIntensity(ParseFloat(sc));
+					break;
 				default:
 					sc.ScriptError("Unknown tag: %s\n", sc.String);
 				}
@@ -952,6 +966,9 @@ class GLDefsParser
 						defaults->SetSpotInnerAngle(innerAngle);
 						defaults->SetSpotOuterAngle(outerAngle);
 					}
+					break;
+				case LIGHTTAG_INTENSITY:
+					defaults->SetLightDefIntensity(ParseFloat(sc));
 					break;
 				default:
 					sc.ScriptError("Unknown tag: %s\n", sc.String);

--- a/src/rendering/hwrenderer/hw_dynlightdata.cpp
+++ b/src/rendering/hwrenderer/hw_dynlightdata.cpp
@@ -95,6 +95,9 @@ void AddLightToList(FDynLightData &dld, int group, FDynamicLight * light, bool f
 	if (light->target && (light->target->renderflags2 & RF2_LIGHTMULTALPHA))
 		cs *= (float)light->target->Alpha;
 
+	// Multiply intensity from GLDEFS
+	cs *= (float)light->GetLightDefIntensity();
+
 	float r = light->GetRed() / 255.0f * cs;
 	float g = light->GetGreen() / 255.0f * cs;
 	float b = light->GetBlue() / 255.0f * cs;

--- a/src/rendering/hwrenderer/scene/hw_spritelight.cpp
+++ b/src/rendering/hwrenderer/scene/hw_spritelight.cpp
@@ -194,6 +194,11 @@ void HWDrawInfo::GetDynSpriteLight(AActor *self, float x, float y, float z, FSec
 							lb *= alpha;
 						}
 
+						// Get GLDEFS intensity
+						lr *= light->GetLightDefIntensity();
+						lg *= light->GetLightDefIntensity();
+						lb *= light->GetLightDefIntensity();
+
 						if (light->IsSubtractive())
 						{
 							float bright = (float)FVector3(lr, lg, lb).Length();

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1356,7 +1356,7 @@ class Actor : Thinker native
 	action native void A_OverlayTranslation(int layer, name trname);
 	
 	native bool A_AttachLightDef(Name lightid, Name lightdef);
-	native bool A_AttachLight(Name lightid, int type, Color lightcolor, int radius1, int radius2, int flags = 0, Vector3 ofs = (0,0,0), double param = 0, double spoti = 10, double spoto = 25, double spotp = 0);
+	native bool A_AttachLight(Name lightid, int type, Color lightcolor, int radius1, int radius2, int flags = 0, Vector3 ofs = (0,0,0), double param = 0, double spoti = 10, double spoto = 25, double spotp = 0, double intensity = 1.0);
 	native bool A_RemoveLight(Name lightid);
 
 	//================================================


### PR DESCRIPTION
- Add "Intensity" property for dynamic lights in GLDEFS that will multiply the brightness of the light, useful for overbrightening/underbrightening a light.

- Also add an "intensity" parameter for A_AttachLight in ZScript.

Note that for any kind of light overbrightening to do anything at all, one of the unclamped LightBlendModes in MAPINFO must be enabled.

Example files:

[LightDefIntensityTest.zip](https://github.com/user-attachments/files/20257566/LightDefIntensityTest.zip)
[LightDefIntensityTest_3DWeapon.zip](https://github.com/user-attachments/files/20257567/LightDefIntensityTest_3DWeapon.zip)

One of the examples uses a 3D model weapon, the other does not. This is to demonstrate the lighting working on each situation.

Also demonstrated is a modified tech torch with the intensity intentionally cranked up via GLDEFS. And another modified red torch with its intensity dialed way down, again via GLDEFS.

Various Actors are placed in the map to demonstrate the effects of the intensity property working properly as far as Actor lighting is concerned.

Lastly, there is a flashlight created using A_AttachLight with an intentionally-cranked-up intensity value, again, to demonstrate the new feature.