### PR TITLE
Disable autoloading mods when playing online

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2029,7 +2029,8 @@ static void AddAutoloadFiles(const char *autoname, std::vector<std::string>& all
 		}
 	}
 
-	if (!(gameinfo.flags & GI_SHAREWARE) && !Args->CheckParm("-noautoload") && !disableautoload)
+	// Disable autoloading in netgames as we don't want people who are hosting/joining loading up random files.
+	if (!(gameinfo.flags & GI_SHAREWARE) && !Args->CheckParm("-noautoload") && !disableautoload && !Args->CheckParm("-host") && !Args->CheckParm("-join"))
 	{
 		FString file;
 


### PR DESCRIPTION
Any mods when hosting and joining should have to be explicitly labeled, this way extra mods aren't accidentally making their way into the lists.