### PR TITLE
Added OnRevive virtual

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -8485,6 +8485,10 @@ void AActor::Revive()
 		Level->total_monsters++;
 	}
 
+	IFOVERRIDENVIRTUALPTRNAME(this, NAME_Actor, OnRevive)
+	{
+		VMCallVoid<AActor*>(func, this);
+	}
 	// [ZZ] resurrect hook
 	Level->localEventManager->WorldThingRevived(this);
 }

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -595,6 +595,9 @@ class Actor : Thinker native
 		return true;
 	}
 
+	// Called after an Actor has been resurrected.
+	virtual void OnRevive() {}
+
 	// Called when an actor is to be reflected by a disc of repulsion.
 	// Returns true to continue normal blast processing.
 	virtual bool SpecialBlastHandling (Actor source, double strength)


### PR DESCRIPTION
Called when a monster (or player via `resurrect`) is resurrected (allows resetting properties without needing an event handler).