### PR TITLE
Fix For Linking Against LLD On Linux Systems

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1383,6 +1383,10 @@ else()
 	)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set_target_properties(zdoom PROPERTIES LINK_FLAGS "-z nostart-stop-gc")
+endif()
+
 if( MSVC )
 	option ( CONSOLE_MODE "Compile as a console application" OFF )
 	if ( CONSOLE_MODE )


### PR DESCRIPTION
Small fix to linking using ld.lld (compiling with clang like on systems like OpenMandriva) reason referenced [here](https://lld.llvm.org/ELF/start-stop-gc.html)