### PR TITLE
Fix IWADINFOs being taken from search paths first before -iwad

### DIFF
--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -533,8 +533,16 @@ void FIWadManager::ValidateIWADs()
 {
 	TArray<int> returns;
 	unsigned originalsize = mIWadInfos.Size();
-	for (auto &p : mFoundWads)
+
+	// Iterating normally will give CheckIWADInfo name conflicts priority to
+	// whatever file is found first, rather than the file that the user
+	// specifically requests with -iwad, because IdentifyVersion appends
+	// the -iwad file to the end of the list. (And it's annoying to change
+	// to be the other way around.)
+	for (int i = mFoundWads.SSize() - 1; i >= 0; i--)
 	{
+		auto &p = mFoundWads[i];
+
 		int index;
 		auto x = strrchr(p.mFullPath.GetChars(), '.');
 		if (x != nullptr && (!stricmp(x, ".iwad") || !stricmp(x, ".ipk3") || !stricmp(x, ".ipk7")))


### PR DESCRIPTION
Scenario:
- Using `-iwad` to explicitly use an IWAD outside of your search paths
- You have other, older versions hiding in your search paths
- You then change your IWADINFO's BannerColors

Cue confusion that your IWAD is still using earlier settings no matter what, even though they (at first glance) don't exist anymore.

Because `IdentifyVersion` does search paths before it appends -iwad, *and* `ValidateIWADs` iterates them in normal order, *and* `CheckIWADInfo` has a case where it filters out IWADINFO lumps for names that already were defined ... the file that gets to determine the IWAD startup settings is whatever file is found on the system instead of the file specifically requested.

This seemed like the easiest & safest place to put a fix, even if it's a little wacky. Removing the duplication case in `CheckIWADInfo` works fine, but I'm just going off the assumption that it was done that way for a reason. `IdentifyVersion` is built around the fact that the -iwad parameter file is last, and a full rework of that function is overkill just to fix this extremely minor issue.