### PR TITLE
Added tooltips for widgets in MENUDEF

### DIFF
--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -69,7 +69,23 @@ CVAR(Int, m_show_backbutton, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR(Bool, m_cleanscale, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 // Option Search
 CVAR(Bool, os_isanyof, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
-
+// Tooltip
+CVAR(Bool, m_tooltip_capwidth, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CUSTOM_CVAR(Int, m_tooltip_lines, 3, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (self < 1)
+		self = 1;
+}
+CUSTOM_CVAR(Float, m_tooltip_delay, 9.0f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (self <= 0.0f)
+		self = 0.1f;
+}
+CUSTOM_CVAR(Float, m_tooltip_speed, 3.0f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (self <= 0.0f)
+		self = 0.1f;
+}
 
 static DMenu *GetCurrentMenu()
 {
@@ -264,6 +280,10 @@ DMenu::DMenu(DMenu *parent)
 	mMouseCapture = false;
 	mBackbuttonSelected = false;
 	DontDim = false;
+	mTooltipFont = nullptr;
+	mTooltipScrollOffset = 0.0;
+	mTooltipScrollTimer = 0.0;
+	mCurrentTooltip = "";
 	GC::WriteBarrier(this, parent);
 }
 
@@ -1014,6 +1034,10 @@ DEFINE_FIELD(DMenu, DontDim);
 DEFINE_FIELD(DMenu, DontBlur);
 DEFINE_FIELD(DMenu, AnimatedTransition);
 DEFINE_FIELD(DMenu, Animated);
+DEFINE_FIELD(DMenu, mCurrentTooltip)
+DEFINE_FIELD(DMenu, mTooltipScrollTimer)
+DEFINE_FIELD(DMenu, mTooltipScrollOffset)
+DEFINE_FIELD(DMenu, mTooltipFont)
 
 DEFINE_FIELD(DMenuDescriptor, mMenuName)
 DEFINE_FIELD(DMenuDescriptor, mNetgameMessage)
@@ -1023,6 +1047,7 @@ DEFINE_FIELD(DMenuItemBase, mXpos)
 DEFINE_FIELD(DMenuItemBase, mYpos)
 DEFINE_FIELD(DMenuItemBase, mAction)
 DEFINE_FIELD(DMenuItemBase, mEnabled)
+DEFINE_FIELD(DMenuItemBase, mTooltip)
 
 DEFINE_FIELD(DListMenuDescriptor, mItems)
 DEFINE_FIELD(DListMenuDescriptor, mSelectedItem)

--- a/src/common/menu/menu.h
+++ b/src/common/menu/menu.h
@@ -239,6 +239,10 @@ public:
 	bool DontBlur;
 	bool Animated;
 	bool AnimatedTransition;
+	FString mCurrentTooltip;
+	double mTooltipScrollTimer;
+	double mTooltipScrollOffset;
+	FFont* mTooltipFont;
 	static int InMenu;
 
 	DMenu(DMenu *parent = NULL);
@@ -265,6 +269,7 @@ public:
 	double mXpos, mYpos;
 	FName mAction;
 	int mEnabled;
+	FString mTooltip;
 
 	bool Activate();
 	bool SetString(int i, const char *s);

--- a/src/common/menu/menudef.cpp
+++ b/src/common/menu/menudef.cpp
@@ -275,9 +275,11 @@ static bool CheckSkipOptionBlock(FScanner &sc)
 
 static void DoParseListMenuBody(FScanner &sc, DListMenuDescriptor *desc, bool &sizecompatible, int insertIndex)
 {
+	bool isValidTooltip = false;
 	sc.MustGetStringName("{");
 	while (!sc.CheckString("}"))
 	{
+		bool foundWidget = false;
 		sc.MustGetString();
 		if (sc.Compare("else"))
 		{
@@ -434,6 +436,14 @@ static void DoParseListMenuBody(FScanner &sc, DListMenuDescriptor *desc, bool &s
 		else if (sc.Compare("CenterText"))
 		{
 			desc->mCenterText = true;
+		}
+		else if (sc.Compare("Tooltip"))
+		{
+			if (!isValidTooltip)
+				sc.ScriptError("Tooltips can only be defined after a list menu widget");
+
+			sc.MustGetString();
+			desc->mItems.Last()->mTooltip = sc.String;
 		}
 		else
 		{
@@ -614,6 +624,7 @@ static void DoParseListMenuBody(FScanner &sc, DListMenuDescriptor *desc, bool &s
 						if (desc->mSelectedItem == -1) desc->mSelectedItem = desc->mItems.Size() - 1;
 					}
 					success = true;
+					foundWidget = true;
 				}
 			}
 			if (!success)
@@ -621,6 +632,7 @@ static void DoParseListMenuBody(FScanner &sc, DListMenuDescriptor *desc, bool &s
 				sc.ScriptError("Unknown keyword '%s'", sc.String);
 			}
 		}
+		isValidTooltip = foundWidget;
 	}
 	for (auto &p : desc->mItems)
 	{
@@ -983,9 +995,11 @@ static void ParseOptionSettings(FScanner &sc)
 
 static void ParseOptionMenuBody(FScanner &sc, DOptionMenuDescriptor *desc, int insertIndex)
 {
+	bool isValidTooltip = false;
 	sc.MustGetStringName("{");
 	while (!sc.CheckString("}"))
 	{
+		bool foundWidget = false;
 		sc.MustGetString();
 		if (sc.Compare("else"))
 		{
@@ -1065,6 +1079,14 @@ static void ParseOptionMenuBody(FScanner &sc, DOptionMenuDescriptor *desc, int i
 		else if (sc.Compare("DontBlur"))
 		{
 			desc->mDontBlur = true;
+		}
+		else if (sc.Compare("Tooltip"))
+		{
+			if (!isValidTooltip)
+				sc.ScriptError("Tooltips can only be defined after an option menu widget");
+
+			sc.MustGetString();
+			desc->mItems.Last()->mTooltip = sc.String;
 		}
 		else
 		{
@@ -1215,6 +1237,7 @@ static void ParseOptionMenuBody(FScanner &sc, DOptionMenuDescriptor *desc, int i
 					}
 
 					success = true;
+					foundWidget = true;
 				}
 			}
 			if (!success)
@@ -1222,6 +1245,7 @@ static void ParseOptionMenuBody(FScanner &sc, DOptionMenuDescriptor *desc, int i
 				sc.ScriptError("Unknown keyword '%s'", sc.String);
 			}
 		}
+		isValidTooltip = foundWidget;
 	}
 	for (auto &p : desc->mItems)
 	{

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -369,6 +369,7 @@ OptionMenu "OptionsMenu" protected
 	Submenu "$OPTMNU_MISCELLANEOUS",	"MiscOptions"
 	Submenu "$OPTMNU_NETWORK",			"NetworkOptions"
 	Submenu "$OPTMNU_SOUND",			"SoundOptions"
+	Submenu "$OPTMNU_ACCESSIBILITY",	"AccessibilityOptions"
 	Submenu "$OPTMNU_DISPLAY",			"VideoOptions"
 	Submenu "$OPTMNU_VIDEO",			"VideoModeMenu"
 	StaticText " "
@@ -2340,6 +2341,27 @@ OptionMenu ModReplayerOptions protected
 	StaticText ""
 	Option "$ADVSNDMNU_OPNCUSTOMBANK", 	 "opn_use_custom_bank", "OnOff"
 	LabeledSubmenu "$ADVSNDMNU_OPNBANKFILE", "opn_custom_bank", "OPNMIDICustomBanksMenu"
+ }
+ 
+ /*=======================================
+ *
+ * Accessibility Menu
+ *
+ *=======================================*/
+ 
+ OptionMenu AccessibilityOptions protected
+ {
+	Title "$ACCMNU_TITLE"
+	
+	StaticText "$ACCMNU_TOOLTIP"
+	Slider "$ACCMNU_TOOLTIP_LINES", "m_tooltip_lines", 1, 4, 1, 0
+	Tooltip "$ACCMNU_TOOLTIP_EXAMPLE"
+	Slider "$ACCMNU_TOOLTIP_SPEED", "m_tooltip_speed", 1.0, 5.0, 1.0, 0
+	Tooltip "$ACCMNU_TOOLTIP_EXAMPLE"
+	Slider "$ACCMNU_TOOLTIP_DELAY", "m_tooltip_delay", 3.0, 15.0, 1.0, 0
+	Tooltip "$ACCMNU_TOOLTIP_EXAMPLE"
+	Option "$ACCMNU_TOOLTIP_CAP", "m_tooltip_capwidth", "OnOff"
+	Tooltip "$ACCMNU_TOOLTIP_EXAMPLE"
  }
 
 /*=======================================

--- a/wadsrc/static/menudef.zsimple
+++ b/wadsrc/static/menudef.zsimple
@@ -12,6 +12,7 @@ OptionMenu "OptionsMenuSimple" protected
 	Submenu "$OPTMNU_PLAYER",			"NewPlayerMenu"
 	StaticText " "
 	Submenu "$OPTMNU_SOUND",			"SoundOptionsSimple"
+	Submenu "$OPTMNU_ACCESSIBILITY",	"AccessibilityOptions" // This should always have the full menu for this.
 	Submenu "$OPTMNU_DISPLAY",			"VideoOptionsSimple"
 	Submenu "$HUDMNU_SCALEOPT",			"ScalingOptionsSimple"
 	StaticText " "

--- a/wadsrc/static/zscript/engine/ui/menu/listmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/listmenu.zs
@@ -124,6 +124,9 @@ class ListMenu : Menu
 		{
 			mDesc.mItems[i].OnMenuCreated();
 		}
+
+		if (mDesc.mSelectedItem >= 0)
+			UpdateTooltip(mDesc.mItems[mDesc.mSelectedItem]);
 	}
 
 	//=============================================================================
@@ -162,6 +165,7 @@ class ListMenu : Menu
 				if (mDesc.mitems[i].Selectable() && mDesc.mItems[i].CheckHotkey(ch))
 				{
 					mDesc.mSelectedItem = i;
+					UpdateTooltip(mDesc.mitems[mDesc.mSelectedItem]);
 					MenuSound("menu/cursor");
 					return true;
 				}
@@ -171,6 +175,7 @@ class ListMenu : Menu
 				if (mDesc.mitems[i].Selectable() && mDesc.mItems[i].CheckHotkey(ch))
 				{
 					mDesc.mSelectedItem = i;
+					UpdateTooltip(mDesc.mitems[mDesc.mSelectedItem]);
 					MenuSound("menu/cursor");
 					return true;
 				}
@@ -200,6 +205,7 @@ class ListMenu : Menu
 			}
 			while (!mDesc.mItems[mDesc.mSelectedItem].Selectable() && mDesc.mSelectedItem != startedAt);
 			if (mDesc.mSelectedItem == startedAt) mDesc.mSelectedItem = oldSelect;
+			else UpdateTooltip(mDesc.mitems[mDesc.mSelectedItem]);
 			MenuSound("menu/cursor");
 			return true;
 
@@ -211,6 +217,7 @@ class ListMenu : Menu
 			}
 			while (!mDesc.mItems[mDesc.mSelectedItem].Selectable() && mDesc.mSelectedItem != startedAt);
 			if (mDesc.mSelectedItem == startedAt) mDesc.mSelectedItem = oldSelect;
+			else UpdateTooltip(mDesc.mitems[mDesc.mSelectedItem]);
 			MenuSound("menu/cursor");
 			return true;
 
@@ -274,6 +281,7 @@ class ListMenu : Menu
 							//MenuSound("menu/cursor");
 						}
 						mDesc.mSelectedItem = i;
+						UpdateTooltip(mDesc.mitems[mDesc.mSelectedItem]);
 						mDesc.mItems[i].MouseEvent(type, x, y);
 						return true;
 					}
@@ -281,6 +289,7 @@ class ListMenu : Menu
 			}
 		}
 		mDesc.mSelectedItem = -1;
+		UpdateTooltip(null);
 		return Super.MouseEvent(type, x, y);
 	}
 

--- a/wadsrc/static/zscript/engine/ui/menu/menuitembase.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/menuitembase.zs
@@ -6,6 +6,7 @@
 
 class MenuItemBase : Object native ui version("2.4")
 {
+	protected native string mTooltip;
 	protected native double mXpos, mYpos;
 	protected native Name mAction;
 	native int mEnabled;
@@ -37,6 +38,7 @@ class MenuItemBase : Object native ui version("2.4")
 	virtual int GetIndent() { return 0; }
 	virtual int Draw(OptionMenuDescriptor desc, int y, int indent, bool selected) { return indent; }
 
+	string GetTooltip() const { return mTooltip; }
 	void OffsetPositionY(double ydelta) { mYpos += ydelta; }
 	double GetY() { return mYpos; }
 	double GetX() { return mXpos; }

--- a/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
@@ -120,6 +120,10 @@ class OptionMenu : Menu
 		DontBlur = desc.mDontBlur;
 		AnimatedTransition = desc.mAnimatedTransition;
 		Animated = desc.mAnimated;
+		mTooltipFont = NewConsoleFont;
+		mCurrentTooltip = "";
+		mTooltipScrollTimer = m_tooltip_delay;
+		mTooltipScrollOffset = 0.0;
 
 		ScrollSound = ! Cvar.FindCVar("silence_menu_scroll").getInt();
 		HoverSound = ! Cvar.FindCVar("silence_menu_hover").getInt();
@@ -150,6 +154,9 @@ class OptionMenu : Menu
 		{
 			mDesc.mItems[i].OnMenuCreated();
 		}
+
+		if (mDesc.mSelectedItem >= 0)
+			UpdateTooltip(mDesc.mItems[mDesc.mSelectedItem]);
 	}
 
 
@@ -263,6 +270,7 @@ class OptionMenu : Menu
 				if (firstLabelCharacter == key)
 				{
 					mDesc.mSelectedItem = index;
+					UpdateTooltip(mDesc.mItems[mDesc.mSelectedItem]);
 					break;
 				}
 			}
@@ -304,6 +312,7 @@ class OptionMenu : Menu
 				mDesc.mSelectedItem = FirstSelectable();
 			}
 
+			UpdateTooltip(mDesc.mItems[mDesc.mSelectedItem]);
 			return mDesc.mSelectedItem - startedAt;
 		}
 
@@ -446,6 +455,7 @@ class OptionMenu : Menu
 			}
 		}
 
+		UpdateTooltip(mDesc.mItems[mDesc.mSelectedItem]);
 		return mDesc.mSelectedItem - startedAt;
 	}
 
@@ -533,6 +543,7 @@ class OptionMenu : Menu
 			}
 		}
 
+		UpdateTooltip(mDesc.mItems[mDesc.mSelectedItem]);
 		return mDesc.mSelectedItem - startedAt;
 	}
 
@@ -643,7 +654,7 @@ class OptionMenu : Menu
 						if (i != mDesc.mSelectedItem)
 						{
 							mDesc.mSelectedItem = i;
-
+							UpdateTooltip(mDesc.mItems[mDesc.mSelectedItem]);
 							if (HoverSound) MenuSound ("menu/cursor");
 						}
 						mDesc.mItems[i].MouseEvent(type, x, y);
@@ -658,6 +669,7 @@ class OptionMenu : Menu
 		}
 
 		mDesc.mSelectedItem = -1;
+		UpdateTooltip(null);
 		return Super.MouseEvent(type, x, y);
 	}
 
@@ -728,8 +740,10 @@ class OptionMenu : Menu
 
 		int indent = GetIndent();
 
+		ScreenArea box;
+		GetTooltipArea(box);
 		int ytop = y + mDesc.mScrollTop * 8 * CleanYfac_1;
-		LastRow = screen.GetHeight() - OptionHeight() * CleanYfac_1;
+		LastRow = box.y - OptionHeight() * CleanYfac_1;
 		int rowheight = OptionMenuSettings.mLinespacing * CleanYfac_1 + 1;
 		MaxItems = (LastRow - y) / rowheight + 1;
 


### PR DESCRIPTION
This is a new feature for MENUDEF that allows tooltips to be assigned to any widget via `Tooltip "Text"` after its definition. Some options are not capable of being explained simply, especially in regards to translations or gameplay mechanics. This has resulted in sentence fragments being used to explain them with mods falling back on large bodies of static text above each option, wasting a ton of room in the menu itself and making it harder to read and navigate. Now a tooltip area is provided at the bottom of every menu that can hold as much text as needed. By default it'll display up to 3 lines at a time, scrolling at 1 line per 3 seconds after a 9 second delay.

As for why it was done this way, it feels the most practical. If a new argument were added to each widget, that would require not only changing all of them internally but forcing all modders to specify every single argument since the argument would have to be at the end. If a new set of widgets were created, this would require duplicating all existing widgets and forcing modders to update their own to get access to it. The current way requires only updating your MENUDEF to include them.

For more specifics, option menus have been shortened to account for the tooltip area, regardless of whether it's drawn or not. I feel this was the best way to keep it consistently sized in case only a few tooltips were needed as not all options will need explaining, and upon testing at smaller resolutions doesn't cause too tiny a viewable area. List menus have no scrolling and just go offscreen so are meant to be short, so no changes were needed here. In order to fix this list menus themselves will need to be updated to support scrolling which is outside of the scope of this PR.

Each tooltip is stored in the menu item with the menu itself having a set of virtuals allowing the tooltip area to be changed and overridden entirely. As expected, language keys are supported. It would also be nice to have a more accessible font for this as GZDoom doesn't have any that aren't pixel fonts. I fell back on `NewConsoleFont` because it seems to be the most readable for large bodies of text, but I'm open for suggestions if someone has other ideas. A new Accessibility option submenu has also been added to give more control over how the tooltip works including number of lines, scroll delay, scroll speed, and whether or not it should be capped to 16:9 for ultrawide setups.

<img width="1922" height="824" alt="example" src="https://github.com/user-attachments/assets/d3be3e8e-0d32-4f5d-8af8-491a649a07c1" />
