### PR TITLE
Re-license m_haptic to GPLv2+

### DIFF
--- a/src/m_haptics.cpp
+++ b/src/m_haptics.cpp
@@ -8,10 +8,10 @@
 ** Copyright 2025 Marcus Minhorst
 ** Copyright 2025 GZDoom Maintainers and Contributors
 **
-** This program is free software: you can redistribute it and/or modify
-** it under the terms of the GNU General Public License as published by
-** the Free Software Foundation, either version 3 of the License, or
-** (at your option) any later version.
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
 **
 ** This program is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -19,7 +19,7 @@
 ** GNU General Public License for more details.
 **
 ** You should have received a copy of the GNU General Public License
-** along with this program.  If not, see http://www.gnu.org/licenses/
+** along with this program; if not, see https://www.gnu.org/licenses/
 **
 **---------------------------------------------------------------------------
 **


### PR DESCRIPTION
I noticed that on commit https://github.com/ZDoom/gzdoom/commit/05151df1180d474b4156d14b109dda5f274d5f94 the file was moved for licensing concerns. The file author has since updated it to gplv2+.

This license update was cherry picked from https://github.com/UZDoom/UZDoom/commit/d9ebfff0b56e0ad1a45476e8841bfcd756473830.