### PR TITLE
Exposed some skymist variables and functions to zscript

### DIFF
--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1588,7 +1588,9 @@ DEFINE_MAP_OPTION(thickfogmultiplier, false)
 {
 	parse.ParseAssign();
 	parse.sc.MustGetFloat();
-	info->thickfogmultiplier = (float)parse.sc.Float;
+	// [DVR] Negative multiplier does have a crazy saturated-white effect, like a nuke blastfront
+	// Could be useful for something some day
+	if ((float)parse.sc.Float > 0.0) info->thickfogmultiplier = (float)parse.sc.Float;
 }
 
 DEFINE_MAP_OPTION(pixelratio, false)

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -1742,8 +1742,36 @@ DEFINE_ACTION_FUNCTION_NATIVE(_Sector, SetXOffset, SetXOffset)
  {
 	 PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
 	 PARAM_INT(skymist);
+	 PARAM_BOOL(usemist);
 	 self->skymisttexture = FSetTextureID(skymist);
+	 if (usemist)
+	 {
+		 self->flags3 |= LEVEL3_SKYMIST;
+	 }
+	 else
+	 {
+		 self->flags3 &= ~LEVEL3_SKYMIST;
+	 }
 	 InitSkyMap(self);
+	 return 0;
+ }
+
+ DEFINE_ACTION_FUNCTION(FLevelLocals, SetSkyFog)
+ {
+	 PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	 PARAM_INT(fogdensity);
+	 self->skyfog = fogdensity;
+	 InitSkyMap(self);
+	 return 0;
+ }
+
+ DEFINE_ACTION_FUNCTION(FLevelLocals, SetThickFog)
+ {
+	 PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	 PARAM_FLOAT(distance);
+	 PARAM_FLOAT(multiplier);
+	 self->thickfogdistance = distance;
+	 if (multiplier > 0.0) self->thickfogmultiplier = multiplier;
 	 return 0;
  }
 

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1418,6 +1418,7 @@ enum ELevelFlags
 	LEVEL3_LIGHTCREATED			= 0x00080000,	// a light had been created in the last frame
 	LEVEL3_NOFOGOFWAR			= 0x00100000,	// disables effect of r_radarclipper CVAR on this map
 	LEVEL3_SECRET				= 0x00200000,	// level is a secret level
+	LEVEL3_SKYMIST				= 0x00400000,   // level skyfog uses the skymist texture
 };
 
 // [RH] Compatibility flags.

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -389,6 +389,7 @@ struct LevelInfo native
 	native readonly String NextSecretMap;
 	native readonly String SkyPic1;
 	native readonly String SkyPic2;
+	native readonly String SkyMistPic;
 	native readonly String F1Pic;
 	native readonly int cluster;
 	native readonly int partime;
@@ -404,6 +405,7 @@ struct LevelInfo native
 	native readonly int musicorder;
 	native readonly float skyspeed1;
 	native readonly float skyspeed2;
+	native readonly float skymistspeed;
 	native readonly int cdtrack;
 	native readonly double gravity;
 	native readonly double aircontrol;
@@ -496,8 +498,10 @@ struct LevelLocals native
 	native readonly int musicorder;
 	native readonly TextureID skytexture1;
 	native readonly TextureID skytexture2;
+	native readonly TextureID skymisttexture;
 	native float skyspeed1;
 	native float skyspeed2;
+	native float skymistspeed;
 	native int total_secrets;
 	native int found_secrets;
 	native int total_items;
@@ -590,6 +594,9 @@ struct LevelLocals native
 	native String GetChecksum() const;
 
 	native void ChangeSky(TextureID sky1, TextureID sky2 );
+	native void ChangeSkyMist(TextureID skymist, bool usemist = true);
+	native void SetSkyFog(int fogdensity);
+	native void SetThickFog(float distance, float multiplier);
 	native void ForceLightning(int mode = 0, sound tempSound = "");
 
 	native clearscope Thinker CreateClientsideThinker(class<Thinker> type, int statnum = Thinker.STAT_DEFAULT);


### PR DESCRIPTION
 Created zscript `levellocals` functions:
- `Level.ChangeSkyMist(TextureID skymist, bool usemist = true)` 
- `Level.SetSkyFog(int density)`
- `Level.SetThickFog(float distance, float multiplier)` 

so that people aren't tied to `MAPINFO` for such things. So far, `skyfog` could only be scripted from ACS 
( `157: SetGlobalFogParameter( property, value )` ).