### PR TITLE
Fixed BT_RUN getting toggled off on command clear

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -407,7 +407,9 @@ void Net_ResetCommands(bool midTic)
 		
 		// Make sure not to run its current command either.
 		auto& curTic = state.Tics[tic % BACKUPTICS];
+		const int running = (curTic.Command.buttons & BT_RUN); // This isn't delta'd so needs to be kept.
 		memset(&curTic.Command, 0, sizeof(curTic.Command));
+		curTic.Command.buttons |= running;
 	}
 
 	NetEvents.ResetStream();


### PR DESCRIPTION
This doesn't get delta'd when networking so its state has to be kept between wipes since it's built entirely from client data.