### PR TITLE
Remove SDL_StartTextInput workaround for Wayland

### DIFF
--- a/src/common/platform/posix/sdl/sdlglvideo.cpp
+++ b/src/common/platform/posix/sdl/sdlglvideo.cpp
@@ -180,8 +180,6 @@ namespace Priv
 		{
 			// Enforce minimum size limit
 			SDL_SetWindowMinimumSize(Priv::window, VID_MIN_WIDTH, VID_MIN_HEIGHT);
-			// Tell SDL to start sending text input on Wayland.
-			if (strncasecmp(SDL_GetCurrentVideoDriver(), "wayland", 7) == 0) SDL_StartTextInput();
 		}
 	}
 


### PR DESCRIPTION
Ubuntu 20.04 has been out of support for a while and 22.04 has SDL 2.0.20 as the bare minimum, which should not need the workaround. This PR, therefore, removes the SDL_StartTextInput workaround.