### PR TITLE
Added ready system to screen jobs for multiplayer

### DIFF
--- a/src/common/cutscenes/screenjob.cpp
+++ b/src/common/cutscenes/screenjob.cpp
@@ -123,12 +123,12 @@ void CallCreateFunction(const char* qname, DObject* runner)
 //
 //=============================================================================
 
-DObject* CreateRunner(bool clearbefore)
+DObject* CreateRunner(bool clearbefore, int skipType)
 {
 	auto obj = cutscene.runnerclass->CreateNew();
 	auto func = LookupFunction("ScreenJobRunner.Init", false);
-	VMValue val[3] = { obj, clearbefore, false };
-	VMCall(func, val, 3, nullptr, 0);
+	VMValue val[4] = { obj, clearbefore, false, skipType };
+	VMCall(func, val, 4, nullptr, 0);
 	return obj;
 }
 

--- a/src/common/cutscenes/screenjob.h
+++ b/src/common/cutscenes/screenjob.h
@@ -19,6 +19,13 @@ enum
 	SJ_BLOCKUI = 1,
 };
 
+enum
+{
+	ST_VOTE,
+	ST_MUST_BE_SKIPPABLE,
+	ST_UNSKIPPABLE,
+};
+
 struct CutsceneDef
 {
 	FString video;
@@ -47,7 +54,7 @@ bool CanWipe();
 
 VMFunction* LookupFunction(const char* qname, bool validate = true);
 void CallCreateFunction(const char* qname, DObject* runner);
-DObject* CreateRunner(bool clearbefore = true);
+DObject* CreateRunner(bool clearbefore = true, int skipType = ST_VOTE);
 void AddGenericVideo(DObject* runner, const FString& fn, int soundid, int fps);
 
 struct CutsceneState

--- a/src/d_net.h
+++ b/src/d_net.h
@@ -151,6 +151,8 @@ void Net_WriteBytes(const uint8_t *, int len);
 void Net_DoCommand(int cmd, uint8_t **stream, int player);
 void Net_SkipCommand(int cmd, uint8_t **stream);
 
+bool Net_CheckCutsceneReady();
+void Net_AdvanceCutscene();
 void Net_ResetCommands(bool midTic);
 void Net_SetWaiting();
 void Net_ClearBuffers();

--- a/src/d_protocol.h
+++ b/src/d_protocol.h
@@ -163,10 +163,11 @@ enum EDemoCommand
 	DEM_NETEVENT,		// 70 String: Event name, Byte: Arg count; each arg is a 4-byte int
 	DEM_MDK,			// 71 String: Damage type
 	DEM_SETINV,			// 72 SetInventory
-	DEM_ENDSCREENJOB,
+	DEM_ENDSCREENJOB,	// 73
 	DEM_ZSC_CMD,		// 74 String: Command, Word: Byte size of command
 	DEM_CHANGESKILL,	// 75 Int: Skill
 	DEM_KICK,			// 76 Byte: Player number
+	DEM_READIED,		// 77 
 };
 
 // The following are implemented by cht_DoCheat in m_cheat.cpp

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -116,7 +116,7 @@ FBaseCVar* G_GetUserCVar(int playernum, const char* cvarname);
 
 class DIntermissionController;
 struct level_info_t;
-void RunIntermission(level_info_t* oldlevel, level_info_t* newlevel, DIntermissionController* intermissionScreen, DObject* statusScreen, std::function<void(bool)> completionf);
+void RunIntermission(level_info_t* oldlevel, level_info_t* newlevel, DIntermissionController* intermissionScreen, DObject* statusScreen, bool ending, std::function<void(bool)> completionf);
 
 extern const AActor *SendItemUse, *SendItemDrop;
 extern int SendItemDropAmount;

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1048,9 +1048,10 @@ DIntermissionController* FLevelLocals::CreateIntermission()
 //
 //=============================================================================
 
-void RunIntermission(level_info_t* fromMap, level_info_t* toMap, DIntermissionController* intermissionScreen, DObject* statusScreen, std::function<void(bool)> completionf)
+void RunIntermission(level_info_t* fromMap, level_info_t* toMap, DIntermissionController* intermissionScreen, DObject* statusScreen, bool ending, std::function<void(bool)> completionf)
 {
-	cutscene.runner = CreateRunner(false);
+	// Make sure the finale can't be skipped, otherwise the intermission always needs to be skippable.
+	cutscene.runner = CreateRunner(false, ending ? ST_UNSKIPPABLE : ST_MUST_BE_SKIPPABLE);
 	GC::WriteBarrier(cutscene.runner);
 	cutscene.completion = std::move(completionf);
 	
@@ -1139,7 +1140,7 @@ void G_DoCompleted (void)
 	bool endgame = strncmp(nextlevel.GetChars(), "enDSeQ", 6) == 0;
 	intermissionScreen = primaryLevel->CreateIntermission();
 	auto nextinfo = !playinter || endgame? nullptr : FindLevelInfo(nextlevel.GetChars(), false);
-	RunIntermission(primaryLevel->info, nextinfo, intermissionScreen, statusScreen, [=](bool)
+	RunIntermission(primaryLevel->info, nextinfo, intermissionScreen, statusScreen, endgame, [=](bool)
 	{
 		if (!endgame) primaryLevel->WorldDone();
 		else D_StartTitle();

--- a/src/intermission/intermission_parse.cpp
+++ b/src/intermission/intermission_parse.cpp
@@ -991,6 +991,6 @@ CCMD(testfinale)
 	}
 
 	auto controller = F_StartFinale(gameinfo.finaleMusic.GetChars(), gameinfo.finaleOrder, -1, 0, gameinfo.FinaleFlat.GetChars(), text, false, false, true, true);
-	RunIntermission(nullptr, nullptr, controller, nullptr, [=](bool) { gameaction = ga_nothing; });
+	RunIntermission(nullptr, nullptr, controller, nullptr, false, [=](bool) { gameaction = ga_nothing; });
 
 }

--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -46,6 +46,7 @@ extern uint8_t globalfreeze, globalchangefreeze;
 
 void C_Ticker();
 void M_Ticker();
+void D_RunCutscene();
 
 //==========================================================================
 //
@@ -91,6 +92,10 @@ void P_RunClientsideLogic()
 		// TODO: Should this be called on all maps...?
 		if (gamestate == GS_LEVEL)
 			primaryLevel->automap->Ticker();
+	}
+	else if (gamestate == GS_CUTSCENE || gamestate == GS_INTRO)
+	{
+		D_RunCutscene();
 	}
 
 	// [MK] Additional ticker for UI events right after all others

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2441,8 +2441,18 @@ OptionMenu NetworkOptions protected
 	StaticText "$NETMNU_HOSTOPTIONS", 1
 	Option "$NETMNU_EXTRATICS",				"net_extratic", "OnOff"
 	Option "$NETMNU_DISABLEPAUSE",			"net_disablepause", "OnOff"
+	Option "$NETMNU_READYTYPE",				"net_cutscenereadytype", "ReadyTypes"
+	Slider "$NETMNU_READYPERCENT",			"net_cutscenereadypercent", "0", "1", "0.05", 2
+	NumberField "$NETMNU_READYCOUNTDOWN",	"net_cutscenecountdown", 0, 300, 5
 	NumberField "$NETMNU_CHATSLOMO",		"net_chatslowmode", 0, 300, 5
 
+}
+
+OptionValue "ReadyTypes"
+{
+	0, "$OPTVAL_VOTE"
+	1, "$OPTVAL_ANYONE"
+	2, "$OPTVAL_HOSTONLY"
 }
 
 OptionValue "ChatTypes"

--- a/wadsrc/static/zscript/ui/intermission.zs
+++ b/wadsrc/static/zscript/ui/intermission.zs
@@ -1,4 +1,86 @@
 
+extend class ScreenJobRunner
+{
+	protected native static void ReadyPlayer();
+	protected native static void ResetReadyTimer();
+
+	native static int GetReadyTimer();
+	native static bool IsPlayerReady(int pNum);
+
+	bool ConsumedInput(InputEvent evt)
+	{
+		if (netgame && evt.type == InputEvent.Type_KeyDown
+			&& (evt.KeyScan == InputEvent.Key_Space || evt.KeyScan == InputEvent.Key_Mouse1
+				|| evt.KeyScan == InputEvent.Key_Pad_A || evt.KeyScan == InputEvent.Key_Joy1))
+		{
+			ReadyPlayer();
+			return true;
+		}
+
+		return false;
+	}
+
+	void DrawReadiedPlayers(double smoothratio)
+	{
+		if (!netgame || GetSkipType() == ST_UNSKIPPABLE)
+			return;
+		
+		if (net_cutscenereadytype == 0)
+		{
+			int totalClients, readyClients;
+			for (int i; i < MAXPLAYERS; ++i)
+			{
+				if (!playerInGame[i] || players[i].Bot)
+					continue;
+
+				++totalClients;
+				readyClients += IsPlayerReady(i);
+			}
+
+			if (totalClients > 1)
+			{
+				TextureID readyico = TexMan.CheckForTexture("READYICO", TexMan.Type_MiscPatch);
+				Vector2 readysize = TexMan.GetScaledSize(readyico);
+				
+				if (IsPlayerReady(consoleplayer))
+					Screen.DrawTexture(readyico, true, 0, 0, DTA_CleanNoMove, true, DTA_TopLeft, true);
+
+				Screen.DrawText(ConFont, Font.CR_UNTRANSLATED, (int(readysize.X) + 4) * CleanXFac, CleanYFac, String.Format("%d/%d", readyClients, totalClients), DTA_CleanNoMove, true);
+				int startTimer = GetReadyTimer();
+				if (startTimer > 0)
+				{
+					int col = Font.CR_UNTRANSLATED;
+					if (startTimer <= GameTicRate * 5)
+						col = Font.CR_RED;
+
+					Screen.DrawText(ConFont, col, 0, int(readysize.Y) * CleanYFac + CleanYFac, SystemTime.Format("%M:%S", int(ceil(double(startTimer) / GameTicRate))), DTA_CleanNoMove, true);
+				}
+			}
+		}
+
+		if (net_cutscenereadytype != 2 || consoleplayer == Net_Arbitrator)
+		{
+			string contType;
+			switch (GetLastInputType())
+			{
+				case INP_KEYBOARD_MOUSE:
+					contType = "$NET_CONTINUE_MKB";
+					break;
+				case INP_CONTROLLER:
+					contType = "$NET_CONTINUE_CONTROLLER";
+					break;
+				case INP_JOYSTICK:
+					contType = "$NET_CONTINUE_JOYSTICK";
+					break;
+			}
+
+			string contTxt = StringTable.Localize(contType);
+			int xOfs = (Screen.GetWidth() - ConFont.StringWidth(contTxt) * CleanXFac) / 2;
+			int yOfs = Screen.GetHeight() - ConFont.GetHeight() * CleanYFac - CleanYFac;
+			Screen.DrawText(ConFont, Font.CR_GREEN, xOfs, yOfs, contTxt, DTA_CleanNoMove, true);
+		}
+	}
+}
 
 class IntermissionController native ui
 {

--- a/wadsrc/static/zscript/ui/statscreen/statscreen.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen.zs
@@ -80,7 +80,7 @@ class StatusScreen : ScreenJob abstract version("2.5")
 
 	InterBackground bg;
 	int				acceleratestage;	// used to accelerate or skip a stage
-	bool				playerready[MAXPLAYERS];
+	bool				playerready[MAXPLAYERS]; // This is no longer used since the server needs to track this
 	int				me;					// wbs.pnum
 	int				bcnt;
 	int				CurState;				// specifies current CurState


### PR DESCRIPTION
Readds the feature to allow players to ready up during stat screens and intermissions instead of autoskipping based on whoever closed it. Comes with a variety of ways to tweak this behavior such as percentage-based auto starting (with a timer), the ability to unready as needed, and who can control it. Players will still be able to skip through individual screen jobs within the runner while waiting to ready up.

I'm going to be honest and say I'm not sure what the best way to set this up was since it requires some currently GZDoom-specific info in the core ScreenJobRunner in order for this to work properly, so some stubs will be needed within ZScript. In particular, `bool ConsumedInput(InputEvent evt)`, `void DrawReadiedPlayers(double smoothratio)`, and `void ResetReadyTimer()` will need them as these are called from the core. Internally it doesn't appear ScreenJobRunner was meant to be inherited from so a deeper rewrite will be needed in order to solve these issues.