### PR TITLE
Fixed quick save rotator breaking save logic

### DIFF
--- a/src/d_event.h
+++ b/src/d_event.h
@@ -100,6 +100,7 @@ enum gameaction_t : int
 	ga_intermission,
 	ga_titleloop,
 	ga_mapwarp,
+	ga_quicksave,
 };
 
 extern	gameaction_t	gameaction;

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2094,7 +2094,7 @@ static bool ShouldStabilizeTick()
 {
 	return gameaction != ga_recordgame && gameaction != ga_newgame && gameaction != ga_newgame2
 			&& gameaction != ga_loadgame && gameaction != ga_loadgamehidecon && gameaction != ga_autoloadgame && gameaction != ga_loadgameplaydemo
-			&& gameaction != ga_savegame && gameaction != ga_autosave
+			&& gameaction != ga_savegame && gameaction != ga_autosave && gameaction != ga_quicksave
 			&& gameaction != ga_worlddone && gameaction != ga_completed && gameaction != ga_screenshot && gameaction != ga_fullconsole;
 }
 

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1196,6 +1196,12 @@ void G_Ticker ()
 			savegamefile = "";
 			savedescription = "";
 			break;
+		case ga_quicksave:
+			G_DoSaveGame(true, true, savegamefile, savedescription.GetChars());
+			gameaction = ga_nothing;
+			savegamefile = "";
+			savedescription = "";
+			break;
 		case ga_autosave:
 			G_DoAutoSave ();
 			gameaction = ga_nothing;
@@ -2145,9 +2151,9 @@ void G_DoLoadGame ()
 // Called by the menu task.
 // Description is a 24 byte text string
 //
-void G_SaveGame (const char *filename, const char *description)
+void G_SaveGame (const char *filename, const char *description, bool quick)
 {
-	if (sendsave || gameaction == ga_savegame)
+	if (sendsave || gameaction == ga_savegame || gameaction == ga_quicksave)
 	{
 		Printf ("%s\n", GStrings.GetString("TXT_SAVEPENDING"));
 	}
@@ -2171,7 +2177,17 @@ void G_SaveGame (const char *filename, const char *description)
 	{
 		savegamefile = filename;
 		savedescription = description;
-		sendsave = true;
+		if (quick)
+		{
+			sendsave = false;
+			gameaction = ga_quicksave;
+		}
+		else
+		{
+			sendsave = true;
+			if (gameaction == ga_quicksave)
+				gameaction = ga_nothing;
+		}
 	}
 }
 
@@ -2268,7 +2284,7 @@ void G_DoQuickSave ()
 
 	readableTime = myasctime ();
 	description.Format("Quicksave %s", readableTime);
-	G_DoSaveGame (true, true, file, description.GetChars());
+	G_SaveGame(file.GetChars(), description.GetChars(), true);
 }
 
 

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -64,7 +64,7 @@ void G_LoadGame (const char* name, bool hidecon=false);
 void G_DoLoadGame (void);
 
 // Called by M_Responder.
-void G_SaveGame (const char *filename, const char *description);
+void G_SaveGame (const char *filename, const char *description, bool quick = false);
 // Called by messagebox
 void G_DoQuickSave ();
 

--- a/src/playsim/p_lnspec.cpp
+++ b/src/playsim/p_lnspec.cpp
@@ -3179,7 +3179,7 @@ FUNC(LS_TranslucentLine)
 
 FUNC(LS_Autosave)
 {
-	if (gameaction != ga_savegame)
+	if (gameaction != ga_savegame && gameaction != ga_quicksave)
 	{
 		Level->flags2 &= ~LEVEL2_NOAUTOSAVEHINT;
 		Net_WriteInt8 (DEM_CHECKAUTOSAVE);

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1150,6 +1150,12 @@ enum EGameAction
 	ga_screenshot,
 	ga_togglemap,
 	ga_fullconsole,
+	ga_resumeconversation,
+	ga_intro,
+	ga_intermission,
+	ga_titleloop,
+	ga_mapwarp,
+	ga_quicksave,
 };
 
 enum EPuffFlags


### PR DESCRIPTION
The game should only ever save during the gameplay loop and never on the spot. Also fixes the quick save rotator skipping certain checks.