### PR TITLE
Fix missing null-terminator when writing demos

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2593,7 +2593,7 @@ void G_BeginRecording (const char *startmap)
 			WriteInt8((uint8_t)i, &demo_p);
 			auto str = D_GetUserInfoStrings(i);
 			memcpy(demo_p, str.GetChars(), str.Len() + 1);
-			demo_p += str.Len();
+			demo_p += str.Len() + 1;
 			FinishChunk(&demo_p);
 		}
 	}


### PR DESCRIPTION
When a map starts while a demo is being recorded, a player info chunk containing a string with a bunch of cvar names and values is written to the demo. The string inside this chunk is not correctly null-terminated, which will sometimes result in the last cvar being incorrectly read when played back.

Hex dump of an affected demo, with the unterminated user info string highlighted:
![Screenshot 2025-06-28 121911](https://github.com/user-attachments/assets/f96a2f38-d462-4ec7-bdd6-bbc3b00c5fd3)

Screenshot of a debugger while GZDoom is reading the demo, confirming the incorrect value is being read. Notice the bottom left where keyname="Wi_NoAutostartMap" and value="falseVARS".
![Screenshot 2025-06-28 122711](https://github.com/user-attachments/assets/7a4f3187-f58b-4bf5-b218-f471a72de398)

The issue is because the string with its null terminator is memcpy'd into the demo_p buffer, but then the demo_p pointer is only advanced for the length of the string without the null terminator, so the next write into the buffer tramples over the null terminator. Many other places in the code handle this correctly, but this case has a `+ 1` for the null terminator missing.

This PR fixes the string to be correctly written with the null terminator.

This bug admittedly isn't very consequential and doesn't currently prevent any demos from playing:
- The affected cvar appears to always be Wi_NoAutostartMap, which doesn't affect demo playback as far as I can tell. Also this cvar defaults to false and invalid values get interpreted as false.
- If the player info chunk happens to be an odd number of bytes, a null padding byte will be put after the chunk, which will be interpreted as the string's null terminator when read, allowing the correct value to be read for the last cvar.
- This bug doesn't screw up the rest of the reading of the demo because the player info chunk contains its own length in its header, and the reader moves onto the next chunk based on that length value immediately after reading the string.

I noticed this while working on a separate bugfix that touched this code. I didn't want this apparent bug to be a distraction in that PR and I felt it better to split this into its own PR.