### PR TITLE
Allow the blood splat decal distance to be customizable in MAPINFO's GameInfo block

### DIFF
--- a/src/gamedata/gi.cpp
+++ b/src/gamedata/gi.cpp
@@ -79,6 +79,7 @@ DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, defaultdropstyle)
 DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, normforwardmove)
 DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, normsidemove)
 DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, mHideParTimes)
+DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, BloodSplatDecalDistance)
 
 const char *GameNames[17] =
 {
@@ -464,6 +465,7 @@ void FMapInfoParser::ParseGameInfo()
 			GAMEINFOKEY_TWODOUBLES(normsidemove, "normsidemove")
 			GAMEINFOKEY_BOOL(nomergepickupmsg, "nomergepickupmsg")
 			GAMEINFOKEY_BOOL(mHideParTimes, "hidepartimes")
+			GAMEINFOKEY_DOUBLE(BloodSplatDecalDistance, "bloodsplatdecaldistance")
 
 		else
 		{

--- a/src/gamedata/gi.h
+++ b/src/gamedata/gi.h
@@ -217,6 +217,7 @@ struct gameinfo_t
 	bool nomergepickupmsg;
 	bool mHideParTimes;
 	CutsceneDef IntroScene;
+	double BloodSplatDecalDistance;
 
 	const char *GetFinalePage(unsigned int num) const;
 };

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -84,6 +84,7 @@
 #include "events.h"
 #include "vm.h"
 #include "d_main.h"
+#include "gi.h"
 
 #include "decallib.h"
 
@@ -5264,7 +5265,11 @@ void P_TraceBleed(int damage, const DVector3 &pos, AActor *actor, DAngle angle, 
 		double cosp = bleedpitch.Cos();
 		DVector3 vdir = DVector3(cosp * bleedang.Cos(), cosp * bleedang.Sin(), -bleedpitch.Sin());
 
-		if (Trace(pos, actor->Sector, vdir, 172, 0, ML_BLOCKEVERYTHING, actor, bleedtrace, TRACE_NoSky))
+		double bleedDist = gameinfo.BloodSplatDecalDistance;
+		if (bleedDist <= 0.0)
+			bleedDist = (double)172.0;
+
+		if (Trace(pos, actor->Sector, vdir, bleedDist, 0, ML_BLOCKEVERYTHING, actor, bleedtrace, TRACE_NoSky))
 		{
 			if (bleedtrace.HitType == TRACE_HitWall)
 			{

--- a/wadsrc/static/mapinfo/common.txt
+++ b/wadsrc/static/mapinfo/common.txt
@@ -5,6 +5,7 @@ Gameinfo
 	CheatKey = "maparrows/key.txt"
 	EasyKey = "maparrows/ravenkey.txt"
 	PrecacheSounds = "misc/secret", "misc/teleport", "misc/fallingsplat", "misc/ripslop"
+	BloodSplatDecalDistance = 172.0
 }
 
 DoomEdNums

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -163,6 +163,7 @@ extend struct GameInfoStruct
 	native double normforwardmove[2];
 	native double normsidemove[2];
 	native bool mHideParTimes;
+	native readonly double BloodSplatDecalDistance;
 }
 
 extend class Object


### PR DESCRIPTION
Implements https://github.com/ZDoom/gzdoom/issues/3207

Example file hilariously changes the blood splat distance to 20k map pixels, essentially making the blood splats appear across practically unlimited distances.

[BloodSplatDistanceTest.zip](https://github.com/user-attachments/files/21334233/BloodSplatDistanceTest.zip)
