### PR TITLE
[Fix] Garbled terminal endoom screen

### DIFF
--- a/src/common/utility/vga2ansi.cpp
+++ b/src/common/utility/vga2ansi.cpp
@@ -50,7 +50,7 @@ static void CPrint(const char* in)
 }
 #endif
 
-enum class Support { NONE, BASIC, FULL };
+enum class Support { DUMB, NONE, BASIC, FULL };
 
 static const char *ansi_esc[2] = {"\x1b[", ";"};
 static const char *ansi_end[2] = {"", "m"};
@@ -93,9 +93,41 @@ inline void ansi_ctrl(bool open)
 	is_ansi_open = open;
 }
 
+// Best effort to translate cp437 to ascii, in order to support dumb terminals
+char cp437_to_ascii(uint8_t ch)
+{
+#if 1
+	static char lo[32] = {
+///////	 0   1   2   3   4   5   6   7   8   9   a   b   c   d   e   f
+/* 0 */	' ','+','#','+','+','+','+','+','#','+','#','+','+','+','+','+',
+/* 1 */	'<','>','|','!','$','$','-','|','^','v','<','>','-','-','^','v',
+	};
+
+	if (ch < 32) return lo[ch];
+
+	static char hi[128] = {
+///////	 0   1   2   3   4   5   6   7   8   9   a   b   c   d   e   f
+/* 8 */	'C','u','e','a','a','a','a','c','e','e','e','i','i','i','A','A',
+/* 9 */	'E','a','A','o','o','o','u','u','y','O','U','$','$','$','$','f',
+/* a */	'a','i','o','u','n','N','*','*','?','-','-','/','/','!','"','"',
+/* b */	':','+','#','|','+','+','+','+','+','+','|','+','+','+','+','+',
+/* c */	'+','+','+','+','-','+','+','+','+','+','+','+','+','-','+','+',
+/* d */	'+','+','+','+','+','+','+','+','+','+','+','#','-','|','|','-',
+/* e */	'a','B','G','p','S','s','u','t','P','T','O','d','8','h','E','-',
+/* f */	'=','+','>','<','|','|','%','=','*','*','*','Q','n','2','#',' ',
+	};
+
+	if (ch >= 128) return hi[ch-128];
+#else
+	if (ch < 32 || ch >= 128) return ' ';
+#endif
+
+	return ch;
+}
+
 void ibm437_to_utf8(char* result, char in);
 
-void vga_to_ansi(const uint8_t *buf) 
+void vga_to_ansi(const uint8_t *buf)
 {
 #ifdef _WIN32
 	// FIXME: support for alternative terminals and old windows
@@ -106,10 +138,12 @@ void vga_to_ansi(const uint8_t *buf)
 
 	Support termcaps =
 		(!term || strcmp(term, "dumb")==0)
+			? Support::DUMB
+		: (!cterm)
 			? Support::NONE
-			: (cterm && (strcmp(cterm, "truecolor")==0 || strcmp(cterm, "24bit")==0))
-				? Support::FULL
-				: Support::BASIC;
+		: (strcmp(cterm, "truecolor")==0 || strcmp(cterm, "24bit")==0)
+			? Support::FULL
+			: Support::BASIC;
 #endif
 
 	for (int row = 0; row < 25; ++row) 
@@ -126,7 +160,7 @@ void vga_to_ansi(const uint8_t *buf)
 			bool blink = !!(attr & 0x80);
 			bool spacer = (ch == 0) || (ch == 32) || (ch == 255);
 
-			if (termcaps != Support::NONE)
+			if (termcaps > Support::NONE)
 			{
 				// Output color if changed
 				if ((fg != last_fg) && !spacer)
@@ -156,17 +190,20 @@ void vga_to_ansi(const uint8_t *buf)
 				ansi_ctrl(0);
 			}
 
-			// Output character, convert CP437 to UTF-8
-			if (spacer)
-				CPrint(" ");
+			if (termcaps == Support::DUMB)
+			{
+				char result[2] = { cp437_to_ascii(ch), '\0' };
+				CPrint(result);
+			}
 			else
 			{
-				char result[4];
-				ibm437_to_utf8(result, ch);
+				// Output character, convert CP437 to UTF-8
+				char result[4] = "\u00A0"; // use nbsp as space
+				if (!spacer) ibm437_to_utf8(result, ch);
 				CPrint(result);
 			}
 		}
-		if (termcaps != Support::NONE)
+		if (termcaps > Support::NONE)
 			CPrint("\x1b[0m"); // Reset colors
 		CPrint("\n");
 	}

--- a/src/common/utility/vga2ansi.cpp
+++ b/src/common/utility/vga2ansi.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2025 Rachael Alexanderson
+// Copyright (c) 2025 GZDoom Maintainers and Contributors
 // 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -98,7 +99,7 @@ void vga_to_ansi(const uint8_t *buf)
 	bool truecolor = true;
 #else
 	const char *ct = getenv("COLORTERM");
-	bool truecolor = ct && (strcmp(ct, "truecolor") || strcmp(ct, "24bit"));
+	bool truecolor = ct && (strcmp(ct, "truecolor")==0 || strcmp(ct, "24bit")==0);
 #endif
 
 	for (int row = 0; row < 25; ++row) 


### PR DESCRIPTION
Previous implementation does not take into account termcaps, leading to garbled messes like this:

<details>
<summary>Colours + multi-byte chars on dumb terminal</summary>
<img width="1116" height="1422" alt="image" src="https://github.com/user-attachments/assets/43625444-b20b-4457-9427-f33b6c1a9009" />

<details>
<summary>Multi-byte chars on dumb terminal (Colours removed)</summary>
<img width="1116" height="1131" alt="image" src="https://github.com/user-attachments/assets/fef12cb2-196c-4c80-ac8e-55baea9f6db7" />
</details>
</details>

This adds support for terminals without colour support (pipes, printers, etc). It also adds a simple translation layer for terminals that are ascii-only.

Currently translation is triggered by terminals identifying themselves as "dumb", or not identifying themselves at all. AFAIK the only correct way of testing is to print a multibyte char and read where the cursor ended up. This is outside of the reasonable scope of this file.

<details>
<summary>Fixed</summary>
<img width="1116" height="770" alt="image" src="https://github.com/user-attachments/assets/b4d50db3-d813-4ab2-a4fa-9dae1eed09f2" />
</details>