### PR TITLE
Added -optfile argument

### DIFF
--- a/src/common/utility/findfile.cpp
+++ b/src/common/utility/findfile.cpp
@@ -50,7 +50,7 @@
 //
 //==========================================================================
 
-bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config)
+bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config, bool optional)
 {
 	if (file == nullptr || *file == '\0')
 	{
@@ -127,7 +127,7 @@ bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check,
 //
 //==========================================================================
 
-void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const char *extension, FConfigFile* config)
+void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const char *extension, FConfigFile* config, bool optional)
 {
 	if (value == nullptr || *value == '\0')
 	{
@@ -137,7 +137,7 @@ void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const 
 
 	if (wadfile != nullptr)
 	{
-		D_AddFile(wadfiles, wadfile, true, -1, config);
+		D_AddFile(wadfiles, wadfile, true, -1, config, optional);
 	}
 	else 
 	{
@@ -150,7 +150,7 @@ void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const 
 		{ 
 			for(auto& entry : list)
 			{
-				D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config);
+				D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config, optional);
 			}
 		}
 	}
@@ -164,7 +164,7 @@ void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const 
 //
 //==========================================================================
 
-void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, const char* extension, FConfigFile *config)
+void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, const char* extension, FConfigFile *config, bool optional)
 {
 	if (config && config->SetSection(section))
 	{
@@ -178,7 +178,7 @@ void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, c
 			{
 				// D_AddWildFile resets config's position, so remember it
 				config->GetPosition(pos);
-				D_AddWildFile(wadfiles, ExpandEnvVars(value).GetChars(), extension, config);
+				D_AddWildFile(wadfiles, ExpandEnvVars(value).GetChars(), extension, config, optional);
 				// Reset config's position to get next wad
 				config->SetPosition(pos);
 			}
@@ -194,7 +194,7 @@ void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, c
 //
 //==========================================================================
 
-void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config)
+void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config, bool optional)
 {
 	FileSys::FileList list;
 	if (FileSys::ScanDirectory(list, dir, "*.wad", true))
@@ -203,7 +203,7 @@ void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const c
 		{
 			if (!entry.isDirectory)
 			{
-				D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config);
+				D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config, optional);
 			}
 		}
 	}

--- a/src/common/utility/findfile.h
+++ b/src/common/utility/findfile.h
@@ -7,8 +7,8 @@
 
 class FConfigFile;
 
-bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config);
-void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const char *extension, FConfigFile* config);
-void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, const char* extension, FConfigFile* config);
-void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config);
+bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config, bool optional = false);
+void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const char *extension, FConfigFile* config, bool optional = false);
+void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, const char* extension, FConfigFile* config, bool optional = false);
+void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config, bool optional = false);
 const char* BaseFileSearch(const char* file, const char* ext, bool lookfirstinprogdir, FConfigFile* config);

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -797,7 +797,7 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, const char
 
 	// [SP] Load non-free assets if available. This must be done before the IWAD.
 	int iwadnum = 1;
-	if (optional_wad && D_AddFile(wadfiles, optional_wad, true, -1, GameConfig))
+	if (optional_wad && D_AddFile(wadfiles, optional_wad, true, -1, GameConfig, true))
 	{
 		iwadnum++;
 	}
@@ -823,7 +823,7 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, const char
 
 			if(supportWAD.IsNotEmpty())
 			{
-				D_AddFile(wadfiles, supportWAD.GetChars(), true, -1, GameConfig);
+				D_AddFile(wadfiles, supportWAD.GetChars(), true, -1, GameConfig, true);
 			}
 		}
 	}


### PR DESCRIPTION
Allows specify optional files from the commandline (note: this currently isn't hooked up to the filesystem proper for marking, this is purely for the file parsing until then).