### PR TITLE
Delete Invalid Polyobjects From Level Array In PO_Init

### DIFF
--- a/src/maploader/polyobjects.cpp
+++ b/src/maploader/polyobjects.cpp
@@ -396,13 +396,19 @@ void MapLoader::PO_Init (void)
 	}
 
 	// check for a startspot without an anchor point
-	for (auto &poly : Level->Polyobjects)
+	for (int i = 0, size = Level->Polyobjects.Size(); i < size; ++i)
 	{
+		const auto& poly = Level->Polyobjects[i];
+
 		if (poly.OriginalPts.Size() == 0)
 		{
 			Printf (TEXTCOLOR_RED "PO_Init: StartSpot located without an Anchor point: %d\n", poly.tag);
+			Level->Polyobjects.Delete(i--);
+			--size;
 		}
 	}
+	Level->Polyobjects.ShrinkToFit();
+
 	InitPolyBlockMap();
 
 	// [RH] Don't need the side lists anymore


### PR DESCRIPTION
A stepping stone to make exporting of polyobjects into ZScript less messy by making sure all the polyobjects in the array are valid.

I've checked the rest of polyobjects.cpp and I'm confident this shouldn't leave dangling references to the deleted polyobjects.