### PR TITLE
Added OnSelect() and OnDeselect() to weapons

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/powerups.zs
+++ b/wadsrc/static/zscript/actors/inventory/powerups.zs
@@ -1104,6 +1104,7 @@ class PowerWeaponLevel2 : Powerup
 		if (weap.GetReadyState() != ready)
 		{
 			player.ReadyWeapon = sister;
+			player.ReadyWeapon.OnSelect(fromPowerup: true);
 			player.SetPsprite(PSP_WEAPON, ready);
 		}
 		else
@@ -1114,11 +1115,13 @@ class PowerWeaponLevel2 : Powerup
 				// If the weapon changes but the state does not, we have to manually change the PSprite's caller here.
 				psp.Caller = sister;
 				player.ReadyWeapon = sister;
+				player.ReadyWeapon.OnSelect(fromPowerup: true);
 			}
 			else
 			{
 				// Something went wrong. Initiate a regular weapon change.
 				player.PendingWeapon = sister;
+				player.PendingWeapon.OnSelect(fromPowerup: true);
 			}
 		}
 	}

--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -143,6 +143,10 @@ class Weapon : StateProvider
 		}
 		return -1, 0;
 	}
+
+	virtual void OnSelect() {}
+	
+	virtual void OnDeselect() {}
 	
 	virtual State GetReadyState ()
 	{

--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -144,9 +144,14 @@ class Weapon : StateProvider
 		return -1, 0;
 	}
 
-	virtual void OnSelect() {}
 	
-	virtual void OnDeselect() {}
+	// [AA] Called when the weapon is selected, including
+	// PowerWeaponLevel2 activation:
+	virtual void OnSelect(bool fromPowerup = false) {}
+	
+	// [AA] Called when the weapon is deselected, including
+	// PowerWeaponLevel2 running out or being tossed:
+	virtual void OnDeselect(bool fromPowerup = false, bool onToss = false) {}
 	
 	virtual State GetReadyState ()
 	{
@@ -694,6 +699,13 @@ class Weapon : StateProvider
 		{
 			return SisterWeapon.CreateTossable (amt);
 		}
+		
+		// [AA] This weapon was selected and its amount is about to become 0:
+		if (Amount == 1 && Owner != NULL && Owner.Player != NULL && Owner.Player.ReadyWeapon == self)
+		{
+			OnDeselect(onToss: true);
+		}
+		
 		let copy = Weapon(Super.CreateTossable (-1));
 
 		if (copy != NULL)
@@ -872,6 +884,7 @@ class Weapon : StateProvider
 				if (player.PendingWeapon == NULL ||	player.PendingWeapon == WP_NOCHANGE)
 				{
 					player.refire = 0;
+					OnDeselect(fromPowerup: true);
 					player.ReadyWeapon = SisterWeapon;
 					player.SetPsprite(PSP_WEAPON, SisterWeapon.GetReadyState());
 				}
@@ -882,6 +895,7 @@ class Weapon : StateProvider
 				if (psp != null && psp.Caller == player.ReadyWeapon && psp.CurState.InStateSequence(ready))
 				{
 					// If the weapon changes but the state does not, we have to manually change the PSprite's caller here.
+					OnDeselect(fromPowerup: true);
 					psp.Caller = SisterWeapon;
 					player.ReadyWeapon = SisterWeapon;
 				}
@@ -890,6 +904,7 @@ class Weapon : StateProvider
 					if (player.PendingWeapon == NULL || player.PendingWeapon == WP_NOCHANGE)
 					{
 						// Something went wrong. Initiate a regular weapon change.
+						OnDeselect(fromPowerup: true);
 						player.refire = 0;
 						player.ReadyWeapon = SisterWeapon;
 						player.SetPsprite(PSP_WEAPON, SisterWeapon.GetReadyState());

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -1884,6 +1884,7 @@ class PlayerPawn : Actor
 
 		if (weapon != null)
 		{
+			weapon.OnSelect();
 			weapon.PlayUpSound(self);
 			player.refire = 0;
 
@@ -1976,6 +1977,7 @@ class PlayerPawn : Actor
 		Weapon weap = player.ReadyWeapon;
 		if ((weap != null) && (player.health > 0 || !weap.bNoDeathDeselect))
 		{
+			weap.OnDeselect();
 			player.SetPsprite(PSP_WEAPON, weap.GetDownState());
 		}
 	}


### PR DESCRIPTION
Added OnSelect() and OnDeselect() virtuals to the Weapon class invoked from PlayerPawn's BringUpWeapon() and DropWeapon() respectively. This would allow mod authors to do something as soon as the weapon gets selected but before it enters any states, and as soon as it's deselected. Useful for things like stopping previously looped weapon sounds on deselection, modifying attached 3D models without conflincting with further instructions in the Select sequence, etc.