### PR TITLE
Export double bindings

### DIFF
--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -1283,6 +1283,7 @@ DEFINE_GLOBAL_NAMED(PClass::AllClasses, AllClasses)
 DEFINE_GLOBAL(AllServices)
 
 DEFINE_GLOBAL(Bindings)
+DEFINE_GLOBAL(DoubleBindings)
 DEFINE_GLOBAL(AutomapBindings)
 DEFINE_GLOBAL(generic_ui)
 

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -195,6 +195,7 @@ struct _ native unsafe(internal)	// These are the global variables, the struct i
     native internal readonly Map<Name , Service> AllServices;
 	native readonly bool multiplayer;
 	native @KeyBindings Bindings;
+	native @KeyBindings DoubleBindings;
 	native @KeyBindings AutomapBindings;
 	native readonly @GameInfoStruct gameinfo;
 	native readonly ui bool netgame;

--- a/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
@@ -569,6 +569,52 @@ class OptionMenuItemControl : OptionMenuItemControlBase
 	}
 }
 
+class OptionMenuItemDoubleTapControl : OptionMenuItemControlBase
+{
+	OptionMenuItemDoubleTapControl Init(String label, Name command)
+	{
+		Super.Init(label, command, DoubleBindings);
+		return self;
+	}
+}
+
+class OptionMenuItemDoubleControl : OptionMenuItemControlBase
+{
+	string mDoubleAction;
+	KeyBindings mDoubleBindings;
+
+	OptionMenuItemDoubleControl Init(String label, Name command, Name doublecommand)
+	{
+		Super.Init(label, command, Bindings);
+		mDoubleAction = doublecommand;
+		mDoubleBindings = DoubleBindings;
+		return self;
+	}
+
+	override bool MenuEvent(int mkey, bool fromcontroller)
+	{
+		if (mkey == Menu.MKEY_Input)
+		{
+			mWaiting = false;
+			mBindings.SetBind(mInput, mAction);
+			mDoubleBindings.SetBind(mInput, mDoubleAction);
+			return true;
+		}
+		else if (mkey == Menu.MKEY_Clear)
+		{
+			mBindings.UnbindACommand(mAction);
+			mDoubleBindings.UnbindACommand(mDoubleAction);
+			return true;
+		}
+		else if (mkey == Menu.MKEY_Abort)
+		{
+			mWaiting = false;
+			return true;
+		}
+		return false;
+	}
+}
+
 class OptionMenuItemMapControl : OptionMenuItemControlBase
 {
 	OptionMenuItemMapControl Init(String label, Name command)


### PR DESCRIPTION
This PR exports the `DoubleBindings` struct to ZScript and adds two new types of option controls:
1. **DoubleTapControl**: Simply assigns a double-tap key to a command.
2. **DoubleControl**: Assigns a standard key press to a command and uses the same key to make a double-tap bind to the second specified command.

For example, `DoubleControl "Homing Missiles" "Acquire" "Fire"` would allow you to say, bind the key `F` to a command called "Acquire" to select targets under your crosshair and then double tapping `F` would execute the second command called "Fire" to fire homing missiles toward selected targets.