### PR TITLE
Expose FStrifeDialogueReply's CloseDialog to ZScript

### DIFF
--- a/src/p_conversation.cpp
+++ b/src/p_conversation.cpp
@@ -761,3 +761,4 @@ DEFINE_FIELD(FStrifeDialogueReply, LogString);
 DEFINE_FIELD(FStrifeDialogueReply, NextNode);
 DEFINE_FIELD(FStrifeDialogueReply, LogNumber);
 DEFINE_FIELD(FStrifeDialogueReply, NeedsGold);
+DEFINE_FIELD(FStrifeDialogueReply, CloseDialog);

--- a/wadsrc/static/zscript/ui/menu/conversationmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/conversationmenu.zs
@@ -65,6 +65,7 @@ struct StrifeDialogueReply native version("2.4")
 	native int NextNode;	// index into StrifeDialogues
 	native int LogNumber;
 	native bool NeedsGold;
+	native bool CloseDialog;
 	
 	native bool ShouldSkipReply(PlayerInfo player);
 }


### PR DESCRIPTION
Quick addition to expose FStrifeDialogueReply's CloseDialog to ZScript. Currently when making custom conversationmenus it is impossible to know if a given reply is intended to close the menu, this addition makes implementing custom behavior less difficult.