### PR TITLE
Allow for progress bar completion

### DIFF
--- a/src/common/engine/st_start.h
+++ b/src/common/engine/st_start.h
@@ -50,7 +50,7 @@ public:
 
 	virtual ~FStartupScreen() = default;
 
-	virtual void Progress() {}
+	virtual void Progress(int advance = 1) {}
 	virtual void AppendStatusLine(const char* status) {}
 	virtual void LoadingStatus(const char* message, int colors) {}
 
@@ -77,7 +77,7 @@ public:
 	FBasicStartupScreen(int max_progress);
 	~FBasicStartupScreen();
 
-	void Progress() override;
+	void Progress(int advance = 1) override;
 
 	void NetInit(const char* message, bool host) override;
 	void NetMessage(const char* message) override;

--- a/src/common/platform/posix/cocoa/st_start.mm
+++ b/src/common/platform/posix/cocoa/st_start.mm
@@ -84,13 +84,9 @@ FBasicStartupScreen::~FBasicStartupScreen()
 }
 
 
-void FBasicStartupScreen::Progress()
+void FBasicStartupScreen::Progress(int advance)
 {
-	if (CurPos < MaxPos)
-	{
-		++CurPos;
-	}
-
+	CurPos = min(CurPos + advance, MaxPos);
 	FConsoleWindow::GetInstance().Progress(CurPos, MaxPos);
 }
 

--- a/src/common/platform/posix/sdl/i_system.cpp
+++ b/src/common/platform/posix/sdl/i_system.cpp
@@ -216,10 +216,15 @@ void CleanProgressBar()
 }
 
 static int ProgressBarCurPos, ProgressBarMaxPos;
+static bool ProgressBarComplete;
 
 void RedrawProgressBar(int CurPos, int MaxPos)
 {
 	if (!isatty(STDOUT_FILENO)) return;
+
+	if (ProgressBarComplete && CurPos >= MaxPos) return;
+	ProgressBarComplete = CurPos >= MaxPos; // draw once
+
 	CleanProgressBar();
 	struct winsize sizeOfWindow;
 	ioctl(STDOUT_FILENO, TIOCGWINSZ, &sizeOfWindow);

--- a/src/common/platform/posix/sdl/st_start.cpp
+++ b/src/common/platform/posix/sdl/st_start.cpp
@@ -53,7 +53,7 @@ class FTTYStartupScreen : public FStartupScreen
 		FTTYStartupScreen(int max_progress);
 		~FTTYStartupScreen();
 
-		void Progress() override;
+		void Progress(int amount = 1) override;
 
 		void NetInit(const char* message, bool host) override;
 		void NetMessage(const char* message) override;
@@ -137,12 +137,9 @@ FTTYStartupScreen::~FTTYStartupScreen()
 //
 //===========================================================================
 
-void FTTYStartupScreen::Progress()
+void FTTYStartupScreen::Progress(int advance)
 {
-	if (CurPos < MaxPos)
-	{
-		++CurPos;
-	}
+	CurPos = min(CurPos + advance, MaxPos);
 	RedrawProgressBar(CurPos, MaxPos);
 }
 
@@ -240,6 +237,7 @@ void FTTYStartupScreen::NetProgress(int cur, int limit)
 
 void FTTYStartupScreen::NetDone()
 {	
+	CurPos = MaxPos;
 	CleanProgressBar();
 	// Restore stdin settings
 	if (DidNetInit)

--- a/src/common/platform/win32/st_start.cpp
+++ b/src/common/platform/win32/st_start.cpp
@@ -117,12 +117,9 @@ FBasicStartupScreen::~FBasicStartupScreen()
 //
 //==========================================================================
 
-void FBasicStartupScreen::Progress()
+void FBasicStartupScreen::Progress(int advance)
 {
-	if (CurPos < MaxPos)
-	{
-		CurPos++;
-	}
+	CurPos = min(CurPos + advance, MaxPos);
 }
 
 //==========================================================================

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3366,7 +3366,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	if (!batchrun) Printf ("ST_Init: Init startup screen.\n");
 	if (!restart)
 	{
-		StartWindow = FStartupScreen::CreateInstance (TexMan.GuesstimateNumTextures() + 5);
+		StartWindow = FStartupScreen::CreateInstance(max_progress);
 	}
 	else
 	{
@@ -3581,7 +3581,9 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 		}
 
 		S_Sound (CHAN_BODY, 0, "misc/startupdone", 1, ATTN_NONE);
+		if (!batchrun) Printf ("Init complete.\n");
 
+		StartWindow->Progress(max_progress);
 		if (StartScreen)
 		{
 			StartScreen->Progress(max_progress);	// advance progress bar to the end.


### PR DESCRIPTION
In the unix terminal, the progress bar is always visible and never complete, which feels very wrong to me.

<img width="2256" height="1504" alt="image" src="https://github.com/user-attachments/assets/36b06bae-2347-4a74-9f2b-4e3353554309" />

This fixes that

<img width="2256" height="1504" alt="image" src="https://github.com/user-attachments/assets/28398bcc-9c70-4180-a87b-0d7f87950b57" />
