### PR TITLE
Fixed interpolation during netgame lag

### DIFF
--- a/src/d_net.h
+++ b/src/d_net.h
@@ -35,6 +35,7 @@
 #include <queue>
 
 uint64_t I_msTime();
+struct particle_t;
 
 enum EChatType
 {
@@ -158,6 +159,10 @@ void Net_AdvanceCutscene();
 void Net_ResetCommands(bool midTic);
 void Net_SetWaiting();
 void Net_ClearBuffers();
+bool Net_IsWaiting();
+double Net_ModifyFrac(double ticFrac);
+double Net_ModifyObjectFrac(DObject* obj, double ticFrac);
+double Net_ModifyParticleFrac(particle_t* part, double ticFrac);
 
 // Netgame stuff (buffers and pointers, i.e. indices).
 

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -71,7 +71,7 @@
 #define XHAIRPICKUPSIZE		(2+XHAIRSHRINKSIZE)
 #define POWERUPICONSIZE		32
 
-int WorldPaused();
+int WorldPaused(bool checkLag);
 
 IMPLEMENT_CLASS(DBaseStatusBar, false, true)
 
@@ -684,7 +684,7 @@ int DBaseStatusBar::GetPlayer ()
 
 void DBaseStatusBar::Tick ()
 {
-	if (!WorldPaused())
+	if (!WorldPaused(false))
 	{
 		PrevCrosshairSize = CrosshairSize;
 

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -44,6 +44,7 @@
 #include "vectors.h"
 #include "texturemanager.h"
 #include "basics.h"
+#include "d_net.h"
 
 #include "hw_models.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
@@ -315,7 +316,7 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 			}
 
 			FHWModelRenderer renderer(di, state, dynlightindex);
-			RenderModel(&renderer, x, y, z, modelframe, actor, di->Viewpoint.TicFrac);
+			RenderModel(&renderer, x, y, z, modelframe, actor, Net_ModifyObjectFrac(actor, di->Viewpoint.TicFrac));
 			state.SetVertexBuffer(screen->mVertexData);
 		}
 	}
@@ -938,7 +939,7 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	// [RH] Make floatbobbing a renderer-only effect.
 	else
 	{
-		float fz = thing->GetBobOffset(vp.TicFrac);
+		float fz = thing->GetBobOffset(Net_ModifyObjectFrac(thing, vp.TicFrac));
 		z += fz;
 	}
 
@@ -1518,7 +1519,7 @@ void HWSprite::ProcessParticle(HWDrawInfo *di, particle_t *particle, sector_t *s
 	ThingColor.a = 255;
 	const auto& vp = di->Viewpoint;
 
-	double timefrac = vp.TicFrac;
+	double timefrac = Net_ModifyParticleFrac(particle, vp.TicFrac);
 	if (paused || (di->Level->isFrozen() && !(particle->flags & SPF_NOTIMEFREEZE)))
 		timefrac = 0.;
 
@@ -1646,7 +1647,7 @@ void HWSprite::AdjustVisualThinker(HWDrawInfo* di, DVisualThinker* spr, sector_t
 	translation = spr->Translation;
 
 	const auto& vp = di->Viewpoint;
-	double timefrac = vp.TicFrac;
+	double timefrac = Net_ModifyObjectFrac(spr, vp.TicFrac);
 
 	if (paused || spr->isFrozen())
 		timefrac = 0.;

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -35,6 +35,7 @@
 #include "hw_weapon.h"
 #include "hw_fakeflat.h"
 #include "texturemanager.h"
+#include "d_net.h"
 
 #include "hw_models.h"
 #include "hw_dynlightdata.h"
@@ -93,7 +94,7 @@ void HWDrawInfo::DrawPSprite(HUDSprite *huds, FRenderState &state)
 		state.AlphaFunc(Alpha_GEqual, 0);
 
 		FHWModelRenderer renderer(this, state, huds->lightindex);
-		RenderHUDModel(&renderer, huds->weapon, huds->translation, huds->rotation + FVector3(huds->mx / 4., (huds->my - WEAPONTOP) / -4., 0), huds->pivot, huds->mframe, Viewpoint.TicFrac);
+		RenderHUDModel(&renderer, huds->weapon, huds->translation, huds->rotation + FVector3(huds->mx / 4., (huds->my - WEAPONTOP) / -4., 0), huds->pivot, huds->mframe, Net_ModifyObjectFrac(huds->weapon, Viewpoint.TicFrac));
 		state.SetVertexBuffer(screen->mVertexData);
 	}
 	else
@@ -164,7 +165,7 @@ static bool isBright(DPSprite *psp)
 static WeaponPosition2D GetWeaponPosition2D(player_t *player, double ticFrac)
 {
 	WeaponPosition2D w;
-	P_BobWeapon(player, &w.bobx, &w.boby, ticFrac);
+	P_BobWeapon(player, &w.bobx, &w.boby, Net_ModifyFrac(ticFrac));
 
 	// Interpolate the main weapon layer once so as to be able to add it to other layers.
 	if ((w.weapon = player->FindPSprite(PSP_WEAPON)) != nullptr)
@@ -176,8 +177,9 @@ static WeaponPosition2D GetWeaponPosition2D(player_t *player, double ticFrac)
 		}
 		else
 		{
-			w.wx = (float)(w.weapon->oldx + (w.weapon->x - w.weapon->oldx) * ticFrac);
-			w.wy = (float)(w.weapon->oldy + (w.weapon->y - w.weapon->oldy) * ticFrac);
+			const double frac = Net_ModifyObjectFrac(w.weapon, ticFrac);
+			w.wx = (float)(w.weapon->oldx + (w.weapon->x - w.weapon->oldx) * frac);
+			w.wy = (float)(w.weapon->oldy + (w.weapon->y - w.weapon->oldy) * frac);
 		}
 	}
 	else
@@ -191,7 +193,7 @@ static WeaponPosition2D GetWeaponPosition2D(player_t *player, double ticFrac)
 static WeaponPosition3D GetWeaponPosition3D(player_t *player, double ticFrac)
 {
 	WeaponPosition3D w;
-	P_BobWeapon3D(player, &w.translation, &w.rotation, ticFrac);
+	P_BobWeapon3D(player, &w.translation, &w.rotation, Net_ModifyFrac(ticFrac));
 
 	// Interpolate the main weapon layer once so as to be able to add it to other layers.
 	if ((w.weapon = player->FindPSprite(PSP_WEAPON)) != nullptr)
@@ -203,8 +205,9 @@ static WeaponPosition3D GetWeaponPosition3D(player_t *player, double ticFrac)
 		}
 		else
 		{
-			w.wx = (float)(w.weapon->oldx + (w.weapon->x - w.weapon->oldx) * ticFrac);
-			w.wy = (float)(w.weapon->oldy + (w.weapon->y - w.weapon->oldy) * ticFrac);
+			const double frac = Net_ModifyObjectFrac(w.weapon, ticFrac);
+			w.wx = (float)(w.weapon->oldx + (w.weapon->x - w.weapon->oldx) * frac);
+			w.wy = (float)(w.weapon->oldy + (w.weapon->y - w.weapon->oldy) * frac);
 		}
 		
 		auto weaponActor = w.weapon->GetCaller();
@@ -705,6 +708,7 @@ void HWDrawInfo::PreparePlayerSprites2D(sector_t * viewsector, area_t in_area)
 	auto oldlightmode = lightmode;
 	if (isSoftwareLighting(oldlightmode)) SetFallbackLightMode();
 
+	const double bobFrac = Net_ModifyFrac(vp.TicFrac);
 	for (DPSprite *psp = player->psprites; psp != nullptr && psp->GetID() < PSP_TARGETCENTER; psp = psp->GetNext())
 	{
 		if (!psp->GetState()) continue;
@@ -724,7 +728,7 @@ void HWDrawInfo::PreparePlayerSprites2D(sector_t * viewsector, area_t in_area)
 		if(ModifyBobLayer && (psp->Flags & PSPF_ADDBOB))
 		{
 			DVector2 out;
-			VMValue param[] = { weap.weapon->GetCaller() , bobxy.X , bobxy.Y , psp->GetID() , vp.TicFrac };
+			VMValue param[] = { weap.weapon->GetCaller() , bobxy.X , bobxy.Y , psp->GetID() , bobFrac };
 			VMReturn ret(&out);
 
 			VMCall(ModifyBobLayer, param, 5, &ret, 1);
@@ -733,7 +737,8 @@ void HWDrawInfo::PreparePlayerSprites2D(sector_t * viewsector, area_t in_area)
 			weap.boby = out.Y;
 		}
 
-		FVector2 spos = BobWeapon2D(weap, psp, vp.TicFrac);
+		const double frac = Net_ModifyObjectFrac(psp, vp.TicFrac);
+		FVector2 spos = BobWeapon2D(weap, psp, frac);
 
 		hudsprite.dynrgb[0] = hudsprite.dynrgb[1] = hudsprite.dynrgb[2] = 0;
 		hudsprite.lightindex = -1;
@@ -743,7 +748,7 @@ void HWDrawInfo::PreparePlayerSprites2D(sector_t * viewsector, area_t in_area)
 			GetDynSpriteLight(playermo, nullptr, hudsprite.dynrgb);
 		}
 
-		if (!hudsprite.GetWeaponRect(this, psp, spos.X, spos.Y, player, vp.TicFrac)) continue;
+		if (!hudsprite.GetWeaponRect(this, psp, spos.X, spos.Y, player, min<double>(bobFrac, frac))) continue;
 		hudsprites.Push(hudsprite);
 	}
 	lightmode = oldlightmode;
@@ -791,6 +796,7 @@ void HWDrawInfo::PreparePlayerSprites3D(sector_t * viewsector, area_t in_area)
 	auto oldlightmode = lightmode;
 	if (isSoftwareLighting(oldlightmode)) SetFallbackLightMode();
 
+	const double bobFrac = Net_ModifyFrac(vp.TicFrac);
 	for (DPSprite *psp = player->psprites; psp != nullptr && psp->GetID() < PSP_TARGETCENTER; psp = psp->GetNext())
 	{
 		if (!psp->GetState()) continue;
@@ -813,7 +819,7 @@ void HWDrawInfo::PreparePlayerSprites3D(sector_t * viewsector, area_t in_area)
 			returns[0].Vec3At(&t);
 			returns[1].Vec3At(&r);
 
-			VMValue param[] = { weap.weapon->GetCaller() , translation.X, translation.Y, translation.Z, rotation.X, rotation.Y, rotation.Z, psp->GetID() , vp.TicFrac };
+			VMValue param[] = { weap.weapon->GetCaller() , translation.X, translation.Y, translation.Z, rotation.X, rotation.Y, rotation.Z, psp->GetID() , bobFrac };
 			VMCall(ModifyBobLayer3D, param, 9, returns, 2);
 
 			weap.translation = FVector3(t);
@@ -826,7 +832,7 @@ void HWDrawInfo::PreparePlayerSprites3D(sector_t * viewsector, area_t in_area)
 
 			VMReturn ret(&p);
 
-			VMValue param[] = { weap.weapon->GetCaller() , pivot.X, pivot.Y, pivot.Z, psp->GetID() , vp.TicFrac };
+			VMValue param[] = { weap.weapon->GetCaller() , pivot.X, pivot.Y, pivot.Z, psp->GetID() , bobFrac };
 			VMCall(ModifyBobPivotLayer3D, param, 6, &ret, 1);
 
 			weap.pivot = FVector3(p);
@@ -834,9 +840,7 @@ void HWDrawInfo::PreparePlayerSprites3D(sector_t * viewsector, area_t in_area)
 
 		if (!hudsprite.GetWeaponRenderStyle(psp, camera, viewsector, light)) continue;
 
-		//FVector2 spos = BobWeapon3D(weap, psp, hudsprite.translation, hudsprite.rotation, hudsprite.pivot, vp.TicFrac);
-
-		FVector2 spos = BobWeapon3D(weap, psp, hudsprite.translation, hudsprite.rotation, hudsprite.pivot, vp.TicFrac);
+		FVector2 spos = BobWeapon3D(weap, psp, hudsprite.translation, hudsprite.rotation, hudsprite.pivot, Net_ModifyObjectFrac(psp, vp.TicFrac));
 
 		hudsprite.dynrgb[0] = hudsprite.dynrgb[1] = hudsprite.dynrgb[2] = 0;
 		hudsprite.lightindex = -1;
@@ -935,7 +939,7 @@ void HWDrawInfo::PrepareTargeterSprites(double ticfrac)
 		{
 			hudsprite.weapon = psp;
 			
-			if (hudsprite.GetWeaponRect(this, psp, psp->x, psp->y, player, ticfrac))
+			if (hudsprite.GetWeaponRect(this, psp, psp->x, psp->y, player, Net_ModifyObjectFrac(psp, ticfrac)))
 			{
 				hudsprites.Push(hudsprite);
 			}

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -913,7 +913,7 @@ static void R_DoActorTickerAngleChanges(player_t* const player, DRotator& angles
 EXTERN_CVAR(Float, chase_dist)
 EXTERN_CVAR(Float, chase_height)
 
-int WorldPaused();
+int WorldPaused(bool checkLag);
 
 void R_SetupFrame(FRenderViewpoint& viewPoint, const FViewWindow& viewWindow, AActor* const actor)
 {
@@ -1039,7 +1039,7 @@ void R_SetupFrame(FRenderViewpoint& viewPoint, const FViewWindow& viewWindow, AA
 		viewPoint.sector = viewPoint.ViewLevel->PointInRenderSubsector(camPos)->sector;
 	}
 
-	if (!WorldPaused())
+	if (!WorldPaused(true))
 	{
 		FQuakeJiggers jiggers;
 		int intensity = DEarthquake::StaticGetQuakeIntensities(viewPoint.TicFrac, viewPoint.camera, jiggers);

--- a/src/rendering/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.cpp
@@ -1046,7 +1046,7 @@ namespace swrenderer
 		// The X offsetting (SpriteOffset.X) is performed in r_sprite.cpp, in RenderSprite::Project().
 		sprite.pos = thing->InterpolatedPosition(Thread->Viewport->viewpoint.TicFrac);
 		sprite.pos += thing->WorldOffset;
-		sprite.pos.Z += thing->GetBobOffset(Thread->Viewport->viewpoint.TicFrac) + thing->GetSpriteOffset(true);
+		sprite.pos.Z += thing->GetBobOffset(Net_ModifyObjectFrac(thing, Thread->Viewport->viewpoint.TicFrac)) + thing->GetSpriteOffset(true);
 		sprite.spritenum = thing->sprite;
 		sprite.tex = nullptr;
 		sprite.voxel = nullptr;

--- a/src/rendering/swrenderer/things/r_particle.cpp
+++ b/src/rendering/swrenderer/things/r_particle.cpp
@@ -79,7 +79,7 @@ namespace swrenderer
 		int 				x1, x2, y1, y2;
 		sector_t*			heightsec = NULL;
 
-		double timefrac = thread->Viewport->viewpoint.TicFrac;
+		double timefrac = Net_ModifyParticleFrac(particle, thread->Viewport->viewpoint.TicFrac);
 		if (paused || thread->Viewport->viewpoint.ViewLevel->isFrozen())
 			timefrac = 0.;
 

--- a/src/rendering/swrenderer/things/r_playersprite.cpp
+++ b/src/rendering/swrenderer/things/r_playersprite.cpp
@@ -154,7 +154,7 @@ namespace swrenderer
 
 			viewport->CenterY = viewheight / 2;
 
-			P_BobWeapon(viewport->viewpoint.camera->player, &bobx, &boby, viewport->viewpoint.TicFrac);
+			P_BobWeapon(viewport->viewpoint.camera->player, &bobx, &boby, Net_ModifyFrac(viewport->viewpoint.TicFrac));
 
 			// Interpolate the main weapon layer once so as to be able to add it to other layers.
 			if ((weapon = viewport->viewpoint.camera->player->FindPSprite(PSP_WEAPON)) != nullptr)
@@ -166,8 +166,9 @@ namespace swrenderer
 				}
 				else
 				{
-					wx = weapon->oldx + (weapon->x - weapon->oldx) * viewport->viewpoint.TicFrac;
-					wy = weapon->oldy + (weapon->y - weapon->oldy) * viewport->viewpoint.TicFrac;
+					const double frac = Net_ModifyObjectFrac(weapon, viewport->viewpoint.TicFrac);
+					wx = weapon->oldx + (weapon->x - weapon->oldx) * frac;
+					wy = weapon->oldy + (weapon->y - weapon->oldy) * frac;
 				}
 			}
 			else
@@ -187,7 +188,7 @@ namespace swrenderer
 
 				if ((psp->GetID() != PSP_TARGETCENTER || CrosshairImage == nullptr) && psp->GetCaller() != nullptr)
 				{
-					RenderSprite(psp, viewport->viewpoint.camera, bobx, boby, wx, wy, viewport->viewpoint.TicFrac, lightlevel, basecolormap, foggy);
+					RenderSprite(psp, viewport->viewpoint.camera, bobx, boby, wx, wy, Net_ModifyObjectFrac(psp, viewport->viewpoint.TicFrac), lightlevel, basecolormap, foggy);
 				}
 
 				psp = psp->GetNext();

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -60,6 +60,7 @@
 #include "s_music.h"
 #include "texturemanager.h"
 #include "v_draw.h"
+#include "d_net.h"
 
 extern int paused;
 extern bool pauseext;
@@ -502,9 +503,9 @@ DEFINE_ACTION_FUNCTION_NATIVE(_Sector, RemoveForceField, RemoveForceField)
 	 return 0;
  }
 
-int WorldPaused()
+int WorldPaused(bool checkLag)
 {
-	if (paused)
+	if (paused || (checkLag && Net_IsWaiting()))
 		return true;
 
 	if (netgame || gamestate != GS_LEVEL)
@@ -516,7 +517,8 @@ int WorldPaused()
 DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, WorldPaused, WorldPaused)
 {
 	PARAM_PROLOGUE;
-	ACTION_RETURN_BOOL(WorldPaused());
+	PARAM_BOOL(checkLag);
+	ACTION_RETURN_BOOL(WorldPaused(checkLag));
 }
 
 static sector_t *PointInSectorXY(FLevelLocals *self, double x, double y)

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -649,7 +649,7 @@ struct LevelLocals native
 	native void SpawnParticle(FSpawnParticleParams p);
 	native VisualThinker SpawnVisualThinker(Class<VisualThinker> type, bool clientSide = false);
 
-	clearscope native static bool WorldPaused();
+	clearscope native static bool WorldPaused(bool checkLag = false);
 }
 
 // a few values of this need to be readable by the play code.


### PR DESCRIPTION
Models, PSprites, and particles will now correctly stop interpolating when the game is lagging, preventing them from repeatedly jittering. A special case is made for PSprite bobbing which only stops when the bob logic itself is no longer predicting.