### PR TITLE
Add StaticMapModel class to doombase.zs

### DIFF
--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -1025,3 +1025,5 @@ struct FRailParams
 	native int SpiralOffset;
 	native int limit;
 };	// [RH] Shoot a railgun
+
+class StaticMapModel : Actor {}  // For compatibility with VkDoom


### PR DESCRIPTION
In case any modders want to take advantage of this new VkDoom feature, this will allow those mods to work in GZDoom.

See https://github.com/dpjudas/VkDoom/commit/d42ebe9760cd79893c0e1fc873281f51d227a79a#diff-4576d039733ec8cddfa9a1a659321c14ab81c501e6f52496f859c310774071d1R988 for more info