### PR TITLE
[GCC] Correct misleading indentation warnings in c_cmds.cpp

### DIFF
--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -1381,7 +1381,7 @@ CCMD (mapinfo)
 	if (myLevel->RedirectCVARMapName.IsNotEmpty())
 	{
 		Printf(" CVAR_Redirect (Map): %s\n", myLevel->RedirectCVARMapName.GetChars());
-		
+
 		Printf("           LightMode: %i\n", (int8_t)myLevel->lightmode);
 	}
 


### PR DESCRIPTION
Resolves two `-Wmisleading-indentation` warnings in `src/console/c_cmds.cpp` that were reported by recent GCC versions.

Exceptions (third-party librarys):

1. readxm.c
```
/home/runner/work/gzdoom/gzdoom/libraries/ZMusic/thirdparty/dumb/src/it/readxm.c:1009:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
 1009 |     if (sigdata->n_orders == 0)
      |     ^~
```
2. readmod.c
```
/home/runner/work/gzdoom/gzdoom/libraries/ZMusic/thirdparty/dumb/src/it/readmod.c:291:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  291 |     if ( dumbfile_seek(f, 0, DFS_SEEK_SET) )
      |     ^~
```
3. itread.c
```
/home/runner/work/gzdoom/gzdoom/libraries/ZMusic/thirdparty/dumb/src/it/itread.c:624:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  624 |     if (dumbfile_getnc((char *)compression_table, 16, f) != 16)
      |     ^~
```