### PR TITLE
Fixed net event data being dropped in packet-server mode

### DIFF
--- a/src/d_protocol.cpp
+++ b/src/d_protocol.cpp
@@ -282,7 +282,10 @@ void ReadUserCmdMessage(TArrayView<uint8_t>& stream, int player, int tic)
 		Net_SkipCommand(type, stream);
 
 	// Subtract a byte to account for the fact the stream head is now sitting on the
-	// user command.
+	// user command. This gets cleared first because it previously got cleared after
+	// executing but that breaks packet-server mode and I have no idea what side effects
+	// might happen if it's not wiped first.
+	curTic.Data.SetData(nullptr, 0u);
 	curTic.Data.SetData(start, int(stream.Data() - start - 1));
 
 	if (type == DEM_USERCMD)
@@ -311,9 +314,6 @@ void RunPlayerCommands(int player, int tic)
 	{
 		while (stream.Size() > 0)
 			Net_DoCommand(ReadInt8(stream), stream, player);
-
-		if (!demorecording)
-			data.SetData(nullptr, 0);
 	}
 }
 

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2573,11 +2573,7 @@ void G_WriteDemoTiccmd (usercmd_t *cmd, int player, int buf)
 
 	// [RH] Write any special "ticcmds" for this player to the demo
 	if ((specdata = ClientStates[player].Tics[buf % BACKUPTICS].Data.GetData (&speclen)) && !(gametic % TicDup))
-	{
 		WriteBytes(TArrayView(specdata, speclen), demo_p);
-
-		ClientStates[player].Tics[buf % BACKUPTICS].Data.SetData(nullptr, 0);
-	}
 
 	// [RH] Now write out a "normal" ticcmd.
 	WriteUserCmdMessage (*cmd, &players[player].cmd, demo_p);


### PR DESCRIPTION
Previously hosts would clear this data after executing which cannot be done as this will fundamentally break retransmissions when playing in packet-server mode.