### PR TITLE
expose ToInt and ToFloat from FString as ToInt and ToDouble

### DIFF
--- a/src/common/scripting/interface/stringformat.cpp
+++ b/src/common/scripting/interface/stringformat.cpp
@@ -526,6 +526,27 @@ DEFINE_ACTION_FUNCTION_NATIVE(FStringStruct, CharLower, StringCharLower)
 	ACTION_RETURN_INT(StringCharLower(ch));
 }
 
+static int StringIsInt(FString *self)
+{
+	return self->IsInt();
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FStringStruct, IsInt, StringIsInt)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FString);
+	ACTION_RETURN_INT(self->IsInt());
+}
+
+static int StringIsDouble(FString *self)
+{
+	return self->IsFloat();
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FStringStruct, IsDouble, StringIsDouble)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FString);
+	ACTION_RETURN_INT(self->IsFloat());
+}
 
 static int StringToInt(FString *self, int base)
 {

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -975,8 +975,12 @@ struct StringStruct native unsafe(internal)
 	native String MakeLower() const;
 	native static int CharUpper(int ch);
 	native static int CharLower(int ch);
+
+	native bool IsInt() const;
+	native bool IsDouble() const;
 	native int ToInt(int base = 0) const;
 	native double ToDouble() const;
+
 	native void Split(out Array<String> tokens, String delimiter, EmptyTokenType keepEmpty = TOK_KEEPEMPTY) const;
 	native void AppendCharacter(int c);
 	native void DeleteLastCharacter();


### PR DESCRIPTION
Will be handy for custom lump parsing and user forms validation.

Not sure why `FString::IsFloat()` returns `true` for an empty string. But, if it's okay for C++ side, it's okay for ZScript side too?

Demo:
```java
version 4.14

class TestZombie : Zombieman replaces Zombieman
{
  override void BeginPlay()
  {
    string intString = "10";
    string doubleString = "-7.5";
    string stringString = "hello";
    string emptyString = "";

    Console.printf("%9s isInt:    %d, toInt: %d", intString, intString.isInt(), intString.toInt());
    Console.printf("%9s isInt:    %d, toInt: %d", doubleString, doubleString.isInt(), doubleString.toInt());
    Console.printf("%9s isInt:    %d, toInt: %d", stringString, stringString.isInt(), stringString.toInt());
    Console.printf("empty     isInt:    %d, toInt: %d", emptyString.isInt(), emptyString.toInt());

    Console.printf("%9s isDouble: %d, toDouble: %f", intString, intString.isDouble(), intString.toDouble());
    Console.printf("%9s isDouble: %d, toDouble: %f", doubleString, doubleString.isDouble(), doubleString.toDouble());
    Console.printf("%9s isDouble: %d, toDouble: %f", stringString, stringString.isDouble(), stringString.toDouble());
    Console.printf("empty     isDouble: %d, toDouble: %d", emptyString.isDouble(), emptyString.toDouble());

    Super.BeginPlay();
  }
}
```

Prints:
```
       10 isInt:    1, toInt: 10
     -7.5 isInt:    0, toInt: -7
    hello isInt:    0, toInt: 0
empty     isInt:    0, toInt: 0
       10 isDouble: 1, toDouble: 10.000000
     -7.5 isDouble: 1, toDouble: -7.500000
    hello isDouble: 0, toDouble: 0.000000
empty     isDouble: 1, toDouble: 0
```
```