### PR TITLE
Rendering bug in Stacked-sector portals and reflective flats fix

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -839,7 +839,7 @@ bool HWSectorStackPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 
 void HWSectorStackPortal::DrawPortalStencil(FRenderState &state, int pass)
 {
-	if (mState->vpIsAllowedOoB)
+	if (true) // mState->vpIsAllowedOoB)
 	{
 		bool isceiling = planesused & (1 << sector_t::ceiling);
 		for (unsigned i = 0; i<subsectors.Size(); i++)
@@ -920,7 +920,7 @@ bool HWPlaneMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 
 void HWPlaneMirrorPortal::DrawPortalStencil(FRenderState &state, int pass)
 {
-	if (mState->vpIsAllowedOoB)
+	if (true) // mState->vpIsAllowedOoB)
 	{
 		bool isceiling = planesused & (1 << sector_t::ceiling);
 		for (unsigned int i = 0; i < lines.Size(); i++)

--- a/src/rendering/hwrenderer/scene/hw_sky.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sky.cpp
@@ -318,15 +318,16 @@ void HWWall::SkyTop(HWWallDispatcher *di, seg_t * seg,sector_t * fs,sector_t * b
 		float frontreflect = fs->GetReflect(sector_t::ceiling);
 		if (frontreflect > 0)
 		{
-			float backreflect = bs->GetReflect(sector_t::ceiling);
-			if (backreflect > 0 && bs->ceilingplane.fD() == fs->ceilingplane.fD() && !bs->isClosed())
-			{
-				// Don't add intra-portal line to the portal.
-				if (!(di->di && di->di->Viewpoint.IsAllowedOoB()))
-				{
-					return;
-				}
-			}
+			// [DVR] Changed the stencil for planemirrors, so now I need intra-portal lines
+			// float backreflect = bs->GetReflect(sector_t::ceiling);
+			// if (backreflect > 0 && bs->ceilingplane.fD() == fs->ceilingplane.fD() && !bs->isClosed())
+			// {
+			// 	Don't add intra-portal line to the portal.
+			// 	if (!(di->di && di->di->Viewpoint.IsAllowedOoB()))
+			// 	{
+			// 		return;
+			// 	}
+			// }
 		}
 		else
 		{
@@ -400,15 +401,16 @@ void HWWall::SkyBottom(HWWallDispatcher *di, seg_t * seg,sector_t * fs,sector_t 
 		float frontreflect = fs->GetReflect(sector_t::floor);
 		if (frontreflect > 0)
 		{
-			float backreflect = bs->GetReflect(sector_t::floor);
-			if (backreflect > 0 && bs->floorplane.fD() == fs->floorplane.fD() && !bs->isClosed())
-			{
-				// Don't add intra-portal line to the portal.
-				if (!(di->di && di->di->Viewpoint.IsAllowedOoB()))
-				{
-					return;
-				}
-			}
+			// [DVR] Changed the stencil for planemirrors, so now I need intra-portal lines
+			// float backreflect = bs->GetReflect(sector_t::floor);
+			// if (backreflect > 0 && bs->floorplane.fD() == fs->floorplane.fD() && !bs->isClosed())
+			// {
+			// 	// Don't add intra-portal line to the portal.
+			// 	if (!(di->di && di->di->Viewpoint.IsAllowedOoB()))
+			// 	{
+			// 		return;
+			// 	}
+			// }
 		}
 		else
 		{


### PR DESCRIPTION
 Stacked-sector and planemirror portals stencil rewrite to address rendering bug with stencil cap.

Discord user named "Mud" reported a rendering bug under "technical-issues" titled "Visual bug with portals", wherein viewing a stacked-sector portal from the top results in a small (often triangular) shape near the center of the view. They uploaded this video-recording from one of their maps:


https://github.com/user-attachments/assets/6f1df540-605b-43f4-a79e-b78116284863

A similar visual bug occurs in reflective flats.
The size of the visual artifact depends on the absolute height/z-value of the plane containing the sector-portal or reflection. The following maps have all flat heights close to -32000.f to exaggerate the effect. In most normal maps, the artifacts will cover a small area of the screen.
Just load the maps and look down. Move around. Duck. etc.

[visual_bug_floormaps.zip](https://github.com/user-attachments/files/21093170/visual_bug_floormaps.zip)

The effect can be made to appear in reflective ceilings or sector portals when viewed from above too. The absolute heights will need to be close to +32000.f to increase the size of the artifacts then.