### PR TITLE
Fix controller reconnect under Linux

### DIFF
--- a/src/common/platform/posix/sdl/i_input.cpp
+++ b/src/common/platform/posix/sdl/i_input.cpp
@@ -32,6 +32,7 @@
 */
 #include <SDL.h>
 #include "m_argv.h"
+#include "m_joy.h"
 #include "v_video.h"
 
 #include "d_eventbase.h"
@@ -466,6 +467,13 @@ void MessagePump (const SDL_Event &sev)
 		event.data1 = KEY_FIRSTJOYBUTTON + sev.jbutton.button;
 		if(event.data1 != 0)
 			D_PostEvent(&event);
+		break;
+
+	case SDL_JOYDEVICEADDED:
+	case SDL_JOYDEVICEREMOVED:
+		I_UpdateDeviceList();
+		event.type = EV_DeviceChange;
+		D_PostEvent (&event);
 		break;
 	}
 }

--- a/src/common/platform/posix/sdl/i_joystick.cpp
+++ b/src/common/platform/posix/sdl/i_joystick.cpp
@@ -281,7 +281,22 @@ class SDLInputJoystickManager
 public:
 	SDLInputJoystickManager()
 	{
-		for(int i = 0;i < SDL_NumJoysticks();i++)
+		this->UpdateDeviceList();
+	}
+	~SDLInputJoystickManager()
+	{
+		for(unsigned int i = 0;i < Joysticks.Size();i++)
+			delete Joysticks[i];
+	}
+
+	void UpdateDeviceList()
+	{
+		for (int i = 0; i < Joysticks.SSize(); i++)
+		{
+			delete Joysticks[i];
+		}
+		Joysticks.clear();
+		for(int i = 0; i < SDL_NumJoysticks(); i++)
 		{
 			SDLInputJoystick *device = new SDLInputJoystick(i);
 			if(device->IsValid())
@@ -289,11 +304,6 @@ public:
 			else
 				delete device;
 		}
-	}
-	~SDLInputJoystickManager()
-	{
-		for(unsigned int i = 0;i < Joysticks.Size();i++)
-			delete Joysticks[i];
 	}
 
 	void AddAxes(float axes[NUM_JOYAXIS])
@@ -364,5 +374,6 @@ void I_ProcessJoysticks()
 
 IJoystickConfig *I_UpdateDeviceList()
 {
+	JoystickManager->UpdateDeviceList();
 	return NULL;
 }

--- a/src/common/platform/posix/sdl/i_joystick.cpp
+++ b/src/common/platform/posix/sdl/i_joystick.cpp
@@ -283,19 +283,10 @@ public:
 	{
 		this->UpdateDeviceList();
 	}
-	~SDLInputJoystickManager()
-	{
-		for(unsigned int i = 0;i < Joysticks.Size();i++)
-			delete Joysticks[i];
-	}
 
 	void UpdateDeviceList()
 	{
-		for (int i = 0; i < Joysticks.SSize(); i++)
-		{
-			delete Joysticks[i];
-		}
-		Joysticks.clear();
+		Joysticks.DeleteAndClear();
 		for(int i = 0; i < SDL_NumJoysticks(); i++)
 		{
 			SDLInputJoystick *device = new SDLInputJoystick(i);
@@ -311,6 +302,7 @@ public:
 		for(unsigned int i = 0;i < Joysticks.Size();i++)
 			Joysticks[i]->AddAxes(axes);
 	}
+
 	void GetDevices(TArray<IJoystickConfig *> &sticks)
 	{
 		for(unsigned int i = 0;i < Joysticks.Size();i++)
@@ -325,8 +317,9 @@ public:
 		for(unsigned int i = 0;i < Joysticks.Size();++i)
 			if(Joysticks[i]->Enabled) Joysticks[i]->ProcessInput();
 	}
+
 protected:
-	TArray<SDLInputJoystick *> Joysticks;
+	TDeletingArray<SDLInputJoystick *> Joysticks;
 };
 static SDLInputJoystickManager *JoystickManager;
 


### PR DESCRIPTION
Fixes #1533

Event loop now responds to SDL_JOYDEVICEADDED and SDL_JOYDEVICEREMOVED. This allows for controller hot-swapping.