### PR TITLE
Fixed bad VisualThinker nodes getting into the render list

### DIFF
--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -995,7 +995,6 @@ void FLevelLocals::Serialize(FSerializer &arc, bool hubload)
 		("automap", automap)
 		("interpolator", interpolator)
 		("frozenstate", frozenstate)
-		("visualthinkerhead", VisualThinkerHead)
 		("actorbehaviors", ActorBehaviors);
 
 

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -1364,13 +1364,18 @@ void DVisualThinker::Serialize(FSerializer& arc)
 		("lightlevel", LightLevel)
 		("animData", PT.animData)
 		("flags", PT.flags)
-		("visualThinkerFlags", flags)
-		("next", _next)
-		("prev", _prev);
+		("visualThinkerFlags", flags);
     
     if(arc.isReading())
     {
         UpdateSector();
+		_prev = _next = nullptr;
+		if (Level->VisualThinkerHead != nullptr)
+		{
+			Level->VisualThinkerHead->_prev = this;
+			_next = Level->VisualThinkerHead;
+		}
+		Level->VisualThinkerHead = this;
     }
 }
 


### PR DESCRIPTION
Relink on loading instead of serializing since order doesn't matter here.