### PR TITLE
Added cl_horizontalautoaim CVAR

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -164,6 +164,7 @@ CVAR (Bool, cl_missiledecals, true, CVAR_ARCHIVE)
 CVAR (Bool, addrocketexplosion, false, CVAR_ARCHIVE)
 CVAR (Int, cl_pufftype, 0, CVAR_ARCHIVE);
 CVAR (Int, cl_bloodtype, 0, CVAR_ARCHIVE);
+CVAR (Bool, cl_horizontalautoaim, true, CVAR_ARCHIVE)
 
 // CODE --------------------------------------------------------------------
 
@@ -8049,6 +8050,10 @@ AActor *P_SpawnPlayerMissile (AActor *source, double x, double y, double z,
 			an = angle + DAngle::fromDeg(angdiff[i]);
 			pitch = P_AimLineAttack (source, an, linetargetrange, pLineTarget, vrange, aimflags);
 	
+			if (!cl_horizontalautoaim) 
+			{
+				break;
+			}
 			if (source->player != NULL &&
 				!nofreeaim &&
 				source->Level->IsFreelookAllowed() &&


### PR DESCRIPTION
This CVAR disables the horizontal auto aiming for missiles, a feature that would often send rockets into nearby walls or outright miss enemies that you're trying to lead