### PR TITLE
Prevent buffer overflows in stream-handling functions

### DIFF
--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -40,6 +40,7 @@
 #include "c_console.h"
 #include "c_dispatch.h"
 #include "c_cvars.h"
+#include "d_protocol.h"
 #include "engineerrors.h"
 #include "printf.h"
 #include "palutil.h"
@@ -1265,12 +1266,10 @@ void FilterCompactCVars (TArray<FBaseCVar *> &cvars, uint32_t filter)
 	}
 }
 
-void C_WriteCVars (uint8_t **demo_p, uint32_t filter, bool compact)
+void C_WriteCVars (TArrayView<uint8_t>& demo_p, uint32_t filter, bool compact)
 {
 	FString dump = C_GetMassCVarString(filter, compact);
-	size_t dumplen = dump.Len() + 1;	// include terminating \0
-	memcpy(*demo_p, dump.GetChars(), dumplen);
-	*demo_p += dumplen;
+	WriteFString(dump, demo_p);
 }
 
 FString C_GetMassCVarString (uint32_t filter, bool compact)
@@ -1306,9 +1305,9 @@ FString C_GetMassCVarString (uint32_t filter, bool compact)
 	return dump;
 }
 
-void C_ReadCVars (uint8_t **demo_p)
+void C_ReadCVars (TArrayView<uint8_t>& demo_p)
 {
-	char *ptr = *((char **)demo_p);
+	char *ptr = (char *)demo_p.Data();
 	char *breakpt;
 
 	if (*ptr++ != '\\')
@@ -1371,7 +1370,7 @@ void C_ReadCVars (uint8_t **demo_p)
 			}
 		}
 	}
-	*demo_p += strlen (*((char **)demo_p)) + 1;
+	AdvanceStream(demo_p, strlen((char*)demo_p.Data()) + 1);
 }
 
 struct FCVarBackup

--- a/src/common/console/c_cvars.h
+++ b/src/common/console/c_cvars.h
@@ -269,7 +269,7 @@ private:
 	// These need to go away!
 	friend FString C_GetMassCVarString (uint32_t filter, bool compact);
 	friend void C_SerializeCVars(FSerializer& arc, const char* label, uint32_t filter);
-	friend void C_ReadCVars (uint8_t **demo_p);
+	friend void C_ReadCVars (TArrayView<uint8_t>& demo_p);
 	friend void C_BackupCVars (void);
 	friend FBaseCVar *FindCVar (const char *var_name, FBaseCVar **prev);
 	friend FBaseCVar *FindCVarSub (const char *var_name, int namelen);
@@ -288,12 +288,12 @@ private:
 // the cvar names are omitted to save space.
 FString C_GetMassCVarString (uint32_t filter, bool compact=false);
 
-// Writes all cvars that could effect demo sync to *demo_p. These are
+// Writes all cvars that could effect demo sync to demo_p. These are
 // cvars that have either CVAR_SERVERINFO or CVAR_DEMOSAVE set.
-void C_WriteCVars (uint8_t **demo_p, uint32_t filter, bool compact=false);
+void C_WriteCVars (TArrayView<uint8_t>& demo_p, uint32_t filter, bool compact=false);
 
-// Read all cvars from *demo_p and set them appropriately.
-void C_ReadCVars (uint8_t **demo_p);
+// Read all cvars from demo_p and set them appropriately.
+void C_ReadCVars (TArrayView<uint8_t>& demo_p);
 
 void C_InstallHandlers(ConsoleCallbacks* cb);
 

--- a/src/common/utility/zstring.cpp
+++ b/src/common/utility/zstring.cpp
@@ -265,6 +265,11 @@ FString &FString::operator = (const char *copyStr)
 	return *this;
 }
 
+TArrayView<uint8_t> FString::GetTArrayView()
+{
+	return TArrayView((uint8_t*)Chars, Len() + 1);
+}
+
 void FString::Format (const char *fmt, ...)
 {
 	va_list arglist;

--- a/src/common/utility/zstring.h
+++ b/src/common/utility/zstring.h
@@ -166,6 +166,8 @@ public:
 
 	const char *GetChars() const { return Chars; }
 
+	TArrayView<uint8_t> GetTArrayView();
+
 	const char &operator[] (int index) const { return Chars[index]; }
 #if defined(_WIN32) && !defined(_WIN64) && defined(_MSC_VER)
 	// Compiling 32-bit Windows source with MSVC: size_t is typedefed to an

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -248,7 +248,7 @@ private:
 		DPrintf(DMSG_NOTIFY, "Expanding special size to %zu\n", MaxSize);
 
 		for (auto& stream : Streams)
-			Streams->Grow(MaxSize);
+			stream.Grow(MaxSize);
 
 		CurrentStream = Streams[CurrentClientTic % BACKUPTICS].Stream + CurrentSize;
 	}

--- a/src/d_net.h
+++ b/src/d_net.h
@@ -65,6 +65,7 @@ public:
 
 	void SetData(const uint8_t* data, int len);
 	uint8_t* GetData(int* len = nullptr);
+	TArrayView<uint8_t> GetTArrayView();
 
 private:
 	uint8_t* m_Data;
@@ -149,8 +150,8 @@ void Net_WriteDouble(double);
 void Net_WriteString(const char *);
 void Net_WriteBytes(const uint8_t *, int len);
 
-void Net_DoCommand(int cmd, uint8_t **stream, int player);
-void Net_SkipCommand(int cmd, uint8_t **stream);
+void Net_DoCommand(int cmd, TArrayView<uint8_t>& stream, int player);
+void Net_SkipCommand(int cmd, TArrayView<uint8_t>& stream);
 
 bool Net_CheckCutsceneReady();
 void Net_AdvanceCutscene();

--- a/src/d_netinf.h
+++ b/src/d_netinf.h
@@ -56,10 +56,10 @@ void D_UserInfoChanged (FBaseCVar *info);
 
 bool D_SendServerInfoChange (FBaseCVar *cvar, UCVarValue value, ECVarType type);
 bool D_SendServerFlagChange (FBaseCVar *cvar, int bitnum, bool set, bool silent);
-void D_DoServerInfoChange (uint8_t **stream, bool singlebit);
+void D_DoServerInfoChange (TArrayView<uint8_t>& stream, bool singlebit);
 
 FString D_GetUserInfoStrings(int pnum, bool compact = false);
-void D_ReadUserInfoStrings (int player, uint8_t **stream, bool update);
+void D_ReadUserInfoStrings (int player, TArrayView<uint8_t>& stream, bool update);
 
 struct FPlayerColorSet;
 void D_GetPlayerColor (int player, float *h, float *s, float *v, FPlayerColorSet **colorset);

--- a/src/d_protocol.cpp
+++ b/src/d_protocol.cpp
@@ -38,7 +38,10 @@
 #include "cmdlib.h"
 #include "serializer.h"
 
-char* ReadString(uint8_t **stream)
+// Unchecked stream functions.
+// Use the checked versions instead unless you're checking the stream size yourself!
+
+char* UncheckedReadString(uint8_t **stream)
 {
 	char *string = *((char **)stream);
 
@@ -46,65 +49,65 @@ char* ReadString(uint8_t **stream)
 	return copystring(string);
 }
 
-const char* ReadStringConst(uint8_t **stream)
+const char* UncheckedReadStringConst(uint8_t **stream)
 {
 	const char *string = *((const char **)stream);
 	*stream += strlen(string) + 1;
 	return string;
 }
 
-uint8_t ReadInt8(uint8_t **stream)
+uint8_t UncheckedReadInt8(uint8_t **stream)
 {
 	uint8_t v = **stream;
 	*stream += 1;
 	return v;
 }
 
-int16_t ReadInt16(uint8_t **stream)
+int16_t UncheckedReadInt16(uint8_t **stream)
 {
 	int16_t v = (((*stream)[0]) << 8) | (((*stream)[1]));
 	*stream += 2;
 	return v;
 }
 
-int32_t ReadInt32(uint8_t **stream)
+int32_t UncheckedReadInt32(uint8_t **stream)
 {
 	int32_t v = (((*stream)[0]) << 24) | (((*stream)[1]) << 16) | (((*stream)[2]) << 8) | (((*stream)[3]));
 	*stream += 4;
 	return v;
 }
 
-int64_t ReadInt64(uint8_t** stream)
+int64_t UncheckedReadInt64(uint8_t **stream)
 {
 	int64_t v = (int64_t((*stream)[0]) << 56) | (int64_t((*stream)[1]) << 48) | (int64_t((*stream)[2]) << 40) | (int64_t((*stream)[3]) << 32)
-				| (int64_t((*stream)[4]) << 24) | (int64_t((*stream)[5]) << 16) | (int64_t((*stream)[6]) << 8) | (int64_t((*stream)[7]));
+		| (int64_t((*stream)[4]) << 24) | (int64_t((*stream)[5]) << 16) | (int64_t((*stream)[6]) << 8) | (int64_t((*stream)[7]));
 	*stream += 8;
 	return v;
 }
 
-float ReadFloat(uint8_t **stream)
+float UncheckedReadFloat(uint8_t **stream)
 {
 	union
 	{
 		int32_t i;
 		float f;
 	} fakeint;
-	fakeint.i = ReadInt32 (stream);
+	fakeint.i = UncheckedReadInt32(stream);
 	return fakeint.f;
 }
 
-double ReadDouble(uint8_t** stream)
+double UncheckedReadDouble(uint8_t **stream)
 {
 	union
 	{
 		int64_t i;
 		double f;
 	} fakeint;
-	fakeint.i = ReadInt64(stream);
+	fakeint.i = UncheckedReadInt64(stream);
 	return fakeint.f;
 }
 
-void WriteString(const char *string, uint8_t **stream)
+void UncheckedWriteString(const char *string, uint8_t **stream)
 {
 	char *p = *((char **)stream);
 
@@ -116,20 +119,20 @@ void WriteString(const char *string, uint8_t **stream)
 	*stream = (uint8_t *)p;
 }
 
-void WriteInt8(uint8_t v, uint8_t **stream)
+void UncheckedWriteInt8(uint8_t v, uint8_t **stream)
 {
 	**stream = v;
 	*stream += 1;
 }
 
-void WriteInt16(int16_t v, uint8_t **stream)
+void UncheckedWriteInt16(int16_t v, uint8_t **stream)
 {
 	(*stream)[0] = v >> 8;
 	(*stream)[1] = v & 255;
 	*stream += 2;
 }
 
-void WriteInt32(int32_t v, uint8_t **stream)
+void UncheckedWriteInt32(int32_t v, uint8_t **stream)
 {
 	(*stream)[0] = v >> 24;
 	(*stream)[1] = (v >> 16) & 255;
@@ -138,7 +141,7 @@ void WriteInt32(int32_t v, uint8_t **stream)
 	*stream += 4;
 }
 
-void WriteInt64(int64_t v, uint8_t** stream)
+void UncheckedWriteInt64(int64_t v, uint8_t **stream)
 {
 	(*stream)[0] = v >> 56;
 	(*stream)[1] = (v >> 48) & 255;
@@ -151,7 +154,231 @@ void WriteInt64(int64_t v, uint8_t** stream)
 	*stream += 8;
 }
 
-void WriteFloat(float v, uint8_t **stream)
+void UncheckedWriteFloat(float v, uint8_t **stream)
+{
+	union
+	{
+		int32_t i;
+		float f;
+	} fakeint;
+	fakeint.f = v;
+	UncheckedWriteInt32(fakeint.i, stream);
+}
+
+void UncheckedWriteDouble(double v, uint8_t **stream)
+{
+	union
+	{
+		int64_t i;
+		double f;
+	} fakeint;
+	fakeint.f = v;
+	UncheckedWriteInt64(fakeint.i, stream);
+}
+
+void AdvanceStream(TArrayView<uint8_t>& stream, size_t bytes)
+{
+	assert(bytes <= stream.Size());
+	stream = TArrayView(stream.Data() + bytes, stream.Size() - bytes);
+}
+
+// Checked stream functions
+
+char* ReadString(TArrayView<uint8_t>& stream)
+{
+	char *string = (char*)stream.Data();
+	size_t len = strnlen(string, stream.Size());
+	if (len == stream.Size())
+	{
+		I_Error("Attempted to read past end of stream");
+	}
+	AdvanceStream(stream, len + 1);
+	return copystring(string);
+}
+
+const char* ReadStringConst(TArrayView<uint8_t>& stream)
+{
+	const char* string = (const char*)stream.Data();
+	size_t len = strnlen(string, stream.Size());
+	if (len == stream.Size())
+	{
+		I_Error("Attempted to read past end of stream");
+	}
+	AdvanceStream(stream, len + 1);
+	return string;
+}
+
+void ReadBytes(TArrayView<uint8_t>& dst, TArrayView<uint8_t>& stream)
+{
+	if (dst.Size() > stream.Size())
+	{
+		I_Error("Attempted to read past end of stream");
+	}
+	if (dst.Size())
+	{
+		memcpy(dst.Data(), stream.Data(), dst.Size());
+		AdvanceStream(stream, dst.Size());
+	}
+}
+
+uint8_t ReadInt8(TArrayView<uint8_t>& stream)
+{
+	if (stream.Size() < 1)
+	{
+		I_Error("Attempted to read past end of stream");
+	}
+	uint8_t v = stream[0];
+	AdvanceStream(stream, 1);
+	return v;
+}
+
+int16_t ReadInt16(TArrayView<uint8_t>& stream)
+{
+	if (stream.Size() < 2)
+	{
+		I_Error("Attempted to read past end of stream");
+	}
+	int16_t v = ((stream[0]) << 8) | stream[1];
+	AdvanceStream(stream, 2);
+	return v;
+}
+
+int32_t ReadInt32(TArrayView<uint8_t>& stream)
+{
+	if (stream.Size() < 4)
+	{
+		I_Error("Attempted to read past end of stream");
+	}
+	int32_t v = (stream[0] << 24) | (stream[1] << 16) | (stream[2] << 8) | stream[3];
+	AdvanceStream(stream, 4);
+	return v;
+}
+
+int64_t ReadInt64(TArrayView<uint8_t>& stream)
+{
+	if (stream.Size() < 8)
+	{
+		I_Error("Attempted to read past end of stream");
+	}
+	int64_t v = (int64_t(stream[0]) << 56) | (int64_t(stream[1]) << 48) | (int64_t(stream[2]) << 40) | (int64_t(stream[3]) << 32)
+				| (int64_t(stream[4]) << 24) | (int64_t(stream[5]) << 16) | (int64_t(stream[6]) << 8) | int64_t(stream[7]);
+	AdvanceStream(stream, 8);
+	return v;
+}
+
+float ReadFloat(TArrayView<uint8_t>& stream)
+{
+	union
+	{
+		int32_t i;
+		float f;
+	} fakeint;
+	fakeint.i = ReadInt32 (stream);
+	return fakeint.f;
+}
+
+double ReadDouble(TArrayView<uint8_t>& stream)
+{
+	union
+	{
+		int64_t i;
+		double f;
+	} fakeint;
+	fakeint.i = ReadInt64(stream);
+	return fakeint.f;
+}
+
+void WriteString(const char *string, TArrayView<uint8_t>& stream)
+{
+	char *p = (char *)stream.Data();
+	unsigned int remaining = stream.Size();
+
+	while (*string) {
+		if (remaining-- == 0)
+		{
+			I_Error("Attempted to write past end of stream");
+		}
+		*p++ = *string++;
+	}
+
+	if (remaining == 0)
+	{
+		I_Error("Attempted to write past end of stream");
+	}
+	*p++ = 0;
+	AdvanceStream(stream, p - (char*)stream.Data());
+}
+
+void WriteBytes(const TArrayView<uint8_t>& source, TArrayView<uint8_t>& stream)
+{
+	if (source.Size() > stream.Size())
+	{
+		I_Error("Attempted to write past end of stream");
+	}
+	if (source.Size())
+	{
+		memcpy(stream.Data(), source.Data(), source.Size());
+		AdvanceStream(stream, source.Size());
+	}
+}
+
+void WriteFString(FString& string, TArrayView<uint8_t>& stream)
+{
+	WriteBytes(string.GetTArrayView(), stream);
+}
+
+void WriteInt8(uint8_t v, TArrayView<uint8_t>& stream)
+{
+	if (stream.Size() < 1)
+	{
+		I_Error("Attempted to write past end of stream");
+	}
+	stream[0] = v;
+	AdvanceStream(stream, 1);
+}
+
+void WriteInt16(int16_t v, TArrayView<uint8_t>& stream)
+{
+	if (stream.Size() < 2)
+	{
+		I_Error("Attempted to write past end of stream");
+	}
+	stream[0] = v >> 8;
+	stream[1] = v & 255;
+	AdvanceStream(stream, 2);
+}
+
+void WriteInt32(int32_t v, TArrayView<uint8_t>& stream)
+{
+	if (stream.Size() < 4)
+	{
+		I_Error("Attempted to write past end of stream");
+	}
+	stream[0] = v >> 24;
+	stream[1] = (v >> 16) & 255;
+	stream[2] = (v >> 8) & 255;
+	stream[3] = v & 255;
+	AdvanceStream(stream, 4);
+}
+
+void WriteInt64(int64_t v, TArrayView<uint8_t>& stream)
+{
+	if (stream.Size() < 8)
+	{
+		I_Error("Attempted to write past end of stream");
+	}
+	stream[0] = v >> 56;
+	stream[1] = (v >> 48) & 255;
+	stream[2] = (v >> 40) & 255;
+	stream[3] = (v >> 32) & 255;
+	stream[4] = (v >> 24) & 255;
+	stream[5] = (v >> 16) & 255;
+	stream[6] = (v >> 8) & 255;
+	stream[7] = v & 255;
+	AdvanceStream(stream, 8);
+}
+
+void WriteFloat(float v, TArrayView<uint8_t>& stream)
 {
 	union
 	{
@@ -162,7 +389,7 @@ void WriteFloat(float v, uint8_t **stream)
 	WriteInt32 (fakeint.i, stream);
 }
 
-void WriteDouble(double v, uint8_t** stream)
+void WriteDouble(double v, TArrayView<uint8_t>& stream)
 {
 	union
 	{
@@ -193,11 +420,8 @@ FSerializer& Serialize(FSerializer& arc, const char* key, usercmd_t& cmd, usercm
 	return arc;
 }
 
-// Returns the number of bytes read
-int UnpackUserCmd(usercmd_t& cmd, const usercmd_t* basis, uint8_t*& stream)
+void UnpackUserCmd(usercmd_t& cmd, const usercmd_t* basis, TArrayView<uint8_t>& stream)
 {
-	const uint8_t* start = stream;
-
 	if (basis != nullptr)
 	{
 		if (basis != &cmd)
@@ -208,7 +432,7 @@ int UnpackUserCmd(usercmd_t& cmd, const usercmd_t* basis, uint8_t*& stream)
 		memset(&cmd, 0, sizeof(usercmd_t));
 	}
 
-	uint8_t flags = ReadInt8(&stream);
+	uint8_t flags = ReadInt8(stream);
 	if (flags)
 	{
 		// We can support up to 29 buttons using 1 to 4 bytes to store them. The most
@@ -216,19 +440,19 @@ int UnpackUserCmd(usercmd_t& cmd, const usercmd_t* basis, uint8_t*& stream)
 		// should be read in excluding the last one which supports all 8 bits.
 		if (flags & UCMDF_BUTTONS)
 		{
-			uint8_t in = ReadInt8(&stream);
+			uint8_t in = ReadInt8(stream);
 			uint32_t buttons = (cmd.buttons & ~0x7F) | (in & 0x7F);
 			if (in & MoreButtons)
 			{
-				in = ReadInt8(&stream);
+				in = ReadInt8(stream);
 				buttons = (buttons & ~(0x7F << 7)) | ((in & 0x7F) << 7);
 				if (in & MoreButtons)
 				{
-					in = ReadInt8(&stream);
+					in = ReadInt8(stream);
 					buttons = (buttons & ~(0x7F << 14)) | ((in & 0x7F) << 14);
 					if (in & MoreButtons)
 					{
-						in = ReadInt8(&stream);
+						in = ReadInt8(stream);
 						buttons = (buttons & ~(0xFF << 21)) | (in << 21);
 					}
 				}
@@ -236,26 +460,24 @@ int UnpackUserCmd(usercmd_t& cmd, const usercmd_t* basis, uint8_t*& stream)
 			cmd.buttons = buttons;
 		}
 		if (flags & UCMDF_PITCH)
-			cmd.pitch = ReadInt16(&stream);
+			cmd.pitch = ReadInt16(stream);
 		if (flags & UCMDF_YAW)
-			cmd.yaw = ReadInt16(&stream);
+			cmd.yaw = ReadInt16(stream);
 		if (flags & UCMDF_FORWARDMOVE)
-			cmd.forwardmove = ReadInt16(&stream);
+			cmd.forwardmove = ReadInt16(stream);
 		if (flags & UCMDF_SIDEMOVE)
-			cmd.sidemove = ReadInt16(&stream);
+			cmd.sidemove = ReadInt16(stream);
 		if (flags & UCMDF_UPMOVE)
-			cmd.upmove = ReadInt16(&stream);
+			cmd.upmove = ReadInt16(stream);
 		if (flags & UCMDF_ROLL)
-			cmd.roll = ReadInt16(&stream);
+			cmd.roll = ReadInt16(stream);
 	}
-
-	return int(stream - start);
 }
 
-int PackUserCmd(const usercmd_t& cmd, const usercmd_t* basis, uint8_t*& stream)
+void PackUserCmd(const usercmd_t& cmd, const usercmd_t* basis, TArrayView<uint8_t>& stream)
 {
 	uint8_t flags = 0;
-	uint8_t* start = stream;
+	auto flagsPosition = TArrayView(stream.Data(), 1);
 
 	usercmd_t blank;
 	if (basis == nullptr)
@@ -264,7 +486,7 @@ int PackUserCmd(const usercmd_t& cmd, const usercmd_t* basis, uint8_t*& stream)
 		basis = &blank;
 	}
 
-	++stream; // Make room for the flags.
+	AdvanceStream(stream, 1); // Make room for the flags.
 	uint32_t buttons_changed = cmd.buttons ^ basis->buttons;
 	if (buttons_changed != 0)
 	{
@@ -284,56 +506,54 @@ int PackUserCmd(const usercmd_t& cmd, const usercmd_t* basis, uint8_t*& stream)
 					bytes[2] |= MoreButtons;
 			}
 		}
-		WriteInt8(bytes[0], &stream);
+		WriteInt8(bytes[0], stream);
 		if (bytes[0] & MoreButtons)
 		{
-			WriteInt8(bytes[1], &stream);
+			WriteInt8(bytes[1], stream);
 			if (bytes[1] & MoreButtons)
 			{
-				WriteInt8(bytes[2], &stream);
+				WriteInt8(bytes[2], stream);
 				if (bytes[2] & MoreButtons)
-					WriteInt8(bytes[3], &stream);
+					WriteInt8(bytes[3], stream);
 			}
 		}
 	}
 	if (cmd.pitch != basis->pitch)
 	{
 		flags |= UCMDF_PITCH;
-		WriteInt16(cmd.pitch, &stream);
+		WriteInt16(cmd.pitch, stream);
 	}
 	if (cmd.yaw != basis->yaw)
 	{
 		flags |= UCMDF_YAW;
-		WriteInt16 (cmd.yaw, &stream);
+		WriteInt16 (cmd.yaw, stream);
 	}
 	if (cmd.forwardmove != basis->forwardmove)
 	{
 		flags |= UCMDF_FORWARDMOVE;
-		WriteInt16 (cmd.forwardmove, &stream);
+		WriteInt16 (cmd.forwardmove, stream);
 	}
 	if (cmd.sidemove != basis->sidemove)
 	{
 		flags |= UCMDF_SIDEMOVE;
-		WriteInt16(cmd.sidemove, &stream);
+		WriteInt16(cmd.sidemove, stream);
 	}
 	if (cmd.upmove != basis->upmove)
 	{
 		flags |= UCMDF_UPMOVE;
-		WriteInt16(cmd.upmove, &stream);
+		WriteInt16(cmd.upmove, stream);
 	}
 	if (cmd.roll != basis->roll)
 	{
 		flags |= UCMDF_ROLL;
-		WriteInt16(cmd.roll, &stream);
+		WriteInt16(cmd.roll, stream);
 	}
 
 	// Write the packing bits
-	WriteInt8(flags, &start);
-
-	return int(stream - start);
+	WriteInt8(flags, flagsPosition);
 }
 
-int WriteUserCmdMessage(const usercmd_t& cmd, const usercmd_t* basis, uint8_t*& stream)
+void WriteUserCmdMessage(const usercmd_t& cmd, const usercmd_t* basis, TArrayView<uint8_t>& stream)
 {
 	if (basis == nullptr)
 	{
@@ -341,58 +561,60 @@ int WriteUserCmdMessage(const usercmd_t& cmd, const usercmd_t* basis, uint8_t*& 
 			|| cmd.pitch || cmd.yaw || cmd.roll
 			|| cmd.forwardmove || cmd.sidemove || cmd.upmove)
 		{
-			WriteInt8(DEM_USERCMD, &stream);
-			return PackUserCmd(cmd, basis, stream) + 1;
+			WriteInt8(DEM_USERCMD, stream);
+			PackUserCmd(cmd, basis, stream);
+			return;
 		}
 	}
 	else if (cmd.buttons != basis->buttons
 			|| cmd.yaw != basis->yaw || cmd.pitch != basis->pitch || cmd.roll != basis->roll
 			|| cmd.forwardmove != basis->forwardmove || cmd.sidemove != basis->sidemove || cmd.upmove != basis->upmove)
 	{
-		WriteInt8(DEM_USERCMD, &stream);
-		return PackUserCmd(cmd, basis, stream) + 1;
+		WriteInt8(DEM_USERCMD, stream);
+		PackUserCmd(cmd, basis, stream);
+		return;
 	}
 
-	WriteInt8(DEM_EMPTYUSERCMD, &stream);
-	return 1;
+	WriteInt8(DEM_EMPTYUSERCMD, stream);
 }
 
 // Reads through the user command without actually setting any of its info. Used to get the size
 // of the command when getting the length of the stream.
-int SkipUserCmdMessage(uint8_t*& stream)
+void SkipUserCmdMessage(TArrayView<uint8_t>& stream)
 {
-	const uint8_t* start = stream;
-
 	while (true)
 	{
-		const uint8_t type = *stream++;
+		const uint8_t type = ReadInt8(stream);
 		if (type == DEM_USERCMD)
 		{
 			int skip = 1;
-			if (*stream & UCMDF_PITCH)
+			if (stream[0] & UCMDF_PITCH)
 				skip += 2;
-			if (*stream & UCMDF_YAW)
+			if (stream[0] & UCMDF_YAW)
 				skip += 2;
-			if (*stream & UCMDF_FORWARDMOVE)
+			if (stream[0] & UCMDF_FORWARDMOVE)
 				skip += 2;
-			if (*stream & UCMDF_SIDEMOVE)
+			if (stream[0] & UCMDF_SIDEMOVE)
 				skip += 2;
-			if (*stream & UCMDF_UPMOVE)
+			if (stream[0] & UCMDF_UPMOVE)
 				skip += 2;
-			if (*stream & UCMDF_ROLL)
+			if (stream[0] & UCMDF_ROLL)
 				skip += 2;
-			if (*stream & UCMDF_BUTTONS)
+			if (stream[0] & UCMDF_BUTTONS)
 			{
-				if (*++stream & MoreButtons)
+				AdvanceStream(stream, 1);
+				if (stream[0] & MoreButtons)
 				{
-					if (*++stream & MoreButtons)
+					AdvanceStream(stream, 1);
+					if (stream[0] & MoreButtons)
 					{
-						if (*++stream & MoreButtons)
-							++stream;
+						AdvanceStream(stream, 1);
+						if (stream[0] & MoreButtons)
+							AdvanceStream(stream, 1);
 					}
 				}
 			}
-			stream += skip;
+			AdvanceStream(stream, skip);
 			break;
 		}
 		else if (type == DEM_EMPTYUSERCMD)
@@ -401,31 +623,29 @@ int SkipUserCmdMessage(uint8_t*& stream)
 		}
 		else
 		{
-			Net_SkipCommand(type, &stream);
+			Net_SkipCommand(type, stream);
 		}
 	}
-
-	return int(stream - start);
 }
 
-int ReadUserCmdMessage(uint8_t*& stream, int player, int tic)
+void ReadUserCmdMessage(TArrayView<uint8_t>& stream, int player, int tic)
 {
 	const int ticMod = tic % BACKUPTICS;
 
 	auto& curTic = ClientStates[player].Tics[ticMod];
 	usercmd_t& ticCmd = curTic.Command;
 
-	const uint8_t* start = stream;
+	const uint8_t* start = stream.Data();
 
 	// Skip until we reach the player command. Event data will get read off once the
 	// tick is actually executed.
 	int type;
-	while ((type = ReadInt8(&stream)) != DEM_USERCMD && type != DEM_EMPTYUSERCMD)
-		Net_SkipCommand(type, &stream);
+	while ((type = ReadInt8(stream)) != DEM_USERCMD && type != DEM_EMPTYUSERCMD)
+		Net_SkipCommand(type, stream);
 
 	// Subtract a byte to account for the fact the stream head is now sitting on the
 	// user command.
-	curTic.Data.SetData(start, int(stream - start - 1));
+	curTic.Data.SetData(start, int(stream.Data() - start - 1));
 
 	if (type == DEM_USERCMD)
 	{
@@ -439,8 +659,6 @@ int ReadUserCmdMessage(uint8_t*& stream, int player, int tic)
 		else
 			memset(&ticCmd, 0, sizeof(ticCmd));
 	}
-
-	return int(stream - start);
 }
 
 void RunPlayerCommands(int player, int tic)
@@ -449,14 +667,12 @@ void RunPlayerCommands(int player, int tic)
 	if (gametic % TicDup)
 		return;
 
-	int len;
 	auto& data = ClientStates[player].Tics[tic % BACKUPTICS].Data;
-	uint8_t* stream = data.GetData(&len);
-	if (stream != nullptr)
+	auto stream = data.GetTArrayView();
+	if (stream.Size())
 	{
-		uint8_t* end = stream + len;
-		while (stream < end)
-			Net_DoCommand(ReadInt8(&stream), &stream, player);
+		while (stream.Size() > 0)
+			Net_DoCommand(ReadInt8(stream), stream, player);
 
 		if (!demorecording)
 			data.SetData(nullptr, 0);
@@ -469,22 +685,23 @@ uint8_t* streamPos = nullptr;
 
 // Write the header of an IFF chunk and leave space
 // for the length field.
-void StartChunk(int id, uint8_t **stream)
+void StartChunk(int id, TArrayView<uint8_t>& stream)
 {
 	WriteInt32(id, stream);
-	streamPos = *stream;
-	*stream += 4;
+	streamPos = stream.Data();
+	AdvanceStream(stream, 4);
 }
 
 // Write the length field for the chunk and insert
 // pad byte if the chunk is odd-sized.
-void FinishChunk(uint8_t **stream)
+void FinishChunk(TArrayView<uint8_t>& stream)
 {
 	if (streamPos == nullptr)
 		return;
 
-	int len = int(*stream - streamPos - 4);
-	WriteInt32(len, &streamPos);
+	int len = int(stream.Data() - streamPos - 4);
+	auto streamPosView = TArrayView<uint8_t>(streamPos, 4);
+	WriteInt32(len, streamPosView);
 	if (len & 1)
 		WriteInt8(0, stream);
 
@@ -493,8 +710,8 @@ void FinishChunk(uint8_t **stream)
 
 // Skip past an unknown chunk. *stream should be
 // pointing to the chunk's length field.
-void SkipChunk(uint8_t **stream)
+void SkipChunk(TArrayView<uint8_t>& stream)
 {
 	int len = ReadInt32(stream);
-	*stream += len + (len & 1);
+	AdvanceStream(stream, len + (len & 1));
 }

--- a/src/d_protocol.h
+++ b/src/d_protocol.h
@@ -229,33 +229,53 @@ enum ECheatCommand
 	CHT_MASSACRE2
 };
 
-void StartChunk (int id, uint8_t **stream);
-void FinishChunk (uint8_t **stream);
-void SkipChunk (uint8_t **stream);
+void StartChunk (int id, TArrayView<uint8_t>& stream);
+void FinishChunk (TArrayView<uint8_t>& stream);
+void SkipChunk (TArrayView<uint8_t>& stream);
 
-// Returns the number of bytes written to the stream
-int UnpackUserCmd(usercmd_t& ucmd, const usercmd_t* basis, uint8_t*& stream);
-int PackUserCmd(const usercmd_t& ucmd, const usercmd_t* basis, uint8_t*& stream);
-int WriteUserCmdMessage(const usercmd_t& ucmd, const usercmd_t *basis, uint8_t*& stream);
+void UnpackUserCmd(usercmd_t& ucmd, const usercmd_t* basis, TArrayView<uint8_t>& stream);
+void PackUserCmd(const usercmd_t& ucmd, const usercmd_t* basis, TArrayView<uint8_t>& stream);
+void WriteUserCmdMessage(const usercmd_t& ucmd, const usercmd_t *basis, TArrayView<uint8_t>& stream);
 
-int SkipUserCmdMessage(uint8_t*& stream);
-int ReadUserCmdMessage(uint8_t*& stream, int player, int tic);
+void SkipUserCmdMessage(TArrayView<uint8_t>& stream);
+void ReadUserCmdMessage(TArrayView<uint8_t>& stream, int player, int tic);
 void RunPlayerCommands(int player, int tic);
 
-uint8_t ReadInt8 (uint8_t **stream);
-int16_t ReadInt16 (uint8_t **stream);
-int32_t ReadInt32 (uint8_t **stream);
-int64_t ReadInt64(uint8_t** stream);
-float ReadFloat (uint8_t **stream);
-double ReadDouble(uint8_t** stream);
-char *ReadString (uint8_t **stream);
-const char *ReadStringConst(uint8_t **stream);
-void WriteInt8 (uint8_t val, uint8_t **stream);
-void WriteInt16 (int16_t val, uint8_t **stream);
-void WriteInt32 (int32_t val, uint8_t **stream);
-void WriteInt64(int64_t val, uint8_t** stream);
-void WriteFloat (float val, uint8_t **stream);
-void WriteDouble(double val, uint8_t** stream);
-void WriteString (const char *string, uint8_t **stream);
+uint8_t UncheckedReadInt8(uint8_t** stream);
+int16_t UncheckedReadInt16(uint8_t** stream);
+int32_t UncheckedReadInt32(uint8_t** stream);
+int64_t UncheckedReadInt64(uint8_t** stream);
+float UncheckedReadFloat(uint8_t** stream);
+double UncheckedReadDouble(uint8_t** stream);
+char* UncheckedReadString(uint8_t** stream);
+const char* UncheckedReadStringConst(uint8_t** stream);
+void UncheckedWriteInt8(uint8_t val, uint8_t** stream);
+void UncheckedWriteInt16(int16_t val, uint8_t** stream);
+void UncheckedWriteInt32(int32_t val, uint8_t** stream);
+void UncheckedWriteInt64(int64_t val, uint8_t** stream);
+void UncheckedWriteFloat(float val, uint8_t** stream);
+void UncheckedWriteDouble(double val, uint8_t** stream);
+void UncheckedWriteString(const char* string, uint8_t** stream);
+
+void AdvanceStream(TArrayView<uint8_t>& stream, size_t bytes);
+
+uint8_t ReadInt8(TArrayView<uint8_t>& stream);
+int16_t ReadInt16(TArrayView<uint8_t>& stream);
+int32_t ReadInt32(TArrayView<uint8_t>& stream);
+int64_t ReadInt64(TArrayView<uint8_t>& stream);
+float ReadFloat(TArrayView<uint8_t>& stream);
+double ReadDouble(TArrayView<uint8_t>& stream);
+char* ReadString(TArrayView<uint8_t>& stream);
+const char* ReadStringConst(TArrayView<uint8_t>& stream);
+void ReadBytes(TArrayView<uint8_t>& dst, TArrayView<uint8_t>& stream);
+void WriteInt8(uint8_t val, TArrayView<uint8_t>& stream);
+void WriteInt16(int16_t val, TArrayView<uint8_t>& stream);
+void WriteInt32(int32_t val, TArrayView<uint8_t>& stream);
+void WriteInt64(int64_t val, TArrayView<uint8_t>& stream);
+void WriteFloat(float val, TArrayView<uint8_t>& stream);
+void WriteDouble(double val, TArrayView<uint8_t>& stream);
+void WriteString(const char* string, TArrayView<uint8_t>& stream);
+void WriteBytes(const TArrayView<uint8_t>& source, TArrayView<uint8_t>& stream);
+void WriteFString(FString& string, TArrayView<uint8_t>& stream);
 
 #endif //__D_PROTOCOL_H__

--- a/src/gamedata/a_weapons.cpp
+++ b/src/gamedata/a_weapons.cpp
@@ -855,7 +855,7 @@ static int ntoh_cmp(const void *a, const void *b)
 //
 //===========================================================================
 
-void P_WriteDemoWeaponsChunk(uint8_t **demo)
+void P_WriteDemoWeaponsChunk(TArrayView<uint8_t>& demo)
 {
 	WriteInt16(Weapons_ntoh.Size(), demo);
 	for (unsigned int i = 1; i < Weapons_ntoh.Size(); ++i)
@@ -873,7 +873,7 @@ void P_WriteDemoWeaponsChunk(uint8_t **demo)
 //
 //===========================================================================
 
-void P_ReadDemoWeaponsChunk(uint8_t **demo)
+void P_ReadDemoWeaponsChunk(TArrayView<uint8_t>& demo)
 {
 	int count, i;
 	PClassActor *type;
@@ -938,7 +938,7 @@ void Net_WriteWeapon(PClassActor *type)
 //
 //===========================================================================
 
-PClassActor *Net_ReadWeapon(uint8_t **stream)
+PClassActor *Net_ReadWeapon(TArrayView<uint8_t>& stream)
 {
 	int index;
 

--- a/src/gamedata/a_weapons.h
+++ b/src/gamedata/a_weapons.h
@@ -120,11 +120,11 @@ public:
 
 void P_PlaybackKeyConfWeapons(FWeaponSlots *slots);
 void Net_WriteWeapon(PClassActor *type);
-PClassActor *Net_ReadWeapon(uint8_t **stream);
+PClassActor *Net_ReadWeapon(TArrayView<uint8_t>& stream);
 
 void P_SetupWeapons_ntohton();
-void P_WriteDemoWeaponsChunk(uint8_t **demo);
-void P_ReadDemoWeaponsChunk(uint8_t **demo);
+void P_WriteDemoWeaponsChunk(TArrayView<uint8_t>& demo);
+void P_ReadDemoWeaponsChunk(TArrayView<uint8_t>& demo);
 
 
 enum class EBobStyle

--- a/src/p_conversation.cpp
+++ b/src/p_conversation.cpp
@@ -667,7 +667,7 @@ static void HandleReply(player_t *player, bool isconsole, int nodenum, int reply
 //
 //============================================================================
 
-void P_ConversationCommand (int netcode, int pnum, uint8_t **stream)
+void P_ConversationCommand (int netcode, int pnum, TArrayView<uint8_t>& stream)
 {
 	player_t *player = &players[pnum];
 

--- a/src/p_conversation.h
+++ b/src/p_conversation.h
@@ -70,7 +70,7 @@ void P_FreeStrifeConversations ();
 void P_StartConversation (AActor *npc, AActor *pc, bool facetalker, bool saveangle);
 void P_ResumeConversation ();
 
-void P_ConversationCommand (int netcode, int player, uint8_t **stream);
+void P_ConversationCommand (int netcode, int player, TArrayView<uint8_t>& stream);
 
 
 #endif

--- a/src/playsim/bots/b_bot.h
+++ b/src/playsim/bots/b_bot.h
@@ -120,7 +120,7 @@ public:
 	void Init ();
 	void End();
 	bool SpawnBot (const char *name, int color = NOCOLOR);
-	void TryAddBot (FLevelLocals *Level, uint8_t **stream, int player);
+	void TryAddBot (FLevelLocals *Level, TArrayView<uint8_t>& stream, int player);
 	void RemoveAllBots (FLevelLocals *Level, bool fromlist);
 	bool LoadBots ();
 	void ForgetBots ();
@@ -154,7 +154,7 @@ public:
 
 private:
 	//(b_game.cpp)
-	bool DoAddBot (FLevelLocals *Level, uint8_t *info, botskill_t skill);
+	bool DoAddBot (FLevelLocals *Level, TArrayView<uint8_t> info, botskill_t skill);
 
 protected:
 	bool	 ctf;

--- a/src/playsim/bots/b_game.cpp
+++ b/src/playsim/bots/b_game.cpp
@@ -319,7 +319,7 @@ bool FCajunMaster::SpawnBot (const char *name, int color)
 	return true;
 }
 
-void FCajunMaster::TryAddBot (FLevelLocals *Level, uint8_t **stream, int player)
+void FCajunMaster::TryAddBot (FLevelLocals *Level, TArrayView<uint8_t>& stream, int player)
 {
 	int botshift = ReadInt8 (stream);
 	char *info = ReadString (stream);
@@ -342,7 +342,7 @@ void FCajunMaster::TryAddBot (FLevelLocals *Level, uint8_t **stream, int player)
 		}
 	}
 
-	if (DoAddBot (Level,(uint8_t *)info, skill))
+	if (DoAddBot (Level, TArrayView((uint8_t*)info, strlen(info)+1), skill))
 	{
 		//Increment this.
 		botnum++;
@@ -363,7 +363,7 @@ void FCajunMaster::TryAddBot (FLevelLocals *Level, uint8_t **stream, int player)
 	delete[] info;
 }
 
-bool FCajunMaster::DoAddBot (FLevelLocals *Level, uint8_t *info, botskill_t skill)
+bool FCajunMaster::DoAddBot (FLevelLocals *Level, TArrayView<uint8_t> info, botskill_t skill)
 {
 	int bnum;
 
@@ -381,7 +381,7 @@ bool FCajunMaster::DoAddBot (FLevelLocals *Level, uint8_t *info, botskill_t skil
 		return false;
 	}
 
-	D_ReadUserInfoStrings (bnum, &info, false);
+	D_ReadUserInfoStrings (bnum, info, false);
 
 	multiplayer = true; //Prevents cheating and so on; emulates real netgame (almost).
 	players[bnum].Bot = Level->CreateThinker<DBot>();


### PR DESCRIPTION
This PR has two commits. The first commit is a one-line fix for a mistake introduced in [94be307225](https://github.com/ZDoom/gzdoom/commit/94be307225bbf9488b8519b9dfae7ed89ca827af) which causes all but the first NetEvents buffers to fail to be resized, which leads to potential buffer overflows and undefined behavior. The rest of this message is about the second commit.

The second commit adds bounds checking to various places reading or writing from a buffer, preventing buffer overflows from being possible in those places. Fixing this required a change to many functions that took a `uint8_t **stream` parameter.

GZDoom has multiple functions which take a `uint8_t **stream` parameter, which is used to read from or write to the current position in a buffer and then advance the current position, but nothing is passed in to these functions to communicate the size of the buffer. This means that these functions are unable to do bounds checking and prevent buffer overflows if they happen to read/write more of the stream than the original caller that allocated the buffer expects. This is a similar API design issue to the classic infamous `char *gets(char *str)` function in the C standard library, which was responsible for one of the vulnerabilities the Morris Worm used and was deprecated in favor of the `fgets()` function which also takes a size parameter.

Details about specific situations that could lead to buffer overflows that this patch addresses have been privately shared with some GZDoom maintainers I could find in the Discord server.

This PR fixes these functions by replacing the `uint8_t **stream` parameters with `TArrayView<uint8_t>& stream` parameters, representing the pointer into the buffer and the remaining size of the buffer together. Once the core stream helper functions (like `WriteInt32()`, `WriteString()`, etc) were updated for this change, many other functions needed no or minimal changes beyond the parameter type change since they did nothing with the stream directly besides passing it to other functions that take a stream parameter.

The only observable behavior change of the second commit should be that `I_Error()` is called in cases where previously a buffer overflow would have happened. There are no changes to what heap allocations/reallocations/deallocations happen.

I did consider a few approaches, and I thought this solution was the smallest convenient change that safely addressed the issue:

- Some functions only receive a stream pointer within a specific global buffer, so it would be possible for those functions to compare the stream pointer against the global buffer and its known size, but it's not a general solution, and many other functions are more general and receive a stream pointer to one of several buffers, so this could not work for them. These functions would need to be passed the length of the buffer somehow, and it's probably best to adopt a consistent solution.
- I considered adding an additional `uint8_t *end` or `size_t& len` parameter to all the stream-accepting functions, but this made the function signatures more complex (especially since it'd be two different kinds of pointers bundled together) and seemingly easier to mess up using. Using a single struct or class that represents both the buffer pointer and the end or remaining size would be equivalent in power while being more convenient and harder to make a mistake with.
- I considered using a `std::span` parameter, as it seems to be the C++ standard library's idiomatic solution for this (equivalent to the basic slice type from Go, Rust, and Zig, consisting of just a pointer and a length value paired together), but this would require C++20 and GZDoom is still using C++17. (I discovered `TArrayView` when I did a search for `std::span` in the codebase and found a comment next to `TArrayView` suggesting that it had the same purpose, which appears accurate. I expect that `TArrayView` could be painlessly replaced with `std::span` in the future.)
- There are certain stream-writing functions where it might make sense to switch to passing an auto-expanding buffer (ie. `std::vector` or `TArray`) or a custom stream class with read/write-and-advance methods instead of a lone pointer into a fixed-size buffer, but that would be a bigger change than I wanted to make in this specific PR. My goal here is just to add buffer size checks to the existing code with minimal abstraction and no other behavior changes.

Some of the existing stream-handling functions would, instead of incrementing the `stream` pointer, return a `size_t` representing the number of bytes written, which would then be used to increment the `stream` pointer in the caller. These functions have been changed to be consistent with the other stream-handling functions that return `void` and directly increment the `stream` pointer. This simplifies things and removes the possibility of the final return statement miscalculating the step amount. (The occasional cases where the return value was disregarded and the caller had its own logic for stepping forward, such as when the stream is stepped forward by a length header value previously read after the chunk is processed, have been handled correctly.)

This patch mostly only touches the `stream` views of various buffers and not the underlying buffers themselves, with the exception of `demobuffer`. That buffer had multiple pointers into it in addition to the stream-like `demo_p` pointer and was malloc'ed/realloc'ed close to where those other pointers were used. I found it clearest to make `demobuffer` into a `TArray` to make its ownership over its memory explicit, differentiating it from the other pointers. It still allocates and reallocates at the same places, so the behavior is unchanged.

While working on this patch, I discovered a minor corruption bug in writing demos. I investigated and addressed that separately in https://github.com/ZDoom/gzdoom/pull/3153 so that this patch could have no behavioral changes besides the added bounds checking.

Several places now use the Write___() stream helper functions instead of doing repeated pointer arithmetic for copying strings or blocks of memory, which in addition to the proper bounds checking has the benefit of being easier to read and less prone to mistakes like the above one.

I've tested this patch in a lot of singleplayer games across maps in my normal playthroughs without complications, and I've done some light testing of multiplayer and demos. I've stepped through the few tricky places (demo compression and decompression) in a debugger to make the TArrayView sizes stay right.

I'm willing to port this patch to Raze or 4.14.x.