### PR TITLE
Silence some warning spam

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -1313,7 +1313,7 @@ void DAutomap::changeWindowLoc ()
 
 void DAutomap::startDisplay()
 {
-	int pnum;
+	uint pnum;
 
 	f_oldloc.x = FLT_MAX;
 	amclock = 0;
@@ -2809,7 +2809,7 @@ void DAutomap::drawPlayers ()
 
 	mpoint_t pt;
 	DAngle angle;
-	int i;
+	uint i;
 
 	if (!multiplayer)
 	{

--- a/src/common/engine/i_interface.cpp
+++ b/src/common/engine/i_interface.cpp
@@ -75,7 +75,7 @@ FStartupSelectionInfo::FStartupSelectionInfo(const TArray<WadStuff>& wads, FArgs
 
 	if (defaultiwad[0] != '\0')
 	{
-		for (int i = 0; i < wads.Size(); ++i)
+		for (int i = 0; i < wads.SSize(); ++i)
 		{
 			if (!wads[i].Name.CompareNoCase(defaultiwad))
 			{
@@ -89,7 +89,7 @@ FStartupSelectionInfo::FStartupSelectionInfo(const TArray<WadStuff>& wads, FArgs
 
 	if (defaultnetiwad[0] != '\0')
 	{
-		for (int i = 0; i < wads.Size(); ++i)
+		for (int i = 0; i < wads.SSize(); ++i)
 		{
 			if (!wads[i].Name.CompareNoCase(defaultnetiwad))
 			{

--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -494,7 +494,7 @@ static void SendPacket(const sockaddr_in& to)
 	// Huge packets should be sent out as sequences, not as one big packet, otherwise it's prone
 	// to high amounts of congestion and reordering needed.
 	if (NetBufferLength > MAX_MSGLEN)
-		I_FatalError("Netbuffer overflow: Tried to send %u bytes of data", NetBufferLength);
+		I_FatalError("Netbuffer overflow: Tried to send %lu bytes of data", NetBufferLength);
 
 	assert(!(NetBuffer[0] & NCMD_COMPRESSED));
 
@@ -973,7 +973,7 @@ static bool HostGame(int arg, bool forcedNetMode)
 	}
 
 	if (MaxClients > MAXPLAYERS)
-		I_FatalError("Cannot host a game with %u players. The limit is currently %u", MaxClients, MAXPLAYERS);
+		I_FatalError("Cannot host a game with %u players. The limit is currently %lu", MaxClients, MAXPLAYERS);
 
 	GenerateGameID();
 	NetworkClients += 0;
@@ -1247,7 +1247,7 @@ static bool JoinGame(int arg)
 		throw CExitEvent(0);
 	}
 
-	for (size_t i = 1u; i < MaxClients; ++i)
+	for (int i = 1u; i < MaxClients; ++i)
 	{
 		if (Connected[i].Status != CSTAT_NONE)
 			Connected[i].Status = CSTAT_READY;

--- a/src/common/scripting/dap/BreakpointManager.cpp
+++ b/src/common/scripting/dap/BreakpointManager.cpp
@@ -207,7 +207,7 @@ dap::ResponseOrError<dap::SetBreakpointsResponse> BreakpointManager::SetBreakpoi
 				found.pop();
 				continue;
 			}
-			for (int i = 0; i < func->LineInfoCount; i++)
+			for (uint i = 0; i < func->LineInfoCount; i++)
 			{
 				if (func->LineInfo[i].LineNumber == line)
 				{
@@ -453,7 +453,7 @@ dap::ResponseOrError<dap::SetInstructionBreakpointsResponse> BreakpointManager::
 
 	dap::SetInstructionBreakpointsResponse response;
 	ClearBreakpointsType(BreakpointInfo::Type::Instruction);
-	for (int i = 0; i < breakpoints.size(); i++)
+	for (uint i = 0; i < breakpoints.size(); i++)
 	{
 		auto &bp = breakpoints[i];
 		void *srcAddress = (void *)(std::stoull(bp.instructionReference.substr(2), nullptr, 16));

--- a/src/common/scripting/dap/DebugExecutionManager.cpp
+++ b/src/common/scripting/dap/DebugExecutionManager.cpp
@@ -337,7 +337,7 @@ dap::array<dap::Breakpoint> DebugExecutionManager::SetExceptionBreakpointFilters
 {
 	m_exceptionFilters.clear();
 	dap::array<dap::Breakpoint> breakpoints;
-	for (int i = 0; i < filterIds.size(); i++)
+	for (uint i = 0; i < filterIds.size(); i++)
 	{
 		auto breakpoint = dap::Breakpoint();
 		int64_t id = (int64_t)DebugExecutionManager::GetFilterID(filterIds[i]);

--- a/src/common/scripting/dap/GameInterfaces.h
+++ b/src/common/scripting/dap/GameInterfaces.h
@@ -750,7 +750,7 @@ static std::string GetParameterName(const VMFrame *m_stackFrame, int paramidx)
 	static const char *const INVOKER = "invoker";
 	static const char *const STATE_POINTER = "stateinfo";
 
-	auto implicitCount = GetImplicitParmeterCount(m_stackFrame);
+	int implicitCount = GetImplicitParmeterCount(m_stackFrame);
 	if (paramidx < implicitCount)
 	{
 		switch (paramidx)
@@ -771,7 +771,7 @@ static std::string GetParameterName(const VMFrame *m_stackFrame, int paramidx)
 	if (variant)
 	{
 		auto &params = variant->ArgNames;
-		if (paramidx < params.Size())
+		if (paramidx < params.SSize())
 		{
 			return params[paramidx].GetChars();
 		}

--- a/src/common/scripting/dap/Nodes/ArrayStateNode.cpp
+++ b/src/common/scripting/dap/Nodes/ArrayStateNode.cpp
@@ -214,7 +214,7 @@ bool ArrayStateNode::GetChildNode(std::string name, std::shared_ptr<StateNodeBas
 				break;
 			default:
 				// too large, return a ptr to the array element
-				assert(elementIndex <= static_cast<FArray *>(array_head)->Count);
+				assert(unsigned(elementIndex) <= static_cast<FArray *>(array_head)->Count);
 				element_val = VMValue((void *)(((char *)static_cast<FArray *>(array_head)->Array) + (elementIndex * elementType->Size)));
 			}
 		}

--- a/src/common/scripting/dap/Nodes/StackFrameStateNode.cpp
+++ b/src/common/scripting/dap/Nodes/StackFrameStateNode.cpp
@@ -67,7 +67,7 @@ bool StackFrameStateNode::SerializeToProtocol(dap::StackFrame &stackFrame, PexCa
 			{
 				// end of the function, get the max line number
 				int max_line = 0;
-				for (int i = 0; i < scriptFunction->LineInfoCount; i++)
+				for (uint i = 0; i < scriptFunction->LineInfoCount; i++)
 				{
 					if (scriptFunction->LineInfo[i].LineNumber > max_line)
 					{

--- a/src/common/scripting/dap/ZScriptDebugger.cpp
+++ b/src/common/scripting/dap/ZScriptDebugger.cpp
@@ -489,7 +489,7 @@ dap::ResponseOrError<dap::VariablesResponse> ZScriptDebugger::GetVariables(const
 	bool only_indexed = request.filter.value("") == "indexed";
 	bool only_named = request.filter.value("") == "named";
 
-	for (int64_t i = 0; i < variableNodes.size(); i++)
+	for (int64_t i = 0; i < (int64_t)variableNodes.size(); i++)
 	{
 		auto asVariableSerializable = dynamic_cast<IProtocolVariableSerializable *>(variableNodes.at(i).get());
 		if (!asVariableSerializable)

--- a/src/common/scripting/vm/vmframe.cpp
+++ b/src/common/scripting/vm/vmframe.cpp
@@ -577,9 +577,9 @@ VMFrame *VMFrameStack::PopFrame()
 
 void VMCheckParamCount(VMFunction* func, int retcount, int argcount)
 {
-	if (func->Proto->ReturnTypes.Size() != retcount)
+	if (func->Proto->ReturnTypes.SSize() != retcount)
 		I_FatalError("Incorrect return value passed to %s", func->PrintableName);
-	if (func->Proto->ArgumentTypes.Size() != argcount)
+	if (func->Proto->ArgumentTypes.SSize() != argcount)
 		I_FatalError("Incorrect parameter count passed to %s", func->PrintableName);
 }
 

--- a/src/common/utility/basics.h
+++ b/src/common/utility/basics.h
@@ -25,6 +25,10 @@ typedef int32_t							fixed_t;
 
 typedef uint32_t			angle_t;
 
+#ifdef _WIN32
+typedef unsigned int		uint;
+#endif
+
 #if defined(__GNUC__)
 // With versions of GCC newer than 4.2, it appears it was determined that the
 // cost of an unaligned pointer on PPC was high enough to add padding to the

--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -254,7 +254,7 @@ CCMD (chase)
 {
 	if (demoplayback)
 	{
-		int i;
+		uint i;
 
 		if (chasedemo)
 		{

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -261,7 +261,7 @@ CUSTOM_CVAR (Int, fraglimit, 0, CVAR_SERVERINFO)
 	// lowered below somebody's current frag count.
 	if (deathmatch && self > 0)
 	{
-		for (int i = 0; i < MAXPLAYERS; ++i)
+		for (uint i = 0; i < MAXPLAYERS; ++i)
 		{
 			if (playeringame[i] && self <= D_GetFragCount(&players[i]))
 			{
@@ -509,7 +509,7 @@ CUSTOM_CVAR (Int, dmflags2, 0, CVAR_SERVERINFO | CVAR_NOINITCALL)
 	if ((self & DF2_NO_AUTOMAP) && automapactive)
 		AM_Stop ();
 
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		player_t *p = &players[i];
 
@@ -2236,7 +2236,7 @@ static void CheckEpisodeCmd()
 	if (v != nullptr)
 	{
 		episode = atoi(v) - 1;
-		if (episode < 0 || episode >= AllEpisodes.Size())
+		if (episode < 0 || episode >= AllEpisodes.SSize())
 		{
 			Printf("Invalid episode %s\n", v);
 			episode = 0;
@@ -3039,7 +3039,7 @@ static void GC_MarkGameRoots()
 		Level->Mark();
 
 	// Mark players.
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (playeringame[i])
 			players[i].PropagateMark();

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -367,7 +367,7 @@ void Net_ClearBuffers()
 {
 	CloseNetwork();
 
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		playeringame[i] = false;
 		players[i].waiting = players[i].inconsistant = false;
@@ -579,7 +579,7 @@ static size_t GetNetBufferSize()
 	}
 
 	// Header info
-	int totalBytes = 10;
+	uint totalBytes = 10;
 	if (NetBuffer[0] & NCMD_QUITTERS)
 		totalBytes += NetBuffer[totalBytes] + 1;
 
@@ -3387,7 +3387,7 @@ CCMD(listmuted)
 	}
 
 	bool found = false;
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (MutedClients & ((uint64_t)1u << i))
 		{

--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -265,7 +265,7 @@ int D_PickRandomTeam ()
 	int numTeams = 0;
 	int team;
 
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (playeringame[i])
 		{
@@ -380,7 +380,7 @@ int D_GetFragCount (player_t *player)
 		// Count total frags for this player's team
 		int count = 0;
 
-		for (int i = 0; i < MAXPLAYERS; ++i)
+		for (uint i = 0; i < MAXPLAYERS; ++i)
 		{
 			if (playeringame[i] && players[i].userinfo.GetTeam() == team)
 			{
@@ -393,7 +393,7 @@ int D_GetFragCount (player_t *player)
 
 void D_SetupUserInfo ()
 {
-	int i;
+	uint i;
 	userinfo_t *coninfo;
 
 	// Reset everybody's userinfo to a default state.
@@ -1019,7 +1019,7 @@ void ReadUserInfo(FSerializer &arc, userinfo_t &info, FString &skin)
 CCMD(playerinfo)
 {
 	TArray<int> inGame = {};
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (playeringame[i])
 			inGame.Push(i);

--- a/src/g_dumpinfo.cpp
+++ b/src/g_dumpinfo.cpp
@@ -347,7 +347,7 @@ CCMD(dumplinktable)
 
 CCMD(printinv)
 {
-	int pnum = consoleplayer;
+	uint pnum = consoleplayer;
 
 #ifdef _DEBUG
 	// Only allow peeking on other players' inventory in debug builds.
@@ -446,7 +446,7 @@ CCMD(listsnapshots)
 		FCompressedBuffer *snapshot = &wadlevelinfos[i].Snapshot;
 		if (snapshot->mBuffer != nullptr)
 		{
-			Printf("%s (%u -> %u bytes)\n", wadlevelinfos[i].MapName.GetChars(), snapshot->mCompressedSize, snapshot->mSize);
+			Printf("%s (%lu -> %lu bytes)\n", wadlevelinfos[i].MapName.GetChars(), snapshot->mCompressedSize, snapshot->mSize);
 		}
 	}
 }

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1154,7 +1154,7 @@ void G_Ticker ()
 
 	// do player reborns if needed
 	// TODO: These should really be moved to queues.
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (!playeringame[i])
 			continue;
@@ -1473,7 +1473,7 @@ double FLevelLocals::PlayersRangeFromSpot (FPlayerStart *spot)
 {
 	double closest = INT_MAX;
 	double distance;
-	int i;
+	uint i;
 
 	for (i = 0; i < MAXPLAYERS; i++)
 	{
@@ -1569,7 +1569,7 @@ void FLevelLocals::DeathMatchSpawnPlayer (int playernum)
 		I_Error ("No deathmatch starts");
 
 	bool hasSpawned = false;
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (PlayerInGame(i) && Players[i]->mo != nullptr && Players[i]->health > 0)
 		{
@@ -1799,7 +1799,7 @@ void G_DoPlayerPop(int playernum)
 	Printf("%s\n", message.GetChars());
 
 	// [RH] Revert each player to their own view if spying through the player who left
-	for (int ii = 0; ii < MAXPLAYERS; ++ii)
+	for (int ii = 0; ii < signed(MAXPLAYERS); ++ii)
 	{
 		if (playeringame[ii] && players[ii].camera == players[playernum].mo)
 		{
@@ -2604,7 +2604,7 @@ void G_RecordDemo (const char* name)
 
 void G_BeginRecording (const char *startmap)
 {
-	int i;
+	uint i;
 
 	if (startmap == NULL)
 	{
@@ -2718,7 +2718,8 @@ bool G_ProcessIFFDemo (FString &mapname)
 	bool headerHit = false;
 	bool bodyHit = false;
 	int numPlayers = 0;
-	int id, len, i;
+	int id, len;
+	uint i;
 	uLong uncompSize = 0;
 	uint8_t *nextchunk;
 
@@ -2991,7 +2992,7 @@ bool G_CheckDemoStatus (void)
 		demoplayback = false;
 		netgame = false;
 		multiplayer = false;
-		for (int i = 1; i < MAXPLAYERS; i++)
+		for (uint i = 1; i < MAXPLAYERS; i++)
 			playeringame[i] = 0;
 		consoleplayer = 0;
 		players[0].camera = nullptr;

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -454,7 +454,7 @@ UNSAFE_CCMD (open)
 
 void G_NewInit ()
 {
-	int i;
+	uint i;
 
 	// Destory all old player refrences that may still exist
 	TThinkerIterator<AActor> it(primaryLevel, NAME_PlayerPawn, STAT_TRAVELLING, false);
@@ -536,7 +536,7 @@ static void InitPlayerClasses ()
 {
 	if (!savegamerestore)
 	{
-		for (int i = 0; i < MAXPLAYERS; ++i)
+		for (uint i = 0; i < MAXPLAYERS; ++i)
 		{
 			SinglePlayerClass[i] = players[i].userinfo.GetPlayerClassNum();
 			if (SinglePlayerClass[i] < 0 || !playeringame[i])
@@ -557,7 +557,7 @@ static void InitPlayerClasses ()
 void G_InitNew (const char *mapname, bool bTitleLevel)
 {
 	bool wantFast;
-	int i;
+	uint i;
 
 	// did we have any level before?
 	if (primaryLevel->info != nullptr)
@@ -821,7 +821,7 @@ void FLevelLocals::ChangeLevel(const char *levelname, int position, int inflags,
 		D_DrawIcon = "TELEICON";
 	}
 
-	for(int i = 0; i < MAXPLAYERS; i++)
+	for(uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (PlayerInGame(i))
 		{
@@ -1156,7 +1156,7 @@ void G_DoCompleted (void)
 
 bool FLevelLocals::DoCompleted (FString nextlevel, wbstartstruct_t &wminfo)
 {
-	int i;
+	uint i;
 
 	// [RH] Mark this level as having been visited
 	if (!(flags & LEVEL_CHANGEMAPCHEAT))
@@ -1381,7 +1381,7 @@ void G_DoLoadLevel(const FString &nextmapname, int position, bool autosave, bool
 void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool autosave, bool newGame)
 {
 	MapName = nextmapname;
-	int i;
+	uint i;
 
 	if (NextSkill >= 0)
 	{
@@ -1482,7 +1482,7 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 
 	if (!FromSnapshot)
 	{
-		for (int i = 0; i<MAXPLAYERS; i++)
+		for (uint i = 0; i < MAXPLAYERS; i++)
 		{
 			if (PlayerInGame(i) && Players[i]->mo != nullptr)
 				P_PlayerStartStomp(Players[i]->mo, !deathmatch);
@@ -1490,7 +1490,7 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 	}
 
 	// For each player, if they are viewing through a player, make sure it is themselves.
-	for (int ii = 0; ii < MAXPLAYERS; ++ii)
+	for (uint ii = 0; ii < MAXPLAYERS; ++ii)
 	{
 		if (PlayerInGame(ii))
 		{
@@ -1621,7 +1621,7 @@ void FLevelLocals::StartTravel ()
 	if (deathmatch)
 		return;
 
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (playeringame[i])
 		{
@@ -1809,7 +1809,7 @@ FLevelLocals::FLevelLocals() : Behaviors(this), tagManager(this)
 {
 	// Make sure that these point to the right data all the time.
 	// This will be needed for as long as it takes to completely separate global UI state from per-level play state.
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		Players[i] = &players[i];
 	}
@@ -2024,7 +2024,7 @@ void G_WriteVisited(FSerializer &arc)
 
 	if (arc.BeginObject("playerclasses"))
 	{
-		for (int i = 0; i < MAXPLAYERS; ++i)
+		for (uint i = 0; i < MAXPLAYERS; ++i)
 		{
 			if (playeringame[i])
 			{
@@ -2098,7 +2098,7 @@ void G_ReadVisited(FSerializer &arc)
 
 	if (arc.BeginObject("playerclasses"))
 	{
-		for (int i = 0; i < MAXPLAYERS; ++i)
+		for (uint i = 0; i < MAXPLAYERS; ++i)
 		{
 			FStringf key("%d", i);
 			arc(key.GetChars(), players[i].cls);

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -621,7 +621,7 @@ public:
 	// This needs to be done better, but for now it should be good enough.
 	bool PlayerInGame(player_t *player)
 	{
-		for (int i = 0; i < MAXPLAYERS; i++)
+		for (uint i = 0; i < MAXPLAYERS; i++)
 		{
 			if (player == Players[i]) return PlayerInGame(i);
 		}
@@ -630,7 +630,7 @@ public:
 
 	int PlayerNum(player_t *player)
 	{
-		for (int i = 0; i < MAXPLAYERS; i++)
+		for (uint i = 0; i < MAXPLAYERS; i++)
 		{
 			if (player == Players[i]) return i;
 		}

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -399,7 +399,7 @@ level_info_t *level_info_t::CheckLevelRedirect ()
 		PClassActor *type = PClass::FindActor(RedirectType);
 		if (type != NULL)
 		{
-			for (int i = 0; i < MAXPLAYERS; ++i)
+			for (uint i = 0; i < MAXPLAYERS; ++i)
 			{
 				if (playeringame[i] && players[i].mo->FindInventory(type))
 				{
@@ -421,7 +421,7 @@ level_info_t *level_info_t::CheckLevelRedirect ()
 			if (var->GetFlags() & CVAR_USERINFO)
 			{
 				// user sync'd cvar, check for all players
-				for (int i = 0; i < MAXPLAYERS; ++i)
+				for (uint i = 0; i < MAXPLAYERS; ++i)
 				{
 					if (playeringame[i] && (var = GetCVar(i, RedirectCVAR.GetChars())))
 					{

--- a/src/launcher/networkpage.cpp
+++ b/src/launcher/networkpage.cpp
@@ -54,7 +54,7 @@ NetworkPage::NetworkPage(LauncherWindow* launcher, const FStartupSelectionInfo& 
 		IWADsList->AddItem(work.GetChars());
 	}
 
-	if (info.DefaultNetIWAD >= 0 && info.DefaultNetIWAD < info.Wads->Size())
+	if (info.DefaultNetIWAD >= 0 && info.DefaultNetIWAD < info.Wads->SSize())
 	{
 		IWADsList->SetSelectedItem(info.DefaultNetIWAD);
 		IWADsList->ScrollToItem(info.DefaultNetIWAD);

--- a/src/launcher/playgamepage.cpp
+++ b/src/launcher/playgamepage.cpp
@@ -41,7 +41,7 @@ PlayGamePage::PlayGamePage(LauncherWindow* launcher, const FStartupSelectionInfo
 		GamesList->AddItem(work.GetChars());
 	}
 
-	if (info.DefaultIWAD >= 0 && info.DefaultIWAD < info.Wads->Size())
+	if (info.DefaultIWAD >= 0 && info.DefaultIWAD < info.Wads->SSize())
 	{
 		GamesList->SetSelectedItem(info.DefaultIWAD);
 		GamesList->ScrollToItem(info.DefaultIWAD);

--- a/src/maploader/maploader.cpp
+++ b/src/maploader/maploader.cpp
@@ -500,7 +500,7 @@ void MapLoader::LoadGLZSegs (FileReader &data, int type)
 
 			if (partner != 0xffffffffu && partner >= Level->segs.Size())
 			{
-				I_Error("partner seg index out of range for subsector %d, seg %d", i, j);
+				I_Error("partner seg index out of range for subsector %d, seg %lu", i, j);
 			}
 
 			if (type >= 2)
@@ -3209,7 +3209,7 @@ void MapLoader::LoadLevel(MapData *map, const char *lumpname, int position)
 		LoadLightmap(map);
 	}
 
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (Level->PlayerInGame(i) && Level->Players[i]->mo != nullptr)
 			Level->Players[i]->health = Level->Players[i]->mo->health;

--- a/src/p_conversation.cpp
+++ b/src/p_conversation.cpp
@@ -322,7 +322,7 @@ void P_FreeStrifeConversations ()
 void P_StartConversation (AActor *npc, AActor *pc, bool facetalker, bool saveangle)
 {
 	AActor *oldtarget;
-	int i;
+	uint i;
 
 	// Make sure this is actually a player.
 	if (pc == nullptr || pc->player == nullptr || npc == nullptr || !pc->Level->isPrimaryLevel()) return;
@@ -377,7 +377,7 @@ void P_StartConversation (AActor *npc, AActor *pc, bool facetalker, bool saveang
 	while (CurNode->ItemCheck.Size() > 0 && CurNode->ItemCheck[0].Item != NULL)
 	{
 		bool jump = true;
-		for (i = 0; i < (int)CurNode->ItemCheck.Size(); ++i)
+		for (i = 0; i < CurNode->ItemCheck.Size(); ++i)
 		{
 			if(!CheckStrifeItem (pc->player, CurNode->ItemCheck[i].Item, CurNode->ItemCheck[i].Amount))
 			{
@@ -446,7 +446,7 @@ void P_StartConversation (AActor *npc, AActor *pc, bool facetalker, bool saveang
 
 void P_ResumeConversation ()
 {
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (!playeringame[i])
 			continue;

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -603,7 +603,7 @@ void FLevelLocals::SerializeSounds(FSerializer &arc)
 void FLevelLocals::SerializePlayers(FSerializer &arc, bool skipload)
 {
 	int numPlayers, numPlayersNow;
-	int i;
+	uint i;
 
 	// Count the number of players present right now.
 	for (numPlayersNow = 0, i = 0; i < MAXPLAYERS; ++i)
@@ -690,7 +690,7 @@ void FLevelLocals::ReadOnePlayer(FSerializer &arc, bool fromHub)
 	player_t temp = {};
 	temp.Serialize(arc);
 
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (!PlayerInGame(i))
 			continue;
@@ -751,7 +751,7 @@ void FLevelLocals::ReadMultiplePlayers(FSerializer &arc, int numPlayers, bool fr
 	// based on their names. If two players in the savegame have the
 	// same name, then they are assigned to players in the current game
 	// on a first-come, first-served basis.
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (!PlayerInGame(i))
 			continue;
@@ -780,7 +780,7 @@ void FLevelLocals::ReadMultiplePlayers(FSerializer &arc, int numPlayers, bool fr
 
 	// Any players that didn't have matching names are assigned to existing
 	// players on a first-come, first-served basis.
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (!PlayerInGame(i) || assignedPlayers[i])
 			continue;
@@ -893,7 +893,7 @@ void FLevelLocals::SpawnExtraPlayers()
 {
 	// If there are more players now than there were in the savegame,
 	// be sure to spawn the extra players.
-	int i;
+	uint i;
 
 	if (deathmatch || !isPrimaryLevel())
 	{
@@ -1046,7 +1046,7 @@ void FLevelLocals::Serialize(FSerializer &arc, bool hubload)
 		{
 			P_Recalculate3DFloors(&sec);
 		}
-		for (int i = 0; i < MAXPLAYERS; ++i)
+		for (uint i = 0; i < MAXPLAYERS; ++i)
 		{
 			if (PlayerInGame(i) && Players[i]->mo != nullptr)
 			{
@@ -1125,7 +1125,7 @@ void FLevelLocals::UnSnapshotLevel(bool hubLoad)
 			next = it.Next();
 			if (pawn->player == nullptr || pawn->player->mo == nullptr || !PlayerInGame(pawn->player))
 			{
-				int i;
+				uint i;
 
 				// If this isn't the unmorphed original copy of a player, destroy it, because it's extra.
 				for (i = 0; i < MAXPLAYERS; ++i)

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -426,7 +426,7 @@ void P_FreeLevelData (bool fullgc)
 
 void P_SetupLevel(FLevelLocals *Level, int position, bool newGame)
 {
-	int i;
+	uint i;
 
 	Level->ShaderStartTime = I_msTimeFS(); // indicate to the shader system that the level just started
 

--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -68,7 +68,7 @@ void P_RunClientsideLogic()
 
 	if (gamestate == GS_LEVEL || gamestate == GS_TITLELEVEL)
 	{
-		for (int i = 0; i < MAXPLAYERS; ++i)
+		for (uint i = 0; i < MAXPLAYERS; ++i)
 		{
 			if (playeringame[i] && players[i].inventorytics > 0)
 				--players[i].inventorytics;
@@ -147,7 +147,7 @@ void P_ClearLevelInterpolation()
 		}
 	}
 
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (playeringame[i])
 		{
@@ -171,7 +171,7 @@ void P_ClearLevelInterpolation()
 //
 void P_Ticker (void)
 {
-	int i;
+	uint i;
 
 	for (auto Level : AllLevels())
 	{

--- a/src/playsim/bots/b_func.cpp
+++ b/src/playsim/bots/b_func.cpp
@@ -283,7 +283,7 @@ void DBot::Dofire (usercmd_t *cmd)
 
 bool FCajunMaster::IsLeader (player_t *player)
 {
-	for (int count = 0; count < MAXPLAYERS; count++)
+	for (uint count = 0; count < MAXPLAYERS; count++)
 	{
 		if (players[count].Bot != NULL
 			&& players[count].Bot->mate == player->mo)
@@ -301,7 +301,7 @@ void FCajunMaster::BotTick(AActor *mo)
 {
 	BotSupportCycles.Clock();
 	m_Thinking = true;
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (!playeringame[i] || players[i].Bot == NULL)
 			continue;
@@ -342,7 +342,7 @@ void FCajunMaster::BotTick(AActor *mo)
 //the mate (teammate coop mate).
 AActor *DBot::Choose_Mate ()
 {
-	int count;
+	uint count;
 	double closest_dist, test;
 	AActor *target;
 
@@ -413,7 +413,7 @@ AActor *DBot::Choose_Mate ()
 //MAKEME: Make this a smart decision
 AActor *DBot::Find_enemy ()
 {
-	int count;
+	uint count;
 	double closest_dist, temp; //To target.
 	AActor *target;
 	DAngle vangle;
@@ -580,7 +580,7 @@ bool FCajunMaster::SafeCheckPosition (AActor *actor, double x, double y, FCheckP
 
 void FCajunMaster::StartTravel ()
 {
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (players[i].Bot != NULL)
 		{
@@ -591,7 +591,7 @@ void FCajunMaster::StartTravel ()
 
 void FCajunMaster::FinishTravel ()
 {
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (players[i].Bot != NULL)
 		{

--- a/src/playsim/bots/b_game.cpp
+++ b/src/playsim/bots/b_game.cpp
@@ -186,7 +186,7 @@ void FCajunMaster::Init ()
 //Called on each level exit (from g_game.c).
 void FCajunMaster::End ()
 {
-	int i;
+	uint i;
 
 	//Arrange wanted botnum and their names, so they can be spawned next level.
 	getspawned.Clear();
@@ -365,7 +365,7 @@ void FCajunMaster::TryAddBot (FLevelLocals *Level, TArrayView<uint8_t>& stream, 
 
 bool FCajunMaster::DoAddBot (FLevelLocals *Level, TArrayView<uint8_t> info, botskill_t skill)
 {
-	int bnum;
+	uint bnum;
 
 	for (bnum = 0; bnum < MAXPLAYERS; bnum++)
 	{
@@ -377,7 +377,7 @@ bool FCajunMaster::DoAddBot (FLevelLocals *Level, TArrayView<uint8_t> info, bots
 
 	if (bnum == MAXPLAYERS)
 	{
-		Printf ("The maximum of %d players/bots has been reached\n", MAXPLAYERS);
+		Printf ("The maximum of %lu players/bots has been reached\n", MAXPLAYERS);
 		return false;
 	}
 
@@ -403,7 +403,7 @@ bool FCajunMaster::DoAddBot (FLevelLocals *Level, TArrayView<uint8_t> info, bots
 
 void FCajunMaster::RemoveAllBots (FLevelLocals *Level, bool fromlist)
 {
-	int i, j;
+	uint i, j;
 
 	for (i = 0; i < MAXPLAYERS; ++i)
 	{

--- a/src/playsim/fragglescript/t_func.cpp
+++ b/src/playsim/fragglescript/t_func.cpp
@@ -263,7 +263,7 @@ PClassActor * FParser::T_GetMobjType(svalue_t arg)
 //==========================================================================
 int FParser::T_GetPlayerNum(const svalue_t &arg)
 {
-	int playernum;
+	uint playernum;
 	if(arg.type == svt_mobj)
 	{
 		if(!actorvalue(arg) || !arg.value.mobj->player)

--- a/src/playsim/mapthinkers/a_quake.cpp
+++ b/src/playsim/mapthinkers/a_quake.cpp
@@ -114,7 +114,7 @@ void DEarthquake::Serialize(FSerializer &arc)
 
 void DEarthquake::Tick ()
 {
-	int i;
+	uint i;
 
 	if (m_Spot == NULL)
 	{

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -1776,7 +1776,7 @@ static int UseInventory (FLevelLocals *Level, AActor *activator, const char *typ
 	}
 	if (activator == NULL)
 	{
-		for (int i = 0; i < MAXPLAYERS; ++i)
+		for (uint i = 0; i < MAXPLAYERS; ++i)
 		{
 			if (Level->PlayerInGame(i))
 				ret += DoUseInv (Level->Players[i]->mo, info);
@@ -3753,7 +3753,7 @@ void DLevelScript::ChangeFlat (int tag, int name, bool floorOrCeiling)
 
 int DLevelScript::CountPlayers ()
 {
-	int count = 0, i;
+	uint count = 0, i;
 
 	for (i = 0; i < MAXPLAYERS; i++)
 		if (Level->PlayerInGame(i))
@@ -3906,7 +3906,7 @@ void DLevelScript::DoFadeRange (int r1, int g1, int b1, int a1,
 	bool fadingFrom = a1 >= 0;
 	float fr1 = 0, fg1 = 0, fb1 = 0, fa1 = 0;
 	float fr2, fg2, fb2, fa2;
-	int i;
+	uint i;
 
 	fr2 = (float)r2 / 255.f;
 	fg2 = (float)g2 / 255.f;
@@ -10189,7 +10189,7 @@ scriptwait:
 
 		case PCD_CHECKPLAYERCAMERA:
 			{
-				int playernum = STACK(1);
+				uint playernum = STACK(1);
 
 				if (playernum < 0 || playernum >= MAXPLAYERS || !Level->PlayerInGame(playernum) ||
 					Level->Players[playernum]->camera == nullptr || Level->Players[playernum]->camera->player != nullptr)

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -1745,7 +1745,7 @@ DEFINE_ACTION_FUNCTION(AActor, CheckIfSeen)
 	PARAM_SELF_PROLOGUE(AActor);
 
 	auto Level = self->Level;
-	for (int i = 0; i < MAXPLAYERS; i++) 
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (Level->PlayerInGame(i))
 		{
@@ -1818,7 +1818,7 @@ DEFINE_ACTION_FUNCTION(AActor, CheckSightOrRange)
 
 	range *= range;
 	auto Level = self->Level;
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (Level->PlayerInGame(i))
 		{
@@ -1848,7 +1848,7 @@ DEFINE_ACTION_FUNCTION(AActor, CheckRange)
 
 	range *= range;
 	auto Level = self->Level;
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (Level->PlayerInGame(i))
 		{

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -1776,7 +1776,7 @@ int P_LookForEnemies (AActor *actor, INTBOOL allaround, FLookExParams *params)
 
 int P_LookForPlayers (AActor *actor, INTBOOL allaround, FLookExParams *params)
 {
-	int 		c;
+	uint 		c;
 	int			pnum;
 	player_t*	player;
 	bool chasegoal = params? (!(params->flags & LOF_DONTCHASEGOAL)) : true;
@@ -3234,7 +3234,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_Pain)
 
 int CheckBossDeath (AActor *actor)
 {
-	int i;
+	uint i;
 
 	// make sure there is a player alive for victory
 	for (i = 0; i < MAXPLAYERS; i++)

--- a/src/playsim/p_interaction.cpp
+++ b/src/playsim/p_interaction.cpp
@@ -632,7 +632,7 @@ void AActor::Die (AActor *source, AActor *inflictor, int dmgflags, FName MeansOf
 				player->Bot->t_respawn = (pr_botrespawn()%15)+((Level->BotInfo.botnum-1)*2)+TICRATE+1;
 
 			//Added by MC: Discard enemies.
-			for (int i = 0; i < MAXPLAYERS; i++)
+			for (uint i = 0; i < MAXPLAYERS; i++)
 			{
 				DBot *Bot = Level->Players[i]->Bot;
 				if (Bot != nullptr && this == Bot->enemy)

--- a/src/playsim/p_lnspec.cpp
+++ b/src/playsim/p_lnspec.cpp
@@ -3018,7 +3018,7 @@ FUNC(LS_SetPlayerProperty)
 					if (power != 4)
 					{
 						auto item = p->mo->GiveInventoryType ((PClass::FindActor(powers[power])));
-						if (item != NULL && power == 0 && arg1 == 1) 
+						if (item != NULL && power == 0 && arg1 == 1)
 						{
 							item->ColorVar(NAME_BlendColor) = MakeSpecialColormap(INVERSECOLORMAP);
 						}

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6031,7 +6031,7 @@ void PlayerPointerSubstitution(AActor* oldPlayer, AActor* newPlayer, bool remove
 	}
 
 	// Go through player infos.
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (!oldPlayer->Level->PlayerInGame(i))
 			continue;
@@ -6152,7 +6152,7 @@ int MorphPointerSubstitution(AActor* from, AActor* to)
 	to->MoveBehaviors(*from);
 
 	// Go through player infos.
-	for (int i = 0; i < MAXPLAYERS; ++i)
+	for (uint i = 0; i < MAXPLAYERS; ++i)
 	{
 		if (!from->Level->PlayerInGame(i))
 			continue;
@@ -6388,7 +6388,7 @@ AActor *FLevelLocals::SpawnPlayer (FPlayerStart *mthing, int playernum, int flag
 		VMCall(func, params, 2, rets, 1);
 	}
 
-	for (int ii = 0; ii < MAXPLAYERS; ++ii)
+	for (uint ii = 0; ii < MAXPLAYERS; ++ii)
 	{
 		if (PlayerInGame(ii) && Players[ii]->camera == oldactor)
 		{
@@ -6621,7 +6621,7 @@ AActor *FLevelLocals::SpawnMapThing (FMapThing *mthing, int position)
 		else if (!deathmatch)
 		{ // Cooperative
 			mask = 0;
-			for (int i = 0; i < MAXPLAYERS; i++)
+			for (uint i = 0; i < MAXPLAYERS; i++)
 			{
 				if (PlayerInGame(i))
 				{

--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -458,7 +458,7 @@ void DPSprite::NewTick()
 	// This function should be called after the beginning of a tick, before any possible
 	// prprite-event, or near the end, after any possible psprite event.
 	// Because data is reset for every tick (which it must be) this has no impact on savegames.
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (playeringame[i])
 		{
@@ -1489,7 +1489,7 @@ ADD_STAT(psprites)
 {
 	FString out;
 	DPSprite *pspr;
-	for (int i = 0; i < MAXPLAYERS; i++)
+	for (uint i = 0; i < MAXPLAYERS; i++)
 	{
 		if (!playeringame[i])
 			continue;

--- a/src/playsim/p_spec.cpp
+++ b/src/playsim/p_spec.cpp
@@ -450,7 +450,7 @@ void P_ActorInSpecialSector (AActor *victim, sector_t * sector, F3DFloor* Ffloor
 
 	if (victim->player && sector->Flags & (SECF_EXIT1 | SECF_EXIT2))
 	{
-		for (int i = 0; i < MAXPLAYERS; i++)
+		for (uint i = 0; i < MAXPLAYERS; i++)
 			if (playeringame[i])
 				P_DamageMobj(players[i].mo, nullptr, nullptr, TELEFRAG_DAMAGE, NAME_InstantDeath);
 		if (sector->Flags & SECF_EXIT2)

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -524,7 +524,7 @@ DEFINE_ACTION_FUNCTION(_PlayerInfo, SetSkin)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(player_t);
 	PARAM_INT(skinIndex);
-	if (skinIndex >= 0 && skinIndex < Skins.size())
+	if (skinIndex >= 0 && skinIndex < Skins.SSize())
 	{
 		// commented code - cvar_set calls this automatically, along with saving the skin selection.
 		//self->userinfo.SkinNumChanged(skinIndex);

--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -558,7 +558,7 @@ bool CalcModelOverrides(int i, const FSpriteModelFrame *smf, DActorModelData* da
 		out.skinid = smf->skinIDs[i];
 	}
 
-	return (out.modelid >= 0 && out.modelid < Models.size());
+	return (out.modelid >= 0 && out.modelid < Models.SSize());
 }
 
 

--- a/src/r_data/r_translate.cpp
+++ b/src/r_data/r_translate.cpp
@@ -228,7 +228,7 @@ FTranslationID CreateBloodTranslation(PalEntry color)
 
 void R_InitTranslationTables ()
 {
-	int i;
+	uint i;
 
 	// Each player gets two translations. Doom and Strife don't use the
 	// extra ones, but Heretic and Hexen do. These are set up during


### PR DESCRIPTION
Compiling spits out 500+ sign-compare warnings on my system. Really annoying to look through a compile log for specific issues with that much noise. This fixes the trivial ones, reducing the spam down to 41 instances.