### PR TITLE
fix compilation in mac with sdl2

### DIFF
--- a/libraries/ZWidget/CMakeLists.txt
+++ b/libraries/ZWidget/CMakeLists.txt
@@ -273,6 +273,7 @@ target_link_options(zwidget PRIVATE ${ZWIDGET_LINK_OPTIONS})
 target_link_libraries(zwidget ${ZWIDGET_LIBS})
 set_target_properties(zwidget PROPERTIES CXX_STANDARD 20)
 target_compile_options(zwidget PRIVATE ${CXX_WARNING_FLAGS})
+target_include_directories(zwidget PRIVATE ${SDL2_INCLUDE_DIRS})
 
 if(MSVC)
 	set_property(TARGET zwidget PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,7 @@ else()
 	if( NOT APPLE OR NOT OSX_COCOA_BACKEND )
 		find_package( SDL2 REQUIRED )
 		include_directories( SYSTEM "${SDL2_INCLUDE_DIR}" )
+		link_directories(${SDL2_LINK_DIR})
 		set( PROJECT_LIBRARIES ${PROJECT_LIBRARIES} "${SDL2_LIBRARY}" )
 	endif()
 


### PR DESCRIPTION
This pull request fixes an compilation issue in mac with sdl2:

When running:
```
cmake -B build
cd build
make
```

I get the following error:

```
In file included from /tmp/ZWidget/src/window/sdl2/sdl2_display_window.cpp:2:
/tmp/ZWidget/src/window/sdl2/sdl2_display_window.h:7:10: fatal error: 'SDL2/SDL.h' file not found
    7 | #include <SDL2/SDL.h>
```

After the fix its possible to compile with:

```
 cmake -B build -DSDL2_INCLUDE_DIRS=/opt/homebrew/include -DOSX_COCOA_BACKEND=OFF -DSDL2_LINK_DIR=/opt/homebrew/lib