### PR TITLE
Stencil broke stacked sectors. Fixing.

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -236,11 +236,11 @@ void HWPortal::DrawPortalStencil(FRenderState &state, int pass)
 
 		if (mBottomCap != ~0u)
 		{
-			state.Draw(DT_TriangleStrip, mBottomCap, 4, false);
+			state.Draw(DT_TriangleStrip, mBottomCap, 4, screen->IsVulkan());
 		}
 		if (mTopCap != ~0u)
 		{
-			state.Draw(DT_TriangleStrip, mTopCap, 4, false);
+			state.Draw(DT_TriangleStrip, mTopCap, 4, screen->IsVulkan());
 		}
 
 		if (pass == STP_DepthRestore) state.SetDepthRange(0, 1);
@@ -839,7 +839,7 @@ bool HWSectorStackPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 
 void HWSectorStackPortal::DrawPortalStencil(FRenderState &state, int pass)
 {
-	if (true) // mState->vpIsAllowedOoB)
+	if (mState->vpIsAllowedOoB)
 	{
 		bool isceiling = planesused & (1 << sector_t::ceiling);
 		for (unsigned i = 0; i<subsectors.Size(); i++)


### PR DESCRIPTION
People found a rendering bug with the new stencil idea: https://github.com/ZDoom/gzdoom/issues/3231
Ditching it and reinitializing renderstate stuff for old stencil caps (only for vulkan).
This seems to fix the new bug and the original bug from here: https://github.com/ZDoom/gzdoom/pull/3183