### PR TITLE
Set correct git tag in Github Actions builds

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -73,7 +73,11 @@ jobs:
           wget -q "https://github.com/coelckers/gzdoom/releases/download/ci_deps/${ZMUSIC_PACKAGE}"
           tar -xf "${ZMUSIC_PACKAGE}"
         fi
-    
+
+    - name: Git describe
+      id: ghd
+      uses: proudust/gh-describe@v2
+
     - name: Configure
       shell: bash
       run: |
@@ -82,6 +86,7 @@ jobs:
     - name: Build
       shell: bash
       run: |
+        export GIT_DESCRIBE="${{ steps.ghd.outputs.describe }}"
         export MAKEFLAGS=--keep-going
         cmake --build build --config ${{ matrix.config.build_type }} --parallel 3
 

--- a/tools/updaterevision/UpdateRevision.cmake
+++ b/tools/updaterevision/UpdateRevision.cmake
@@ -15,16 +15,20 @@ endmacro()
 # Populate variables "Hash", "Tag", and "Timestamp" with relevant information
 # from source repository.  If anything goes wrong return something in "Error."
 function(query_repo_info)
-	execute_process(
-		COMMAND git describe --tags --dirty=-m
-		RESULT_VARIABLE Error
-		OUTPUT_VARIABLE Tag
-		ERROR_QUIET
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-	)
-	if(NOT "${Error}" STREQUAL "0")
-		ret_var(Error)
-		return()
+	if(DEFINED ENV{GIT_DESCRIBE})
+		set(Tag "$ENV{GIT_DESCRIBE}")
+	else()
+		execute_process(
+			COMMAND git describe --tags --dirty=-m
+			RESULT_VARIABLE Error
+			OUTPUT_VARIABLE Tag
+			ERROR_QUIET
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
+		if(NOT "${Error}" STREQUAL "0")
+			ret_var(Error)
+			return()
+		endif()
 	endif()
 
 	execute_process(


### PR DESCRIPTION
I noticed that the Gzdoom builds produced by Github Actions have their version set to `<unknown version>`, visible in the console and logs. This PR fixes that.

The issue is because the `git describe --tags` command, used by UpdateRevision.cmake, can't be used on shallow checkouts of the git repository as Github Actions does for efficiency. This could be fixed by forcing a full git checkout, but that would make the workflow take longer to run, so instead I use the [gh-describe](https://github.com/marketplace/actions/gh-describe) action which was built for handling this case and gives the same output as the git command.

(This might seem like an unnecessary fix if the Github Actions here happen to be intended just to test that the build works, but in my own toy fork of Gzdoom, I'm interested in getting Github Actions to produce the release builds for users for all systems.)