### PR TITLE
Added ViewModelFOV field for models

### DIFF
--- a/src/common/models/model.h
+++ b/src/common/models/model.h
@@ -47,6 +47,7 @@ struct FSpriteModelFrame
 	float xrotate, yrotate, zrotate;
 	float rotationCenterX, rotationCenterY, rotationCenterZ;
 	float rotationSpeed;
+	float viewModelFOV;
 private:
 	unsigned int flags;
 public:


### PR DESCRIPTION
Allows manually setting FOV for models instead of scaling from 90 degrees. Positive values are exact FOVs while negative FOVs are scalars from 90. SCALEWEAPONFOV does not work with exact values since it automatically scales based on FOV.