### PR TITLE
Fix VM debugging being always active = vm_jit permanently disabled = poor performance

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3165,7 +3165,7 @@ static int FileSystemPrintf(FSMessageLevel level, const char* fmt, ...)
 static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allwads, std::vector<std::string>& pwads)
 {
 	NetworkEntityManager::InitializeNetworkEntities();
-	bool dap_debugging = vm_debug.get();
+	bool dap_debugging = *vm_debug;
 	if (Args->CheckValue("-debug") || dap_debugging)
 	{
 		dap_debugging = true;


### PR DESCRIPTION
Prevents vm_jit from being permanently disabled due to an oversight in the code.