### PR TITLE
Move additional includes out of the FileSys namespace.

### DIFF
--- a/src/common/filesystem/source/fs_findfile.cpp
+++ b/src/common/filesystem/source/fs_findfile.cpp
@@ -48,6 +48,11 @@
 #include <fnmatch.h>
 #include <dirent.h>
 
+#else
+
+#include <windows.h>
+#include <direct.h>
+
 #endif
 
 namespace FileSys {
@@ -201,9 +206,6 @@ static size_t FS_GetFileSize(findstate_t* handle, const char* pathname)
 
 
 #else
-
-#include <windows.h>
-#include <direct.h>
 
 std::wstring toWide(const char* str)
 {


### PR DESCRIPTION
Moves a couple of Windows specific includes out of the FileSys namespace.

- Fixes build on ARM64 - Windows
- Doesn't break the build on X64 - Windows
- Shouldn't have any effect on other systems, but I did test the build on AMD64 - Linux and it worked

This resolves this issue: https://github.com/ZDoom/gzdoom/issues/3042