### PR TITLE
Fixed MBF21_GunFlashTo

### DIFF
--- a/wadsrc/static/zscript/actors/mbf21.zs
+++ b/wadsrc/static/zscript/actors/mbf21.zs
@@ -500,7 +500,7 @@ extend class Weapon
 		if (!weapon) return;
 
 		if (!dontchangeplayer) player.mo.PlayAttacking2();
-		player.SetPsprite(PSP_FLASH, tstate);
+		player.SetPsprite(PSP_FLASH, tstate, true);
 	}
 
 	// needed to call A_SeekerMissile with proper defaults.


### PR DESCRIPTION
This needs to use the original vanilla behavior for processing PSprites since it's dehacked.