### PR TITLE
- implement limits for state loops to prevent infinite state freezes

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -874,9 +874,17 @@ bool AActor::SetState (FState *newstate, bool nofunction)
 	if (debugfile && player && (player->cheats & CF_PREDICTING))
 		fprintf (debugfile, "for pl %d: SetState while predicting!\n", Level->PlayerNum(player));
 	
+	int statelooplimit = 300000;
 	auto oldstate = state;
 	do
 	{
+		if (!(--statelooplimit))
+		{
+			Printf(TEXTCOLOR_RED "Infinite state loop in Actor '%s' state '%s'\n", GetClass()->TypeName.GetChars(), FState::StaticGetStateName(state).GetChars());
+			state = nullptr;
+			Destroy();
+			return false;
+		}
 		if (newstate == NULL)
 		{
 			state = NULL;

--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -488,10 +488,20 @@ void DPSprite::SetState(FState *newstate, bool pending)
 								WF_USER1OK | WF_USER2OK | WF_USER3OK | WF_USER4OK);
 	}
 
+	int statelooplimit = 300000;
+
 	processPending = pending;
 
 	do
 	{
+		if (!(--statelooplimit))
+		{
+			Printf(TEXTCOLOR_RED "Infinite state loop in weapon state '%s'\n", FState::StaticGetStateName(State).GetChars());
+			State = nullptr;
+			Destroy();
+			return;
+		}
+
 		if (newstate == nullptr)
 		{ // Object removed itself.
 			Destroy();


### PR DESCRIPTION
This doesn't seem to impact performance. But, performance regression testing should be done on this anyway.