### PR TITLE
Mark offensive items and ammo as WEAPONSPAWN

### DIFF
--- a/wadsrc/static/zscript/actors/heretic/hereticartifacts.zs
+++ b/wadsrc/static/zscript/actors/heretic/hereticartifacts.zs
@@ -54,6 +54,7 @@ Class ArtiTomeOfPower : PowerupGiver
 	{
 		+COUNTITEM
 		+FLOATBOB
+		+WEAPONSPAWN
 		Inventory.PickupFlash "PickupFlash";
 		Inventory.Icon "ARTIPWBK";
 		Powerup.Type "PowerWeaponlevel2";
@@ -129,6 +130,7 @@ Class ArtiTimeBomb : Inventory
 	{
 		+COUNTITEM
 		+FLOATBOB
+		+WEAPONSPAWN
 		Inventory.PickupFlash "PickupFlash";
 		+INVENTORY.INVBAR
 		+INVENTORY.FANCYPICKUPSOUND

--- a/wadsrc/static/zscript/actors/hexen/blastradius.zs
+++ b/wadsrc/static/zscript/actors/hexen/blastradius.zs
@@ -4,6 +4,7 @@ class ArtiBlastRadius : CustomInventory
 	Default
 	{
 		+FLOATBOB
+		+WEAPONSPAWN
 		Inventory.DefMaxAmount;
 		Inventory.PickupFlash "PickupFlash";
 		+INVENTORY.INVBAR +INVENTORY.FANCYPICKUPSOUND

--- a/wadsrc/static/zscript/actors/hexen/flechette.zs
+++ b/wadsrc/static/zscript/actors/hexen/flechette.zs
@@ -157,6 +157,7 @@ class ArtiPoisonBag : Inventory
 	Default
 	{
 		+FLOATBOB
+		+WEAPONSPAWN
 		Inventory.DefMaxAmount;
 		Inventory.PickupFlash "PickupFlash";
 		+INVENTORY.INVBAR +INVENTORY.FANCYPICKUPSOUND

--- a/wadsrc/static/zscript/actors/hexen/mana.zs
+++ b/wadsrc/static/zscript/actors/hexen/mana.zs
@@ -57,6 +57,7 @@ class Mana3 : CustomInventory
 		Radius 8;
 		Height 8;
 		+FLOATBOB
+		+WEAPONSPAWN
 		Inventory.PickupMessage "$TXT_MANA_BOTH";
 	}
 	States
@@ -79,6 +80,7 @@ class ArtiBoostMana : CustomInventory
 	{
 		+FLOATBOB
 		+COUNTITEM
+		+WEAPONSPAWN
 		+INVENTORY.INVBAR
 		+INVENTORY.FANCYPICKUPSOUND
 		Inventory.PickupFlash "PickupFlash";

--- a/wadsrc/static/zscript/actors/hexen/summon.zs
+++ b/wadsrc/static/zscript/actors/hexen/summon.zs
@@ -7,6 +7,7 @@ class ArtiDarkServant : Inventory
 	{
 		+COUNTITEM
 		+FLOATBOB
+		+WEAPONSPAWN
 		Inventory.RespawnTics 4230;
 		Inventory.DefMaxAmount;
 		Inventory.PickupFlash "PickupFlash";

--- a/wadsrc/static/zscript/actors/hexen/teleportother.zs
+++ b/wadsrc/static/zscript/actors/hexen/teleportother.zs
@@ -7,6 +7,7 @@ class ArtiTeleportOther : Inventory
 	{
 		+COUNTITEM
 		+FLOATBOB
+		+WEAPONSPAWN
 		+INVENTORY.INVBAR
 		+INVENTORY.FANCYPICKUPSOUND
 		Inventory.PickupFlash "PickupFlash";

--- a/wadsrc/static/zscript/actors/inventory/ammo.zs
+++ b/wadsrc/static/zscript/actors/inventory/ammo.zs
@@ -48,6 +48,7 @@ class Ammo : Inventory
 	Default
 	{
 		+INVENTORY.KEEPDEPLETED
+		+WEAPONSPAWN
 		Inventory.PickupSound "misc/ammo_pkup";
 		
 		Ammo.DropAmmoFactorMultiplier 1;
@@ -241,6 +242,11 @@ class Ammo : Inventory
 class BackpackItem : Inventory
 {
 	bool bDepleted;
+
+	Default
+	{
+		+WEAPONSPAWN
+	}
 	
 	//===========================================================================
 	//

--- a/wadsrc/static/zscript/actors/raven/artiegg.zs
+++ b/wadsrc/static/zscript/actors/raven/artiegg.zs
@@ -35,6 +35,7 @@ class ArtiEgg : CustomInventory
 		+INVENTORY.INVBAR
 		Inventory.PickupFlash "PickupFlash";
 		+INVENTORY.FANCYPICKUPSOUND
+		+WEAPONSPAWN
 		Inventory.Icon "ARTIEGGC";
 		Inventory.PickupSound "misc/p_pkup";
 		Inventory.PickupMessage "$TXT_ARTIEGG";
@@ -90,6 +91,7 @@ class ArtiPork : CustomInventory
 		+INVENTORY.INVBAR
 		Inventory.PickupFlash "PickupFlash";
 		+INVENTORY.FANCYPICKUPSOUND
+		+WEAPONSPAWN
 		Inventory.Icon "ARTIPORK";
 		Inventory.PickupSound "misc/p_pkup";
 		Inventory.PickupMessage "$TXT_ARTIEGG2";


### PR DESCRIPTION
Better filters these when playing in co-op mode with multiplayer things enabled.