### PR TITLE
Added UUID for game sessions

### DIFF
--- a/src/common/engine/i_interface.cpp
+++ b/src/common/engine/i_interface.cpp
@@ -6,6 +6,7 @@
 #include "gstrings.h"
 #include "version.h"
 #include "m_argv.h"
+#include "m_random.h"
 
 static_assert(sizeof(void*) == 8,
 	"Only LP64/LLP64 builds are officially supported. "
@@ -182,3 +183,12 @@ int FStartupSelectionInfo::SaveInfo()
 	return DefaultIWAD;
 }
 
+FString GameUUID;
+static FRandom pr_uuid("GameUUID");
+
+FString GenerateUUID()
+{
+	FString uuid;
+	uuid.AppendFormat("%08X-%04X-4%03X-9%03X-%08X%04X", pr_uuid.GenRand32(), pr_uuid(UINT16_MAX), pr_uuid(4095), pr_uuid(4095), pr_uuid.GenRand32(), pr_uuid(UINT16_MAX));
+	return uuid;
+}

--- a/src/common/engine/i_interface.h
+++ b/src/common/engine/i_interface.h
@@ -13,6 +13,9 @@ class FConfigFile;
 class FArgs;
 struct FTranslationID;
 
+extern FString GameUUID;
+FString GenerateUUID();
+
 struct SystemCallbacks
 {
 	bool (*G_Responder)(event_t* ev);	// this MUST be set, otherwise nothing will work

--- a/src/common/menu/savegamemanager.h
+++ b/src/common/menu/savegamemanager.h
@@ -12,6 +12,7 @@ struct FSaveGameNode
 	FString SaveTitle;
 	FString Filename;
 	FString CreationTime;
+	FString UUID;
 	bool bOldVersion = false;
 	bool bMissingWads = false;
 	bool bNoDelete = false;
@@ -57,6 +58,7 @@ public:
 	FSaveGameNode *GetSavegame(int i);
 	void InsertNewSaveNode();
 	bool RemoveNewSaveNode();
+	int RemoveUUIDSaveSlots();
 
 };
 

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2009,6 +2009,7 @@ void G_DoLoadGame ()
 	arc("Save Version", SaveVersion);
 	arc("Engine", engine);
 	arc("Current Map", map);
+	arc("GameUUID", GameUUID);
 
 	if (engine.CompareNoCase(GAMESIG) != 0)
 	{
@@ -2386,6 +2387,7 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 	savegameinfo.AddString("Software", buf)
 		.AddString("Engine", GAMESIG)
 		("Save Version", ver)
+		("GameUUID", GameUUID)
 		.AddString("Title", description)
 		.AddString("Current Map", primaryLevel->MapName.GetChars());
 

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -636,6 +636,7 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 			players[i].playerstate = PST_ENTER;	// [BC]
 
 		STAT_StartNewGame(mapname);
+		GameUUID = GenerateUUID();
 	}
 
 	usergame = !bTitleLevel;		// will be set false if a demo

--- a/src/menu/loadsavemenu.cpp
+++ b/src/menu/loadsavemenu.cpp
@@ -102,6 +102,7 @@ void FSavegameManager::ReadSaveStrings()
 						FString iwad = arc.GetString("Game WAD");
 						FString title = arc.GetString("Title");
 						FString creationtime = arc.GetString("Creation Time");
+						FString uuid = arc.GetString("GameUUID");
 
 
 						if (engine.Compare(GAMESIG) != 0 || savever > SAVEVER)
@@ -128,6 +129,7 @@ void FSavegameManager::ReadSaveStrings()
 
 						FSaveGameNode *node = new FSaveGameNode;
 						node->Filename = entry.FilePath.c_str();
+						node->UUID = uuid;
 						node->bOldVersion = oldVer;
 						node->bMissingWads = missing;
 						node->SaveTitle = title;

--- a/wadsrc/static/zscript/engine/ui/menu/loadsavemenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/loadsavemenu.zs
@@ -38,6 +38,7 @@ struct SaveGameNode native
 {
 	native String SaveTitle;
 	native readonly String Filename;
+	native readonly String UUID;
 	native bool bOldVersion;
 	native bool bMissingWads;
 	native bool bNoDelete;
@@ -68,6 +69,7 @@ struct SavegameManager native ui
 	native SaveGameNode GetSavegame(int i);
 	native void InsertNewSaveNode();
 	native bool RemoveNewSaveNode();
+	native int RemoveUUIDSaveSlots();
 
 }
 


### PR DESCRIPTION
Allows the SavegameManager to destroy all saves related to the current UUID session so hardcore mods can enforce this safely instead of needing to go nuclear.