### PR TITLE
Support WAD loading tweaks

### DIFF
--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -58,7 +58,7 @@ EXTERN_CVAR(Bool, autoloadbrightmaps)
 EXTERN_CVAR(Bool, autoloadwidescreen)
 EXTERN_CVAR(String, language)
 
-CVAR(Int, i_loadsupportwad, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG) // 0=never, 1=singleplayer only, 2=always
+CVAR(Bool, i_loadsupportwad, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG) // Disabled in net games.
 
 bool foundprio = false; // global to prevent iwad box from appearing
 
@@ -772,6 +772,7 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, const char
 		if (autoloadlights) flags |= 2;
 		if (autoloadbrightmaps) flags |= 4;
 		if (autoloadwidescreen) flags |= 8;
+		if (i_loadsupportwad) flags |= 16;
 
 		FStartupSelectionInfo info = FStartupSelectionInfo(wads, *Args, flags);
 		if (I_PickIWad(queryiwad, info))
@@ -781,6 +782,7 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, const char
 			autoloadlights = !!(info.DefaultStartFlags & 2);
 			autoloadbrightmaps = !!(info.DefaultStartFlags & 4);
 			autoloadwidescreen = !!(info.DefaultStartFlags & 8);
+			i_loadsupportwad = !!(info.DefaultStartFlags & 16);
 		}
 		else
 		{
@@ -813,9 +815,9 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, const char
 
 	if(info.SupportWAD.IsNotEmpty())
 	{
-		bool wantsnetgame = (Args->CheckParm("-join") || Args->CheckParm("-host"));
-
-		if ((!wantsnetgame && i_loadsupportwad == 1) || (i_loadsupportwad == 2))
+		// For net games all wads must be explicitly named to make it easier for the host to know
+		// exactly what's being loaded.
+		if (i_loadsupportwad && !Args->CheckParm("-join") && !Args->CheckParm("-host"))
 		{
 			FString supportWAD = IWADPathFileSearch(info.SupportWAD);
 

--- a/src/launcher/settingspage.cpp
+++ b/src/launcher/settingspage.cpp
@@ -20,6 +20,7 @@ SettingsPage::SettingsPage(LauncherWindow* launcher, const FStartupSelectionInfo
 	LightsCheckbox = new CheckboxLabel(this);
 	BrightmapsCheckbox = new CheckboxLabel(this);
 	WidescreenCheckbox = new CheckboxLabel(this);
+	SupportWadsCheckbox = new CheckboxLabel(this);
 
 	FullscreenCheckbox->SetChecked(info.DefaultFullscreen);
 	DontAskAgainCheckbox->SetChecked(!info.DefaultQueryIWAD);
@@ -28,6 +29,7 @@ SettingsPage::SettingsPage(LauncherWindow* launcher, const FStartupSelectionInfo
 	LightsCheckbox->SetChecked(info.DefaultStartFlags & 2);
 	BrightmapsCheckbox->SetChecked(info.DefaultStartFlags & 4);
 	WidescreenCheckbox->SetChecked(info.DefaultStartFlags & 8);
+	SupportWadsCheckbox->SetChecked(info.DefaultStartFlags & 16);
 
 #ifdef RENDER_BACKENDS
 	BackendLabel = new TextLabel(this);
@@ -110,6 +112,7 @@ void SettingsPage::SetValues(FStartupSelectionInfo& info) const
 	if (LightsCheckbox->GetChecked()) flags |= 2;
 	if (BrightmapsCheckbox->GetChecked()) flags |= 4;
 	if (WidescreenCheckbox->GetChecked()) flags |= 8;
+	if (SupportWadsCheckbox->GetChecked()) flags |= 16;
 	info.DefaultStartFlags = flags;
 
 #ifdef RENDER_BACKENDS
@@ -132,6 +135,7 @@ void SettingsPage::UpdateLanguage()
 	LightsCheckbox->SetText(GStrings.GetString("PICKER_LIGHTS"));
 	BrightmapsCheckbox->SetText(GStrings.GetString("PICKER_BRIGHTMAPS"));
 	WidescreenCheckbox->SetText(GStrings.GetString("PICKER_WIDESCREEN"));
+	SupportWadsCheckbox->SetText(GStrings.GetString("PICKER_SUPPORTWADS"));
 
 #ifdef RENDER_BACKENDS
 	BackendLabel->SetText(GStrings.GetString("PICKER_PREFERBACKEND"));
@@ -172,6 +176,10 @@ void SettingsPage::OnGeometryChanged()
 	WidescreenCheckbox->SetFrameGeometry(w - panelWidth, y, panelWidth, WidescreenCheckbox->GetPreferredHeight());
 	y += DontAskAgainCheckbox->GetPreferredHeight();
 
+	SupportWadsCheckbox->SetFrameGeometry(0.0, y, 190.0, SupportWadsCheckbox->GetPreferredHeight());
+	y += SupportWadsCheckbox->GetPreferredHeight();
+	const double optionsBottom = y;
+
 #ifdef RENDER_BACKENDS
 	double x = w / 2 - panelWidth / 2;
 	y = 0;
@@ -188,6 +196,7 @@ void SettingsPage::OnGeometryChanged()
 	y += GLESCheckbox->GetPreferredHeight();
 #endif
 
+	y = max<double>(y, optionsBottom);
 	if (!hideLanguage)
 	{
 		LangLabel->SetFrameGeometry(0.0, y, w, LangLabel->GetPreferredHeight());

--- a/src/launcher/settingspage.h
+++ b/src/launcher/settingspage.h
@@ -33,6 +33,7 @@ private:
 	CheckboxLabel* LightsCheckbox = nullptr;
 	CheckboxLabel* BrightmapsCheckbox = nullptr;
 	CheckboxLabel* WidescreenCheckbox = nullptr;
+	CheckboxLabel* SupportWadsCheckbox = nullptr;
 #ifdef RENDER_BACKENDS
 	TextLabel* BackendLabel = nullptr;
 	CheckboxLabel* VulkanCheckbox = nullptr;


### PR DESCRIPTION
Disable auto loading support wads (e.g. id24) in net games (this should always be done explicitly). Add an option for it in the launcher settings.