### PR TITLE
Fixed startup music being cancelled

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3237,8 +3237,6 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 		else if (gameinfo.gametype == GAME_Strife)
 			GameStartupInfo.Type = FStartupInfo::StrifeStartup;
 	}
-
-	StartScreen = nostartscreen? nullptr : GetGameStartScreen(per_shader_progress > 0 ? max_progress * 10 / 9 : max_progress + 3);
 	
 	GameConfig->DoKeySetup(gameinfo.ConfigName.GetChars());
 
@@ -3281,7 +3279,6 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	if (!restart)
 	{
 		screen->CompileNextShader();
-		if (StartScreen != nullptr) StartScreen->Render();
 	}
 	else
 	{
@@ -3291,6 +3288,9 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 
 	// Base systems have been inited; enable cvar callbacks
 	FBaseCVar::EnableCallbacks ();
+
+	StartScreen = nostartscreen? nullptr : GetGameStartScreen(per_shader_progress > 0 ? max_progress * 10 / 9 : max_progress + 3);
+	if (StartScreen != nullptr) StartScreen->Render();
 	
 	// +compatmode cannot be used on the command line, so use this as a substitute
 	auto compatmodeval = Args->CheckValue("-compatmode");


### PR DESCRIPTION
This seems to happen from one of the music cvar callbacks wiping it, but I'm ensure of which (possibly music volume?). Move it to after cvar initializing until a proper fix can be found.