### PR TITLE
Fix crash in FileSystem::ReadFile when loading empty lumps.

### DIFF
--- a/src/common/filesystem/source/filesystem.cpp
+++ b/src/common/filesystem/source/filesystem.cpp
@@ -1247,13 +1247,16 @@ unsigned FileSystem::GetFilesInFolder(const char *inpath, std::vector<FolderEntr
 void FileSystem::ReadFile (int lump, void *dest)
 {
 	auto lumpr = OpenFileReader (lump);
-	auto size = lumpr.GetLength ();
-	auto numread = lumpr.Read (dest, size);
-
-	if (numread != size)
+	if (lumpr.mReader != nullptr)
 	{
-		throw FileSystemException("W_ReadFile: only read %td of %td on '%s'\n",
-			numread, size, FileInfo[lump].LongName);
+		auto size = lumpr.GetLength ();
+		auto numread = lumpr.Read (dest, size);
+
+		if (numread != size)
+		{
+			throw FileSystemException("W_ReadFile: only read %td of %td on '%s'\n",
+				numread, size, FileInfo[lump].LongName);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://forum.zdoom.org/viewtopic.php?t=80699&sid=e4955f1a5292e5088edfc09408a3d77c