### PR TITLE
Clear next and prev list pointers on VTs when destroyed

### DIFF
--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -1023,7 +1023,7 @@ void DVisualThinker::OnDestroy()
 		_next->_prev = _prev;
 	if (Level->VisualThinkerHead == this)
 		Level->VisualThinkerHead = _next;
-
+	_next = _prev = nullptr;
 	PT.alpha = 0.0; // stops all rendering.
 	Super::OnDestroy();
 }


### PR DESCRIPTION
Fixes #3058