### PR TITLE
Fix gl_pipeline_depth maximum value

### DIFF
--- a/src/common/rendering/v_video.cpp
+++ b/src/common/rendering/v_video.cpp
@@ -77,7 +77,15 @@ CVAR(Bool, r_skipmats, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL
 // 0 means 'no pipelining' for non GLES2 and 4 elements for GLES2
 CUSTOM_CVAR(Int, gl_pipeline_depth, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
 {
-	if (self < 0 || self >= HW_MAX_PIPELINE_BUFFERS) self = 0;
+	if (self < 0)
+	{
+		self = 0;
+	}
+	else if (self > HW_MAX_PIPELINE_BUFFERS)
+	{
+		self = HW_MAX_PIPELINE_BUFFERS;
+	}
+
 	Printf("Changing the pipeline depth requires a restart for " GAMENAME ".\n");
 }
 


### PR DESCRIPTION
`gl_pipeline_depth 2` is supposed to be valid, but it was overwriting back to 0 when >= 2. This means you can't save the maximum valid value.

~~Why remove the limit, instead of clamping it properly? I've looked at & tested all of the code that uses this cvar already, and it's always clamped manually there. Additionally, `HW_MAX_PIPELINE_BUFFERS` can change based on a define, which means that using the same config between different systems could revert this value on startup. I personally dislike that behavior, so I'd like it to just trust the existing clamping. (If this is contentious, I will put it back, though.)~~

I was able to test that 2 (or more) works, even without any code changes, by using `+gl_pipeline_depth 2` on command line. Some weird order of operations doesn't change the value back before the renderer code gets the value on startup, so you can try different values. (Which, tbh, is kind of scary? But I don't have to spoons to investigate right now, or if it matters for anything else.)