### PR TITLE
Fix up saving in multiplayer

### DIFF
--- a/src/common/platform/posix/unix/i_specialpaths.cpp
+++ b/src/common/platform/posix/unix/i_specialpaths.cpp
@@ -42,6 +42,8 @@
 
 #include "version.h"	// for GAMENAME
 
+extern bool netgame;
+
 
 FString GetUserFile (const char *file)
 {
@@ -191,7 +193,10 @@ FString M_GetScreenshotsPath()
 
 FString M_GetSavegamesPath()
 {
-	return NicePath("$HOME/" GAME_DIR "/savegames/");
+	FString pName = "$HOME/" GAME_DIR "/savegames/";
+	if (netgame)
+		pName << "netgame/";
+	return NicePath(pName.GetChars());
 }
 
 //===========================================================================

--- a/src/common/platform/win32/i_specialpaths.cpp
+++ b/src/common/platform/win32/i_specialpaths.cpp
@@ -51,6 +51,8 @@
 
 static int isportable = -1;
 
+extern bool netgame;
+
 //===========================================================================
 //
 // IsProgramDirectoryWritable
@@ -377,6 +379,8 @@ FString M_GetSavegamesPath()
 		path = GetKnownFolder(-1, FOLDERID_SavedGames, true);
 		path << "/" GAMENAME "/";
 	}
+	if (netgame)
+		path << "NetGame/";
 	return path;
 }
 

--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -713,7 +713,7 @@ UNSAFE_CCMD(save)
 		Printf("saving to an absolute path is not allowed\n");
 		return;
 	}
-	if (fname.IndexOf("..") > 0)
+	if (fname.IndexOf("..") >= 0)
 	{
 		Printf("'..' not allowed in file names\n");
 		return;

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -128,6 +128,7 @@ CVAR (Bool, enablescriptscreenshot, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 CVAR (Bool, cl_restartondeath, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 EXTERN_CVAR (Float, con_midtime);
 EXTERN_CVAR(Int, net_disablepause)
+EXTERN_CVAR(Bool, net_limitsaves)
 
 //==========================================================================
 //
@@ -2161,6 +2162,10 @@ void G_SaveGame (const char *filename, const char *description)
     {
 		Printf ("%s\n", GStrings.GetString("TXT_SPPLAYERDEAD"));
     }
+	else if (netgame && net_limitsaves && !players[consoleplayer].settings_controller)
+	{
+		Printf("Only settings controllers can save the game\n");
+	}
 	else
 	{
 		savegamefile = filename;
@@ -2196,6 +2201,10 @@ CUSTOM_CVAR (Int, quicksaverotationcount, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 
 void G_DoAutoSave ()
 {
+	// Never autosave in netgames since you can't load this properly anyway.
+	if (netgame)
+		return;
+
 	FString description;
 	FString file;
 	// Keep up to four autosaves at a time
@@ -2231,6 +2240,10 @@ void G_DoAutoSave ()
 
 void G_DoQuickSave ()
 {
+	// Never quicksave in netgames since you can't load this properly anyway.
+	if (netgame)
+		return;
+
 	FString description;
 	FString file;
 	// Keeps a rotating set of quicksaves

--- a/src/menu/doommenu.cpp
+++ b/src/menu/doommenu.cpp
@@ -477,7 +477,7 @@ CCMD (quicksave)
 		return;
 
 	// If the quick save rotation is enabled, it handles the save slot.
-	if (quicksaverotation)
+	if (!netgame && quicksaverotation)
 	{
 		G_DoQuickSave();
 		return;


### PR DESCRIPTION
By default allow only settings controllers to save the game. Use actual file names to help prevent possible save file overriding as savexx is unreliable online. Prevent quicksave behavior from working with the rotator. Force a unique netgame subfolder for multiplayer saves to remove the ability to override singleplayer saves. Send over the host's -loadgame argument to make loading easier (will not override the guest's -loadgame in case they need a special file name).