### PR TITLE
Put extra WADs in launcher behind define

### DIFF
--- a/src/launcher/settingspage.cpp
+++ b/src/launcher/settingspage.cpp
@@ -17,18 +17,22 @@ SettingsPage::SettingsPage(LauncherWindow* launcher, const FStartupSelectionInfo
 	FullscreenCheckbox = new CheckboxLabel(this);
 	DisableAutoloadCheckbox = new CheckboxLabel(this);
 	DontAskAgainCheckbox = new CheckboxLabel(this);
+#ifdef EXTRA_WADS
 	LightsCheckbox = new CheckboxLabel(this);
 	BrightmapsCheckbox = new CheckboxLabel(this);
 	WidescreenCheckbox = new CheckboxLabel(this);
+#endif
 	SupportWadsCheckbox = new CheckboxLabel(this);
 
 	FullscreenCheckbox->SetChecked(info.DefaultFullscreen);
 	DontAskAgainCheckbox->SetChecked(!info.DefaultQueryIWAD);
 
 	DisableAutoloadCheckbox->SetChecked(info.DefaultStartFlags & 1);
+#ifdef EXTRA_WADS
 	LightsCheckbox->SetChecked(info.DefaultStartFlags & 2);
 	BrightmapsCheckbox->SetChecked(info.DefaultStartFlags & 4);
 	WidescreenCheckbox->SetChecked(info.DefaultStartFlags & 8);
+#endif
 	SupportWadsCheckbox->SetChecked(info.DefaultStartFlags & 16);
 
 #ifdef RENDER_BACKENDS
@@ -109,9 +113,11 @@ void SettingsPage::SetValues(FStartupSelectionInfo& info) const
 
 	int flags = 0;
 	if (DisableAutoloadCheckbox->GetChecked()) flags |= 1;
+#ifdef EXTRA_WADS
 	if (LightsCheckbox->GetChecked()) flags |= 2;
 	if (BrightmapsCheckbox->GetChecked()) flags |= 4;
 	if (WidescreenCheckbox->GetChecked()) flags |= 8;
+#endif
 	if (SupportWadsCheckbox->GetChecked()) flags |= 16;
 	info.DefaultStartFlags = flags;
 
@@ -132,9 +138,12 @@ void SettingsPage::UpdateLanguage()
 	FullscreenCheckbox->SetText(GStrings.GetString("PICKER_FULLSCREEN"));
 	DisableAutoloadCheckbox->SetText(GStrings.GetString("PICKER_NOAUTOLOAD"));
 	DontAskAgainCheckbox->SetText(GStrings.GetString("PICKER_DONTASK"));
+
+#ifdef EXTRA_WADS
 	LightsCheckbox->SetText(GStrings.GetString("PICKER_LIGHTS"));
 	BrightmapsCheckbox->SetText(GStrings.GetString("PICKER_BRIGHTMAPS"));
 	WidescreenCheckbox->SetText(GStrings.GetString("PICKER_WIDESCREEN"));
+#endif
 	SupportWadsCheckbox->SetText(GStrings.GetString("PICKER_SUPPORTWADS"));
 
 #ifdef RENDER_BACKENDS
@@ -161,23 +170,19 @@ void SettingsPage::OnGeometryChanged()
 	double h = GetHeight();
 
 	GeneralLabel->SetFrameGeometry(0.0, y, 190.0, GeneralLabel->GetPreferredHeight());
-	ExtrasLabel->SetFrameGeometry(w - panelWidth, y, panelWidth, ExtrasLabel->GetPreferredHeight());
 	y += GeneralLabel->GetPreferredHeight();
 
 	FullscreenCheckbox->SetFrameGeometry(0.0, y, 190.0, FullscreenCheckbox->GetPreferredHeight());
-	LightsCheckbox->SetFrameGeometry(w - panelWidth, y, panelWidth, LightsCheckbox->GetPreferredHeight());
 	y += FullscreenCheckbox->GetPreferredHeight();
 
 	DisableAutoloadCheckbox->SetFrameGeometry(0.0, y, 190.0, DisableAutoloadCheckbox->GetPreferredHeight());
-	BrightmapsCheckbox->SetFrameGeometry(w - panelWidth, y, panelWidth, BrightmapsCheckbox->GetPreferredHeight());
 	y += DisableAutoloadCheckbox->GetPreferredHeight();
 
 	DontAskAgainCheckbox->SetFrameGeometry(0.0, y, 190.0, DontAskAgainCheckbox->GetPreferredHeight());
-	WidescreenCheckbox->SetFrameGeometry(w - panelWidth, y, panelWidth, WidescreenCheckbox->GetPreferredHeight());
 	y += DontAskAgainCheckbox->GetPreferredHeight();
 
 	SupportWadsCheckbox->SetFrameGeometry(0.0, y, 190.0, SupportWadsCheckbox->GetPreferredHeight());
-	y += SupportWadsCheckbox->GetPreferredHeight() + 10.0;
+	y += SupportWadsCheckbox->GetPreferredHeight();
 	const double optionsBottom = y;
 
 #ifdef RENDER_BACKENDS
@@ -195,8 +200,24 @@ void SettingsPage::OnGeometryChanged()
 	GLESCheckbox->SetFrameGeometry(x, y, 190.0, GLESCheckbox->GetPreferredHeight());
 	y += GLESCheckbox->GetPreferredHeight();
 #endif
+	const double backendsBottom = y;
 
-	y = max<double>(y, optionsBottom);
+#ifdef EXTRA_WADS
+	y = 0;
+	ExtrasLabel->SetFrameGeometry(w - panelWidth, y, panelWidth, ExtrasLabel->GetPreferredHeight());
+	y += ExtrasLabel->GetPreferredHeight();
+
+	LightsCheckbox->SetFrameGeometry(w - panelWidth, y, panelWidth, LightsCheckbox->GetPreferredHeight());
+	y += LightsCheckbox->GetPreferredHeight();
+
+	BrightmapsCheckbox->SetFrameGeometry(w - panelWidth, y, panelWidth, BrightmapsCheckbox->GetPreferredHeight());
+	y += BrightmapsCheckbox->GetPreferredHeight();
+
+	WidescreenCheckbox->SetFrameGeometry(w - panelWidth, y, panelWidth, WidescreenCheckbox->GetPreferredHeight());
+	y += WidescreenCheckbox->GetPreferredHeight();
+#endif
+
+	y = max<double>(y, max<double>(optionsBottom, backendsBottom)) + 10.0;
 	if (!hideLanguage)
 	{
 		LangLabel->SetFrameGeometry(0.0, y, w, LangLabel->GetPreferredHeight());

--- a/src/launcher/settingspage.h
+++ b/src/launcher/settingspage.h
@@ -5,6 +5,8 @@
 
 #define RENDER_BACKENDS
 
+#define EXTRA_WADS
+
 class LauncherWindow;
 class TextLabel;
 class CheckboxLabel;
@@ -30,9 +32,11 @@ private:
 	CheckboxLabel* FullscreenCheckbox = nullptr;
 	CheckboxLabel* DisableAutoloadCheckbox = nullptr;
 	CheckboxLabel* DontAskAgainCheckbox = nullptr;
+#ifdef EXTRA_WADS
 	CheckboxLabel* LightsCheckbox = nullptr;
 	CheckboxLabel* BrightmapsCheckbox = nullptr;
 	CheckboxLabel* WidescreenCheckbox = nullptr;
+#endif
 	CheckboxLabel* SupportWadsCheckbox = nullptr;
 #ifdef RENDER_BACKENDS
 	TextLabel* BackendLabel = nullptr;


### PR DESCRIPTION
These files aren't supposed to be included with indie games, so add the ability for engine forks to hide it from the launcher easily.
