### PR TITLE
New client-side ACS ownership + always backup players

### DIFF
--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1474,22 +1474,10 @@ nodetype *RestoreNodeList(AActor *act, nodetype *linktype::*otherlist, TArray<no
 
 void P_PredictPlayer (player_t *player)
 {
-	int maxtic;
-
-	if (demoplayback ||
+	if (demoplayback || gamestate != GS_LEVEL ||
 		player->mo == NULL ||
 		player != player->mo->Level->GetConsolePlayer() ||
-		player->playerstate != PST_LIVE ||
-		(!netgame && cl_debugprediction == 0) ||
-		/*player->morphTics ||*/
 		(player->cheats & CF_PREDICTING))
-	{
-		return;
-	}
-
-	maxtic = ClientTic;
-
-	if (gametic == maxtic)
 	{
 		return;
 	}
@@ -1545,6 +1533,12 @@ void P_PredictPlayer (player_t *player)
 		block = block->NextBlock;
 	}
 	act->BlockNode = NULL;
+
+	int maxtic = ClientTic;
+	if (gametic == maxtic || player->playerstate != PST_LIVE)
+	{
+		return;
+	}
 
 	// This essentially acts like a mini P_Ticker where only the stuff relevant to the client is actually
 	// called. Call order is preserved.


### PR DESCRIPTION
Moved to a new ownership system. Only clients that own the activators will be allowed to call truly client-side scripts. Server objects that attempt to do this will instead run on the server.

Players are now always backed up, even in singleplayer. This way client-side actions will be consistent between multiplayer and singleplayer making structuring much easier.